### PR TITLE
updated README - additional comments, deleting pv and pvc

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,7 @@ export CLUSTER=test
 ./hack/push-operator-gcr.sh
 
 # apply the operator
-# replace the -i argument with the image name
-./hack/apply-operator.sh -i myimagename:2342 -c $CLUSTER
+./hack/apply-operator.sh -c $CLUSTER
 
 # validate the the operator is running
 alias kubectl=k
@@ -44,6 +43,9 @@ Clean up the cluster
 
 # delete the operator
 ./hack/delete-operator.sh -c $CLUSTER
+
+# If you're still using the gke cluster, you can delete persistent volumes and persistent volume claims. It is not recommended to do this in production. Use --help for details.
+kubectl delete pv,pvc --help
 
 # delete the cluster
 # note this is async, and the script will complete without waiting the entire time

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The rest of dependencies are packed into Docker images which are executed from t
 git clone https://github.com/cockroachdb/cockroach-operator.git
 export CLUSTER=test
 # create a gke cluster
-./hack/create-gke-cluster.sh -t $CLUSTER
+./hack/create-gke-cluster.sh -c $CLUSTER
 
 # build the image locally and push it to your image repo
 # record the output of the command, as it will tell you the image to use with kustomize


### PR DESCRIPTION
For first time users, it's not intuitive that persistent volumes and persistent volume claims are not deleted when the CockroachDB cluster is deleted from Kubernetes. This additional comment clarifies how to manually remove persistent volumes and persistent volume claims.

cc @chrislovecnm 