### PR TITLE
Stop auto-mounting SA Token

### DIFF
--- a/e2e/testdata/TestCreatesInsecureCluster/creates_3-node_insecure_cluster.golden
+++ b/e2e/testdata/TestCreatesInsecureCluster/creates_3-node_insecure_cluster.golden
@@ -22,6 +22,7 @@ metadata:
     statefulset.kubernetes.io/pod-name: crdb-0
   name: crdb-0
 spec:
+  automountServiceAccountToken: false
   containers:
   - args:
     - shell
@@ -68,9 +69,6 @@ spec:
     volumeMounts:
     - mountPath: /cockroach/cockroach-data/
       name: datadir
-    - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
-      name: default-token-0
-      readOnly: true
   dnsPolicy: ClusterFirst
   enableServiceLinks: true
   priority: 0
@@ -93,10 +91,6 @@ spec:
   volumes:
   - emptyDir: {}
     name: datadir
-  - name: default-token-0
-    secret:
-      defaultMode: 420
-      secretName: default-token-0
 status: {}
 
 ---
@@ -111,6 +105,7 @@ metadata:
     statefulset.kubernetes.io/pod-name: crdb-1
   name: crdb-1
 spec:
+  automountServiceAccountToken: false
   containers:
   - args:
     - shell
@@ -157,9 +152,6 @@ spec:
     volumeMounts:
     - mountPath: /cockroach/cockroach-data/
       name: datadir
-    - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
-      name: default-token-0
-      readOnly: true
   dnsPolicy: ClusterFirst
   enableServiceLinks: true
   priority: 0
@@ -182,10 +174,6 @@ spec:
   volumes:
   - emptyDir: {}
     name: datadir
-  - name: default-token-0
-    secret:
-      defaultMode: 420
-      secretName: default-token-0
 status: {}
 
 ---
@@ -200,6 +188,7 @@ metadata:
     statefulset.kubernetes.io/pod-name: crdb-2
   name: crdb-2
 spec:
+  automountServiceAccountToken: false
   containers:
   - args:
     - shell
@@ -246,9 +235,6 @@ spec:
     volumeMounts:
     - mountPath: /cockroach/cockroach-data/
       name: datadir
-    - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
-      name: default-token-0
-      readOnly: true
   dnsPolicy: ClusterFirst
   enableServiceLinks: true
   priority: 0
@@ -271,10 +257,6 @@ spec:
   volumes:
   - emptyDir: {}
     name: datadir
-  - name: default-token-0
-    secret:
-      defaultMode: 420
-      secretName: default-token-0
 status: {}
 
 ---
@@ -388,6 +370,7 @@ spec:
         app.kubernetes.io/instance: crdb
         app.kubernetes.io/name: cockroachdb
     spec:
+      automountServiceAccountToken: false
       containers:
       - args:
         - shell

--- a/e2e/testdata/TestCreatesSecureClusterWithGeneratedCert/creates_1-node_cluster.golden
+++ b/e2e/testdata/TestCreatesSecureClusterWithGeneratedCert/creates_1-node_cluster.golden
@@ -70,9 +70,6 @@ spec:
       name: datadir
     - mountPath: /cockroach/cockroach-certs/
       name: certs
-    - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
-      name: default-token-0
-      readOnly: true
   dnsPolicy: ClusterFirst
   enableServiceLinks: true
   priority: 0
@@ -115,10 +112,6 @@ spec:
           - key: tls.key
             path: client.root.key
           name: crdb-root
-  - name: default-token-0
-    secret:
-      defaultMode: 420
-      secretName: default-token-0
 
 ---
 apiVersion: v1

--- a/e2e/testdata/TestCreatesSecureClusterWithGeneratedCert/creates_1-node_secure_cluster.golden
+++ b/e2e/testdata/TestCreatesSecureClusterWithGeneratedCert/creates_1-node_secure_cluster.golden
@@ -23,6 +23,7 @@ metadata:
     statefulset.kubernetes.io/pod-name: crdb-0
   name: crdb-0
 spec:
+  automountServiceAccountToken: false
   containers:
   - args:
     - shell
@@ -71,9 +72,6 @@ spec:
       name: datadir
     - mountPath: /cockroach/cockroach-certs/
       name: certs
-    - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
-      name: default-token-0
-      readOnly: true
   dnsPolicy: ClusterFirst
   enableServiceLinks: true
   priority: 0
@@ -116,10 +114,6 @@ spec:
           - key: tls.key
             path: client.root.key
           name: crdb-root
-  - name: default-token-0
-    secret:
-      defaultMode: 420
-      secretName: default-token-0
 status: {}
 
 ---
@@ -236,6 +230,7 @@ spec:
         app.kubernetes.io/instance: crdb
         app.kubernetes.io/name: cockroachdb
     spec:
+      automountServiceAccountToken: false
       containers:
       - args:
         - shell

--- a/pkg/resource/statefulset.go
+++ b/pkg/resource/statefulset.go
@@ -154,6 +154,7 @@ func (b StatefulSetBuilder) makePodTemplate() corev1.PodTemplateSpec {
 		Spec: corev1.PodSpec{
 			TerminationGracePeriodSeconds: ptr.Int64(60),
 			Containers:                    b.makeContainers(),
+			AutomountServiceAccountToken:  ptr.Bool(false),
 		},
 	}
 }

--- a/pkg/resource/testdata/TestStatefulSetBuilder/default_insecure_statefulset.golden
+++ b/pkg/resource/testdata/TestStatefulSetBuilder/default_insecure_statefulset.golden
@@ -20,6 +20,7 @@ spec:
         app.kubernetes.io/instance: test-cluster
         app.kubernetes.io/name: cockroachdb
     spec:
+      automountServiceAccountToken: false
       containers:
       - args:
         - shell

--- a/pkg/resource/testdata/TestStatefulSetBuilder/default_secure.golden
+++ b/pkg/resource/testdata/TestStatefulSetBuilder/default_secure.golden
@@ -20,6 +20,7 @@ spec:
         app.kubernetes.io/instance: test-cluster
         app.kubernetes.io/name: cockroachdb
     spec:
+      automountServiceAccountToken: false
       containers:
       - args:
         - shell

--- a/pkg/resource/testdata/TestStatefulSetBuilder/insecure_statefulset_cli_args.golden
+++ b/pkg/resource/testdata/TestStatefulSetBuilder/insecure_statefulset_cli_args.golden
@@ -20,6 +20,7 @@ spec:
         app.kubernetes.io/instance: test-cluster
         app.kubernetes.io/name: cockroachdb
     spec:
+      automountServiceAccountToken: false
       containers:
       - args:
         - shell

--- a/pkg/resource/testdata/TestStatefulSetBuilder/insecure_statefulset_with_resources.golden
+++ b/pkg/resource/testdata/TestStatefulSetBuilder/insecure_statefulset_with_resources.golden
@@ -20,6 +20,7 @@ spec:
         app.kubernetes.io/instance: test-cluster
         app.kubernetes.io/name: cockroachdb
     spec:
+      automountServiceAccountToken: false
       containers:
       - args:
         - shell


### PR DESCRIPTION
By default Kubernetes mounts the default API authentication
token to a Pod.  This PR adds 'automountServiceAccountToken: false'
to the StatefulSet definition for a managed database.

Closes #66 