### PR TITLE
Adding more configurations for pushing images

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -22,7 +22,7 @@ container_push(
     format = "Docker",
     image = "//cmd/cockroach-operator:operator_image",
     registry = "{STABLE_DOCKER_REGISTRY}",
-    repository = "cockroach-operator",
+    repository = "{STABLE_IMAGE_REPOSITORY}",
     # TODO need a way to override this
     # probably https://github.com/jetstack/cert-manager/blob/ba7871d5f685e0f8d2b256f3a1230f8786d110fe/build/BUILD.bazel#L58
     tag = "{STABLE_BUILD_GIT_COMMIT}",

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,10 @@
 # Install instuctions https://docs.bazel.build/versions/master/install.html
 #
 
+# values used in workspace-status.sh
+DOCKER_REGISTRY?=us.gcr.io/chris-love-operator-playground
+DOCKER_IMAGE_REPOSITORY?=cockroach-operator
+
 # 
 # Testing targets
 # 
@@ -83,7 +87,6 @@ k8s/delete:
 #
 .PHONY: release/image
 release/image:
-	bazel run \
-		--stamp \
-		--platforms=@io_bazel_rules_go//go/toolchain:linux_amd64 \
+	DOCKER_REGISTRY=$(DOCKER_REGISTRY) DOCKER_IMAGE_REPOSITORY=$(DOCKER_IMAGE_REPOSITORY) \
+	bazel run --stamp --platforms=@io_bazel_rules_go//go/toolchain:linux_amd64 \
 		//:push_operator_image 

--- a/hack/build/print-workspace-status.sh
+++ b/hack/build/print-workspace-status.sh
@@ -41,7 +41,9 @@ STABLE_BUILD_MINOR_VERSION ${KUBE_GIT_MINOR-}
 STABLE_DOCKER_TAG ${APP_VERSION:-${KUBE_GIT_VERSION/+/-}}
 STABLE_DOCKER_REGISTRY ${DOCKER_REGISTRY:-us.gcr.io/chris-love-operator-playground}
 STABLE_DOCKER_PUSH_REGISTRY ${DOCKER_PUSH_REGISTRY:-${DOCKER_REGISTRY:-us.gcr.io/chris-love-operator-playground}}
+STABLE_IMAGE_REPOSITORY ${DOCKER_IMAGE_REPOSITORY:-cockroach-operator}
 IMAGE_REGISTRY ${DEV_REGISTRY:-us.gcr.io/chris-love-operator-playground}
+
 CLUSTER ${K8S_CLUSTER:-gke_chris-love-operator-playground_us-central1-a_test}
 gitCommit ${KUBE_GIT_COMMIT-}
 gitTreeState ${KUBE_GIT_TREE_STATE-}


### PR DESCRIPTION
Added the capability to set a custom image registry name for
use with pushing to a image repository.  The Makefile now
allows the use of these EVN variables with bazel.