### PR TITLE
Using RedHat UBI Minimal Base Image

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -79,13 +79,17 @@ load("@io_bazel_rules_docker//repositories:pip_repositories.bzl", "pip_deps")
 
 pip_deps()
 
-load(
-    "@io_bazel_rules_docker//container:container.bzl",
-    "container_pull",
-)
+load("@io_bazel_rules_docker//container:container.bzl", "container_pull")
 load("@io_bazel_rules_docker//go:image.bzl", _go_image_repos = "repositories")
 
 _go_image_repos()
+
+container_pull(
+    name = "redhat_ubi_minimal",
+    registry = "registry.access.redhat.com",
+    repository = "ubi8/ubi-minimal",
+    digest = "sha256:3364fa3bd7a5aea2932e352a446ec7f46378885f6a8f03847acc64dd100aa4cc",
+)
 
 # Load and define targets defined in //hack/bin
 load("//hack/bin:deps.bzl", install_hack_bin = "install")

--- a/cmd/cockroach-operator/BUILD.bazel
+++ b/cmd/cockroach-operator/BUILD.bazel
@@ -1,5 +1,6 @@
-load("@io_bazel_rules_docker//go:image.bzl", "go_image")
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+load("@io_bazel_rules_docker//container:container.bzl", "container_image")
+load("@io_bazel_rules_docker//go:image.bzl", "go_image")
 
 go_library(
     name = "go_default_library",
@@ -23,9 +24,17 @@ go_binary(
     visibility = ["//visibility:public"],
 )
 
+container_image(
+    name = "ubi_base_image",
+    # References container_pull from WORKSPACE
+    base = "@redhat_ubi_minimal//image",
+)
+
 go_image(
     name = "operator_image",
     binary = ":cockroach-operator",
+    # using the ubi image instead of the go base image
+    base = ":ubi_base_image",
     visibility = ["//visibility:public"],
 )
 


### PR DESCRIPTION
Configured bazel to use RedHat's UBI image for the building of the
operator.