### PR TITLE
Changing e2e testing to use kind

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,7 +43,7 @@ test/pkg:
 test/verify:
 	bazel test //hack/...
 
-# This target uses kind to start a cluster and runs the e2e tests
+# This target uses kind to start a k8s cluster  and runs the e2e tests
 # against that cluster.
 .PHONY: test/e2e
 test/e2e: 

--- a/e2e/BUILD.bazel
+++ b/e2e/BUILD.bazel
@@ -32,6 +32,8 @@ go_test(
         "//hack/bin:etcd",
         "//hack/bin:kube-apiserver",
         "//hack/bin:kubectl",
+        "//hack/bin:kubetest2",
+        "//hack/bin:kubetest2-kind",
     ] + glob(["testdata/**"]),
     embed = [":go_default_library"],
     deps = [

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -64,11 +64,9 @@ func TestMain(m *testing.M) {
 	flag.Parse()
 
 	// We are running in bazel so set up the directory for the test binaries
-	// TODO pick up from command line if we are going to use kind
 	if os.Getenv("TEST_WORKSPACE") != "" {
-		// TODO change these by splitting the args that we are passing in
-		paths.MaybeSetEnv("TEST_ASSET_KUBECTL", "kubectl", "hack", "bin", "kubectl")
-		paths.MaybeSetEnv("TEST_ASSET_KIND", "kind", "hack", "bin", "kind")
+		// TODO create a toolchain for this
+		paths.MaybeSetEnv("PATH", "kubetest2-kind", "hack", "bin", "kubetest2-kind")
 	}
 
 	noKind := os.Getenv("TEST_DO_NOT_USE_KIND")

--- a/e2e/testdata/TestCreatesInsecureCluster/creates_3-node_insecure_cluster.golden
+++ b/e2e/testdata/TestCreatesInsecureCluster/creates_3-node_insecure_cluster.golden
@@ -15,7 +15,6 @@ spec:
 apiVersion: v1
 kind: Pod
 metadata:
-  creationTimestamp: null
   labels:
     app.kubernetes.io/component: database
     app.kubernetes.io/instance: crdb
@@ -92,13 +91,11 @@ spec:
   volumes:
   - emptyDir: {}
     name: datadir
-status: {}
 
 ---
 apiVersion: v1
 kind: Pod
 metadata:
-  creationTimestamp: null
   labels:
     app.kubernetes.io/component: database
     app.kubernetes.io/instance: crdb
@@ -175,13 +172,11 @@ spec:
   volumes:
   - emptyDir: {}
     name: datadir
-status: {}
 
 ---
 apiVersion: v1
 kind: Pod
 metadata:
-  creationTimestamp: null
   labels:
     app.kubernetes.io/component: database
     app.kubernetes.io/instance: crdb
@@ -258,7 +253,6 @@ spec:
   volumes:
   - emptyDir: {}
     name: datadir
-status: {}
 
 ---
 apiVersion: policy/v1beta1

--- a/e2e/testdata/TestCreatesSecureClusterWithGeneratedCert/creates_1-node_secure_cluster.golden
+++ b/e2e/testdata/TestCreatesSecureClusterWithGeneratedCert/creates_1-node_secure_cluster.golden
@@ -16,7 +16,6 @@ spec:
 apiVersion: v1
 kind: Pod
 metadata:
-  creationTimestamp: null
   labels:
     app.kubernetes.io/component: database
     app.kubernetes.io/instance: crdb
@@ -115,7 +114,6 @@ spec:
           - key: tls.key
             path: client.root.key
           name: crdb-root
-status: {}
 
 ---
 apiVersion: v1

--- a/hack/bin/BUILD.bazel
+++ b/hack/bin/BUILD.bazel
@@ -99,6 +99,26 @@ genrule(
 )
 
 genrule(
+    name = "fetch_kubetest2",
+    srcs = select({
+        ":k8": ["@kubetest2_linux//file"],
+    }),
+    outs = ["kubetest2"],
+    cmd = "cp $(SRCS) $@",
+    visibility = ["//visibility:public"],
+)
+
+genrule(
+    name = "fetch_kubetest2_kind",
+    srcs = select({
+        ":k8": ["@kubetest2_kind_linux//file"],
+    }),
+    outs = ["kubetest2-kind"],
+    cmd = "cp $(SRCS) $@",
+    visibility = ["//visibility:public"],
+)
+
+genrule(
     name = "fetch_controller-gen",
     srcs = ["@io_k8s_sigs_controller_tools//cmd/controller-gen"],
     outs = ["controller-gen"],

--- a/hack/bin/deps.bzl
+++ b/hack/bin/deps.bzl
@@ -25,6 +25,8 @@ def install():
     install_kubectl()
     install_oc3()
     install_kind()
+    install_kubetest2()
+    install_kubetest2_kind()
 
     # Install golang.org/x/build as kubernetes/repo-infra requires it for the
     # build-tar bazel target.
@@ -233,3 +235,41 @@ def install_kind():
         sha256 = "0e07d5a9d5b8bf410a1ad8a7c8c9c2ea2a4b19eda50f1c629f1afadb7c80fae7",
         urls = ["https://github.com/kubernetes-sigs/kind/releases/download/v0.7.0/kind-linux-amd64"],
     )
+
+## Fetch kubetest2 binary used during e2e tests
+def install_kubetest2():
+    # install kubetest2 binary
+    # TODO osx support
+    #http_file(
+    #    name = "kubetest2_darwin",
+    #    executable = 1,
+    #    sha256 = "11b8a7fda7c9d6230f0f28ffe57831a7227c0655dfb8d38e838e8f03db6612de",
+    #    urls = ["https://github.com/kubernetes-sigs/kind/releases/download/v0.7.0/kind-darwin-amd64"],
+    #)
+
+    http_file(
+        name = "kubetest2_linux",
+        executable = 1,
+        sha256 = "a2617f5c65e8edcc49dcb72ec79c4d21043ef4ee6278e7179fe76ff362192054",
+        urls = ["https://storage.googleapis.com/crdb-bazel-artifacts/kubetest2"],
+    )
+
+## Fetch kubetest2-kind binary used during e2e tests
+def install_kubetest2_kind():
+    # install kubetest2 binary
+    # TODO osx support
+    #http_file(
+    #    name = "kubetest2_darwin",
+    #    executable = 1,
+    #    sha256 = "11b8a7fda7c9d6230f0f28ffe57831a7227c0655dfb8d38e838e8f03db6612de",
+    #    urls = ["https://github.com/kubernetes-sigs/kind/releases/download/v0.7.0/kind-darwin-amd64"],
+    #)
+
+    http_file(
+        name = "kubetest2_kind_linux",
+        executable = 1,
+        sha256 = "b8d570ce69155beb9f882489b096583676f69afb4cd2a5061106264b45b5d113",
+        urls = ["https://storage.googleapis.com/crdb-bazel-artifacts/kubetest2-kind"],
+    )
+
+

--- a/pkg/testutil/paths/paths.go
+++ b/pkg/testutil/paths/paths.go
@@ -25,13 +25,17 @@ import (
 // MaybeSetEnv sets an environment variable that points to a binary. If that
 // binary does not exist in the path this func throws a panic.
 func MaybeSetEnv(key, bin string, path ...string) {
-	if os.Getenv(key) != "" {
+	if os.Getenv(key) != "" && key != "PATH" {
 		return
 	}
 	p, err := getPath(bin, path...)
 	if err != nil {
 		panic(fmt.Sprintf(`Failed to find integration test dependency %q.
-Either re-run this test using "bazel test //test/integration/{name}" or set the %s environment variable.`, bin, key))
+Either re-run this test using "bazel test //e2e/{name}" or set the %s environment variable.`, bin, key))
+	}
+	if key == "PATH" {
+		p = p[:len(p)-len("/"+bin)]
+		p = p + ":" + os.Getenv("PATH")
 	}
 	os.Setenv(key, p)
 }


### PR DESCRIPTION
We previously allowed for gke testing during e2e, but
we are going to use kind.  This removes a couple of YAML
stanzas in the test data that kind does not produce.