### PR TITLE
Updating e2e test to remove annotations in GKE

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,24 @@ shell.nix
 
 # Build caches for docker build
 .docker-build/
+
+# log files
+*.log
+
+# OSX leaves these everywhere on SMB shares
+._*
+
+# OSX trash
+.DS_Store
+
+# Emacs save files
+*~
+\#*\#
+.\#*
+
+# Vim-related files
+[._]*.s[a-w][a-z]
+[._]s[a-w][a-z]
+*.un~
+Session.vim
+.netrwhist

--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ test-short: generate manifests
 
 e2e-test:
 	#$(TOOLS_WRAPPER) -v ${HOME}/.kube:/root/.kube -v ${HOME}/.config/gcloud:/root/.config/gcloud -e USE_EXISTING_CLUSTER=true $(REGISTRY_PREFIX)/$(TEST_RUNNER_IMG) go test -v  -run TestCreatesSecureClusterWithGeneratedCert ./e2e/... 
-	$(TOOLS_WRAPPER) -v ${HOME}/.kube:/root/.kube -v ${HOME}/.config/gcloud:/root/.config/gcloud -e USE_EXISTING_CLUSTER=true $(REGISTRY_PREFIX)/$(TEST_RUNNER_IMG) go test -v  ./e2e/... > e2e-test-output.$(DATE_STAMP).log
+	$(TOOLS_WRAPPER) -v ${HOME}/.kube:/root/.kube -v ${HOME}/.config/gcloud:/root/.config/gcloud -e USE_EXISTING_CLUSTER=true $(REGISTRY_PREFIX)/$(TEST_RUNNER_IMG) go test -v  ./e2e/... 2>&1 | tee  e2e-test-output.$(DATE_STAMP).log
 
 e2e-test-gke:
 	hack/create-gke-cluster.sh -c test

--- a/Makefile
+++ b/Makefile
@@ -15,10 +15,10 @@ CONTROLLER_GEN = $(TOOLS_WRAPPER) $(REGISTRY_PREFIX)/$(GENERATOR_IMG) controller
 CRD_OPTIONS ?= "crd:trivialVersions=true"
 
 # Run tests
-native-test: fmt vet
+native-test:
 	go test -v ./api/... ./pkg/... -coverprofile cover.out
 
-native-test-short: fmt vet
+native-test-short:
 	go test -v -short ./api/... ./pkg/... -coverprofile cover.out
 
 test: generate manifests
@@ -28,14 +28,15 @@ test-short: generate manifests
 	$(TOOLS_WRAPPER) $(REGISTRY_PREFIX)/$(TEST_RUNNER_IMG) make native-test-short
 
 e2e-test:
-	$(TOOLS_WRAPPER) -v ${HOME}/.kube:/root/.kube -v ${HOME}/.config/gcloud:/root/.config/gcloud -e USE_EXISTING_CLUSTER=true $(REGISTRY_PREFIX)/$(TEST_RUNNER_IMG) go test -v  -run TestCreatesSecureClusterWithGeneratedCert ./e2e/... 
+	#$(TOOLS_WRAPPER) -v ${HOME}/.kube:/root/.kube -v ${HOME}/.config/gcloud:/root/.config/gcloud -e USE_EXISTING_CLUSTER=true $(REGISTRY_PREFIX)/$(TEST_RUNNER_IMG) go test -v  -run TestCreatesSecureClusterWithGeneratedCert ./e2e/... 
+	$(TOOLS_WRAPPER) -v ${HOME}/.kube:/root/.kube -v ${HOME}/.config/gcloud:/root/.config/gcloud -e USE_EXISTING_CLUSTER=true $(REGISTRY_PREFIX)/$(TEST_RUNNER_IMG) go test -v  ./e2e/... > e2e-test-output.$(DATE_STAMP).log
 
 e2e-test-gke:
 	hack/create-gke-cluster.sh -c test
 	$(TOOLS_WRAPPER) -v ${HOME}/.kube:/root/.kube -v ${HOME}/.config/gcloud:/root/.config/gcloud -e USE_EXISTING_CLUSTER=true $(REGISTRY_PREFIX)/$(TEST_RUNNER_IMG) go test -v ./e2e/... > e2e-test-output.$(DATE_STAMP).log
-	# hack/delete-gke-cluster.sh -c test
+	hack/delete-gke-cluster.sh -c test
 
-run: fmt vet
+run:
 	go run ./cmd/cockroach-operator/main.go
 
 fmt:

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,7 @@ GENERATOR_IMG ?= cockroach-operator/code-generator
 TEST_RUNNER_IMG ?= cockroach-operator/test-runner
 UBI_IMG ?= cockroach-operator/cockroach-operator-ubi
 VERSION ?= latest
+DATE_STAMP=$(shell date "+%Y%m%d-%H%M%S")
 
 LOCAL_GOPATH := $(shell go env GOPATH)
 
@@ -15,10 +16,10 @@ CRD_OPTIONS ?= "crd:trivialVersions=true"
 
 # Run tests
 native-test: fmt vet
-	go test ./api/... ./pkg/... -coverprofile cover.out
+	go test -v ./api/... ./pkg/... -coverprofile cover.out
 
 native-test-short: fmt vet
-	go test -short ./api/... ./pkg/... -coverprofile cover.out
+	go test -v -short ./api/... ./pkg/... -coverprofile cover.out
 
 test: generate manifests
 	$(TOOLS_WRAPPER) $(REGISTRY_PREFIX)/$(TEST_RUNNER_IMG) make native-test
@@ -27,7 +28,12 @@ test-short: generate manifests
 	$(TOOLS_WRAPPER) $(REGISTRY_PREFIX)/$(TEST_RUNNER_IMG) make native-test-short
 
 e2e-test:
-	$(TOOLS_WRAPPER) -v ${HOME}/.kube:/root/.kube -v ${HOME}/.config/gcloud:/root/.config/gcloud -e USE_EXISTING_CLUSTER=true $(REGISTRY_PREFIX)/$(TEST_RUNNER_IMG) go test -v ./e2e/...
+	$(TOOLS_WRAPPER) -v ${HOME}/.kube:/root/.kube -v ${HOME}/.config/gcloud:/root/.config/gcloud -e USE_EXISTING_CLUSTER=true $(REGISTRY_PREFIX)/$(TEST_RUNNER_IMG) go test -v  -run TestCreatesSecureClusterWithGeneratedCert ./e2e/... 
+
+e2e-test-gke:
+	hack/create-gke-cluster.sh -c test
+	$(TOOLS_WRAPPER) -v ${HOME}/.kube:/root/.kube -v ${HOME}/.config/gcloud:/root/.config/gcloud -e USE_EXISTING_CLUSTER=true $(REGISTRY_PREFIX)/$(TEST_RUNNER_IMG) go test -v ./e2e/... > e2e-test-output.$(DATE_STAMP).log
+	# hack/delete-gke-cluster.sh -c test
 
 run: fmt vet
 	go run ./cmd/cockroach-operator/main.go

--- a/e2e/testdata/TestCreatesInsecureCluster/creates_1-node_insecure_cluster.golden
+++ b/e2e/testdata/TestCreatesInsecureCluster/creates_1-node_insecure_cluster.golden
@@ -14,6 +14,7 @@ spec:
 apiVersion: v1
 kind: Pod
 metadata:
+  creationTimestamp: null
   labels:
     app.kubernetes.io/component: database
     app.kubernetes.io/instance: crdb
@@ -96,6 +97,7 @@ spec:
     secret:
       defaultMode: 420
       secretName: default-token-0
+status: {}
 
 ---
 apiVersion: v1

--- a/e2e/testdata/TestCreatesSecureClusterWithGeneratedCert/creates_1-node_secure_cluster.golden
+++ b/e2e/testdata/TestCreatesSecureClusterWithGeneratedCert/creates_1-node_secure_cluster.golden
@@ -15,6 +15,7 @@ spec:
 apiVersion: v1
 kind: Pod
 metadata:
+  creationTimestamp: null
   labels:
     app.kubernetes.io/component: database
     app.kubernetes.io/instance: crdb
@@ -119,6 +120,7 @@ spec:
     secret:
       defaultMode: 420
       secretName: default-token-0
+status: {}
 
 ---
 apiVersion: v1

--- a/hack/apply-operator.sh
+++ b/hack/apply-operator.sh
@@ -58,4 +58,3 @@ until $ROLLOUT_STATUS_CMD || [ $ATTEMPTS -eq 60 ]; do
   ATTEMPTS=$((attempts + 1))
   sleep 10
 done
-

--- a/hack/create-gke-cluster.sh
+++ b/hack/create-gke-cluster.sh
@@ -61,3 +61,8 @@ gcloud container clusters create "$CLUSTER_NAME" \
   --num-nodes=1 \
   --enable-network-policy \
   --enable-ip-alias
+
+gcloud container clusters get-credentials "$CLUSTER_NAME" --zone "$ZONE"
+
+echo "Cluster created"
+echo "kubectl context set to cluster: $CLUSTER_NAME"

--- a/pkg/testutil/assert.go
+++ b/pkg/testutil/assert.go
@@ -1,12 +1,65 @@
 package testutil
 
 import (
+	"bytes"
 	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/require"
+	"k8s.io/api/core/v1"
+	"strings"
 	"testing"
 )
 
+// AssertDiff compares an expected interface with an actual interface
+// and fails if the two interfaces do not match.
+// This func removes all metadata calico annotations.
 func AssertDiff(t *testing.T, expected interface{}, actual interface{}) {
-	if diff := cmp.Diff(expected, actual); diff != "" {
-		t.Fatalf("unexpected result (-want +got):\n%v", diff)
+
+	if actual, ok := actual.(string); ok {
+		decode, encode := Yamlizers(t, InitScheme(t))
+		var newSlice []string
+		actualSlice := strings.Split(actual, "---")
+
+		for _, str := range actualSlice {
+			// we are getting zero length string because the string starts with ---
+			if len(str) == 0 {
+				continue
+			}
+			// if we do not need to parse the string if it does not have an annotation in it
+			if !strings.Contains(str, "cni.projectcalico.org") {
+				newSlice = append(newSlice, str)
+				continue
+			}
+			// TODO test if the string is actually an api definition???
+			// otherwise the decode is going to throw an error
+
+			obj := decode([]byte(str))
+
+			// we are only removing annotations out of pods
+			switch obj.(type) {
+			case *v1.Pod:
+				pod := obj.(*v1.Pod)
+				delete(pod.ObjectMeta.Annotations, "cni.projectcalico.org/podIP")
+				var b bytes.Buffer
+				err := encode(pod, &b)
+				require.NoError(t, err)
+				newSlice = append(newSlice, "\n"+b.String()+"\n")
+
+			default:
+				// todo warn and log
+				newSlice = append(newSlice, str)
+			}
+		}
+
+		newYaml := strings.Join(newSlice, "---")
+		newYaml = "---" + newYaml
+		if diff := cmp.Diff(expected, newYaml); diff != "" {
+			t.Fatalf("unexpected result (-want +got):\n%v", diff)
+		}
+	} else {
+		// Doing the else because of scoping weirdness
+		// I set actual to the strings.Join and it did not carry through
+		if diff := cmp.Diff(expected, actual); diff != "" {
+			t.Fatalf("unexpected result (-want +got):\n%v", diff)
+		}
 	}
 }


### PR DESCRIPTION
Often annotations are added to pods by other sources. When
testing with gke with network policies enabled the unit tests are
failing because annotations are added by Calico. I am removing
those annotations in this test.

I have some updates to the Makefile as well.

CLOSES ISSUE: https://github.com/cockroachdb/cockroach-operator/issues/45

