### PR TITLE
Missed headers on go files

### DIFF
--- a/pkg/resource/pod_distruption_budget.go
+++ b/pkg/resource/pod_distruption_budget.go
@@ -1,3 +1,18 @@
+/*
+Copyright 2020 The Cockroach Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 package resource
 
 import (

--- a/pkg/resource/pod_distruption_budget_test.go
+++ b/pkg/resource/pod_distruption_budget_test.go
@@ -1,3 +1,18 @@
+/*
+Copyright 2020 The Cockroach Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 package resource_test
 
 import (


### PR DESCRIPTION
And this is why we need CI.  I missed headers on two new
go files.