### PR TITLE
Using HOSTNAME ENV variable

### DIFF
--- a/e2e/testdata/TestCreatesInsecureCluster/creates_3-node_insecure_cluster.golden
+++ b/e2e/testdata/TestCreatesInsecureCluster/creates_3-node_insecure_cluster.golden
@@ -28,7 +28,7 @@ spec:
     - shell
     - -ecx
     - '>- exec /cockroach/cockroach start --join=crdb-0.crdb.[sandbox_namespace]:26257,crdb-1.crdb.[sandbox_namespace]:26257,crdb-2.crdb.[sandbox_namespace]:26257
-      --advertise-host=$(echo $HOSTNAME) --logtostderr=INFO --insecure --http-port=8080
+      --advertise-host=$(echo ${COCKROACH_POD_NAME}.crdb.$(awk -v s=search '{if($1 == s)print $2}' /etc/resolv.conf)) --logtostderr=INFO --insecure --http-port=8080
       --port=26257 --cache=25% --max-sql-memory=25%'
     env:
     - name: COCKROACH_CHANNEL
@@ -109,7 +109,7 @@ spec:
     - shell
     - -ecx
     - '>- exec /cockroach/cockroach start --join=crdb-0.crdb.[sandbox_namespace]:26257,crdb-1.crdb.[sandbox_namespace]:26257,crdb-2.crdb.[sandbox_namespace]:26257
-      --advertise-host=$(echo $HOSTNAME) --logtostderr=INFO --insecure --http-port=8080
+      --advertise-host=$(echo ${COCKROACH_POD_NAME}.crdb.$(awk -v s=search '{if($1 == s)print $2}' /etc/resolv.conf)) --logtostderr=INFO --insecure --http-port=8080
       --port=26257 --cache=25% --max-sql-memory=25%'
     env:
     - name: COCKROACH_CHANNEL
@@ -190,7 +190,7 @@ spec:
     - shell
     - -ecx
     - '>- exec /cockroach/cockroach start --join=crdb-0.crdb.[sandbox_namespace]:26257,crdb-1.crdb.[sandbox_namespace]:26257,crdb-2.crdb.[sandbox_namespace]:26257
-      --advertise-host=$(echo $HOSTNAME) --logtostderr=INFO --insecure --http-port=8080
+      --advertise-host=$(echo ${COCKROACH_POD_NAME}.crdb.$(awk -v s=search '{if($1 == s)print $2}' /etc/resolv.conf)) --logtostderr=INFO --insecure --http-port=8080
       --port=26257 --cache=25% --max-sql-memory=25%'
     env:
     - name: COCKROACH_CHANNEL
@@ -371,7 +371,7 @@ spec:
         - shell
         - -ecx
         - '>- exec /cockroach/cockroach start --join=crdb-0.crdb.[sandbox_namespace]:26257,crdb-1.crdb.[sandbox_namespace]:26257,crdb-2.crdb.[sandbox_namespace]:26257
-          --advertise-host=$(echo $HOSTNAME) --logtostderr=INFO --insecure --http-port=8080
+          --advertise-host=$(echo ${COCKROACH_POD_NAME}.crdb.$(awk -v s=search '{if($1 == s)print $2}' /etc/resolv.conf)) --logtostderr=INFO --insecure --http-port=8080
           --port=26257 --cache=25% --max-sql-memory=25%'
         env:
         - name: COCKROACH_CHANNEL

--- a/e2e/testdata/TestCreatesInsecureCluster/creates_3-node_insecure_cluster.golden
+++ b/e2e/testdata/TestCreatesInsecureCluster/creates_3-node_insecure_cluster.golden
@@ -28,7 +28,7 @@ spec:
     - shell
     - -ecx
     - '>- exec /cockroach/cockroach start --join=crdb-0.crdb.[sandbox_namespace]:26257,crdb-1.crdb.[sandbox_namespace]:26257,crdb-2.crdb.[sandbox_namespace]:26257
-      --advertise-host=$(hostname -f) --logtostderr=INFO --insecure --http-port=8080
+      --advertise-host=$(echo $HOSTNAME) --logtostderr=INFO --insecure --http-port=8080
       --port=26257 --cache=25% --max-sql-memory=25%'
     env:
     - name: COCKROACH_CHANNEL
@@ -109,7 +109,7 @@ spec:
     - shell
     - -ecx
     - '>- exec /cockroach/cockroach start --join=crdb-0.crdb.[sandbox_namespace]:26257,crdb-1.crdb.[sandbox_namespace]:26257,crdb-2.crdb.[sandbox_namespace]:26257
-      --advertise-host=$(hostname -f) --logtostderr=INFO --insecure --http-port=8080
+      --advertise-host=$(echo $HOSTNAME) --logtostderr=INFO --insecure --http-port=8080
       --port=26257 --cache=25% --max-sql-memory=25%'
     env:
     - name: COCKROACH_CHANNEL
@@ -190,7 +190,7 @@ spec:
     - shell
     - -ecx
     - '>- exec /cockroach/cockroach start --join=crdb-0.crdb.[sandbox_namespace]:26257,crdb-1.crdb.[sandbox_namespace]:26257,crdb-2.crdb.[sandbox_namespace]:26257
-      --advertise-host=$(hostname -f) --logtostderr=INFO --insecure --http-port=8080
+      --advertise-host=$(echo $HOSTNAME) --logtostderr=INFO --insecure --http-port=8080
       --port=26257 --cache=25% --max-sql-memory=25%'
     env:
     - name: COCKROACH_CHANNEL
@@ -371,7 +371,7 @@ spec:
         - shell
         - -ecx
         - '>- exec /cockroach/cockroach start --join=crdb-0.crdb.[sandbox_namespace]:26257,crdb-1.crdb.[sandbox_namespace]:26257,crdb-2.crdb.[sandbox_namespace]:26257
-          --advertise-host=$(hostname -f) --logtostderr=INFO --insecure --http-port=8080
+          --advertise-host=$(echo $HOSTNAME) --logtostderr=INFO --insecure --http-port=8080
           --port=26257 --cache=25% --max-sql-memory=25%'
         env:
         - name: COCKROACH_CHANNEL

--- a/e2e/testdata/TestCreatesSecureClusterWithGeneratedCert/creates_1-node_cluster.golden
+++ b/e2e/testdata/TestCreatesSecureClusterWithGeneratedCert/creates_1-node_cluster.golden
@@ -28,7 +28,7 @@ spec:
     - shell
     - -ecx
     - '>- exec /cockroach/cockroach start --join=crdb-0.crdb.[sandbox_namespace]:26257
-      --advertise-host=$(echo $HOSTNAME) --logtostderr=INFO --certs-dir=/cockroach/cockroach-certs/
+      --advertise-host=$(echo ${COCKROACH_POD_NAME}.crdb.$(awk -v s=search '{if($1 == s)print $2}' /etc/resolv.conf)) --logtostderr=INFO --certs-dir=/cockroach/cockroach-certs/
       --http-port=8080 --port=26257 --cache=25% --max-sql-memory=25%'
     env:
     - name: COCKROACH_CHANNEL
@@ -233,7 +233,7 @@ spec:
         - shell
         - -ecx
         - '>- exec /cockroach/cockroach start --join=crdb-0.crdb.[sandbox_namespace]:26257
-          --advertise-host=$(echo $HOSTNAME) --logtostderr=INFO --certs-dir=/cockroach/cockroach-certs/
+          --advertise-host=$(echo ${COCKROACH_POD_NAME}.crdb.$(awk -v s=search '{if($1 == s)print $2}' /etc/resolv.conf)) --logtostderr=INFO --certs-dir=/cockroach/cockroach-certs/
           --http-port=8080 --port=26257 --cache=25% --max-sql-memory=25%'
         env:
         - name: COCKROACH_CHANNEL

--- a/e2e/testdata/TestCreatesSecureClusterWithGeneratedCert/creates_1-node_cluster.golden
+++ b/e2e/testdata/TestCreatesSecureClusterWithGeneratedCert/creates_1-node_cluster.golden
@@ -28,7 +28,7 @@ spec:
     - shell
     - -ecx
     - '>- exec /cockroach/cockroach start --join=crdb-0.crdb.[sandbox_namespace]:26257
-      --advertise-host=$(hostname -f) --logtostderr=INFO --certs-dir=/cockroach/cockroach-certs/
+      --advertise-host=$(echo $HOSTNAME) --logtostderr=INFO --certs-dir=/cockroach/cockroach-certs/
       --http-port=8080 --port=26257 --cache=25% --max-sql-memory=25%'
     env:
     - name: COCKROACH_CHANNEL
@@ -233,7 +233,7 @@ spec:
         - shell
         - -ecx
         - '>- exec /cockroach/cockroach start --join=crdb-0.crdb.[sandbox_namespace]:26257
-          --advertise-host=$(hostname -f) --logtostderr=INFO --certs-dir=/cockroach/cockroach-certs/
+          --advertise-host=$(echo $HOSTNAME) --logtostderr=INFO --certs-dir=/cockroach/cockroach-certs/
           --http-port=8080 --port=26257 --cache=25% --max-sql-memory=25%'
         env:
         - name: COCKROACH_CHANNEL

--- a/e2e/testdata/TestCreatesSecureClusterWithGeneratedCert/creates_1-node_secure_cluster.golden
+++ b/e2e/testdata/TestCreatesSecureClusterWithGeneratedCert/creates_1-node_secure_cluster.golden
@@ -29,7 +29,7 @@ spec:
     - shell
     - -ecx
     - '>- exec /cockroach/cockroach start --join=crdb-0.crdb.[sandbox_namespace]:26257
-      --advertise-host=$(echo $HOSTNAME) --logtostderr=INFO --certs-dir=/cockroach/cockroach-certs/
+      --advertise-host=$(echo ${COCKROACH_POD_NAME}.crdb.$(awk -v s=search '{if($1 == s)print $2}' /etc/resolv.conf)) --logtostderr=INFO --certs-dir=/cockroach/cockroach-certs/
       --http-port=8080 --port=26257 --cache=25% --max-sql-memory=25%'
     env:
     - name: COCKROACH_CHANNEL
@@ -235,7 +235,7 @@ spec:
         - shell
         - -ecx
         - '>- exec /cockroach/cockroach start --join=crdb-0.crdb.[sandbox_namespace]:26257
-          --advertise-host=$(echo $HOSTNAME) --logtostderr=INFO --certs-dir=/cockroach/cockroach-certs/
+          --advertise-host=$(echo ${COCKROACH_POD_NAME}.crdb.$(awk -v s=search '{if($1 == s)print $2}' /etc/resolv.conf)) --logtostderr=INFO --certs-dir=/cockroach/cockroach-certs/
           --http-port=8080 --port=26257 --cache=25% --max-sql-memory=25%'
         env:
         - name: COCKROACH_CHANNEL

--- a/e2e/testdata/TestCreatesSecureClusterWithGeneratedCert/creates_1-node_secure_cluster.golden
+++ b/e2e/testdata/TestCreatesSecureClusterWithGeneratedCert/creates_1-node_secure_cluster.golden
@@ -29,7 +29,7 @@ spec:
     - shell
     - -ecx
     - '>- exec /cockroach/cockroach start --join=crdb-0.crdb.[sandbox_namespace]:26257
-      --advertise-host=$(hostname -f) --logtostderr=INFO --certs-dir=/cockroach/cockroach-certs/
+      --advertise-host=$(echo $HOSTNAME) --logtostderr=INFO --certs-dir=/cockroach/cockroach-certs/
       --http-port=8080 --port=26257 --cache=25% --max-sql-memory=25%'
     env:
     - name: COCKROACH_CHANNEL
@@ -235,7 +235,7 @@ spec:
         - shell
         - -ecx
         - '>- exec /cockroach/cockroach start --join=crdb-0.crdb.[sandbox_namespace]:26257
-          --advertise-host=$(hostname -f) --logtostderr=INFO --certs-dir=/cockroach/cockroach-certs/
+          --advertise-host=$(echo $HOSTNAME) --logtostderr=INFO --certs-dir=/cockroach/cockroach-certs/
           --http-port=8080 --port=26257 --cache=25% --max-sql-memory=25%'
         env:
         - name: COCKROACH_CHANNEL

--- a/pkg/resource/statefulset.go
+++ b/pkg/resource/statefulset.go
@@ -198,6 +198,14 @@ func (b StatefulSetBuilder) MakeContainers() []corev1.Container {
 					Name:  "COCKROACH_CHANNEL",
 					Value: "kubernetes-operator",
 				},
+				{
+					Name: "COCKROACH_POD_NAME",
+					ValueFrom: &corev1.EnvVarSource{
+						FieldRef: &corev1.ObjectFieldSelector{
+							FieldPath: "metadata.name",
+						},
+					},
+				},
 			},
 			Ports: []corev1.ContainerPort{
 				{
@@ -276,7 +284,7 @@ func (b StatefulSetBuilder) dbArgs() []string {
 		"-ecx",
 		">- exec /cockroach/cockroach start" +
 			" --join=" + b.joinStr() +
-			" --advertise-host=$(hostname -f)" +
+			" --advertise-host=$(echo ${COCKROACH_POD_NAME}." + b.StatefulSetName() + ".$(awk -v s=search '{if($1 == s)print $2}' /etc/resolv.conf))" +
 			" --logtostderr=INFO" +
 			b.Cluster.SecureMode() +
 			" --http-port=" + fmt.Sprint(*b.Spec().HTTPPort) +

--- a/pkg/resource/testdata/TestStatefulSetBuilder/default_insecure_statefulset.golden
+++ b/pkg/resource/testdata/TestStatefulSetBuilder/default_insecure_statefulset.golden
@@ -26,7 +26,7 @@ spec:
         - shell
         - -ecx
         - '>- exec /cockroach/cockroach start --join=test-cluster-0.test-cluster.test-ns:26257
-          --advertise-host=$(hostname -f) --logtostderr=INFO --insecure --http-port=8080
+          --advertise-host=$(echo $HOSTNAME) --logtostderr=INFO --insecure --http-port=8080
           --port=26257 --cache=25% --max-sql-memory=25%'
         env:
         - name: COCKROACH_CHANNEL

--- a/pkg/resource/testdata/TestStatefulSetBuilder/default_insecure_statefulset.golden
+++ b/pkg/resource/testdata/TestStatefulSetBuilder/default_insecure_statefulset.golden
@@ -26,7 +26,7 @@ spec:
         - shell
         - -ecx
         - '>- exec /cockroach/cockroach start --join=test-cluster-0.test-cluster.test-ns:26257
-          --advertise-host=$(echo $HOSTNAME) --logtostderr=INFO --insecure --http-port=8080
+          --advertise-host=$(echo ${COCKROACH_POD_NAME}.test-cluster.$(awk -v s=search '{if($1 == s)print $2}' /etc/resolv.conf)) --logtostderr=INFO --insecure --http-port=8080
           --port=26257 --cache=25% --max-sql-memory=25%'
         env:
         - name: COCKROACH_CHANNEL

--- a/pkg/resource/testdata/TestStatefulSetBuilder/default_secure.golden
+++ b/pkg/resource/testdata/TestStatefulSetBuilder/default_secure.golden
@@ -26,7 +26,7 @@ spec:
         - shell
         - -ecx
         - '>- exec /cockroach/cockroach start --join=test-cluster-0.test-cluster.test-ns:26257
-          --advertise-host=$(echo $HOSTNAME) --logtostderr=INFO --certs-dir=/cockroach/cockroach-certs/
+          --advertise-host=$(echo ${COCKROACH_POD_NAME}.test-cluster.$(awk -v s=search '{if($1 == s)print $2}' /etc/resolv.conf)) --logtostderr=INFO --certs-dir=/cockroach/cockroach-certs/
           --http-port=8080 --port=26257 --cache=25% --max-sql-memory=25%'
         env:
         - name: COCKROACH_CHANNEL

--- a/pkg/resource/testdata/TestStatefulSetBuilder/default_secure.golden
+++ b/pkg/resource/testdata/TestStatefulSetBuilder/default_secure.golden
@@ -26,7 +26,7 @@ spec:
         - shell
         - -ecx
         - '>- exec /cockroach/cockroach start --join=test-cluster-0.test-cluster.test-ns:26257
-          --advertise-host=$(hostname -f) --logtostderr=INFO --certs-dir=/cockroach/cockroach-certs/
+          --advertise-host=$(echo $HOSTNAME) --logtostderr=INFO --certs-dir=/cockroach/cockroach-certs/
           --http-port=8080 --port=26257 --cache=25% --max-sql-memory=25%'
         env:
         - name: COCKROACH_CHANNEL

--- a/pkg/resource/testdata/TestStatefulSetBuilder/insecure_statefulset_cli_args.golden
+++ b/pkg/resource/testdata/TestStatefulSetBuilder/insecure_statefulset_cli_args.golden
@@ -26,7 +26,7 @@ spec:
         - shell
         - -ecx
         - '>- exec /cockroach/cockroach start --join=test-cluster-0.test-cluster.test-ns:26257
-          --advertise-host=$(echo $HOSTNAME) --logtostderr=INFO --insecure --http-port=8080
+          --advertise-host=$(echo ${COCKROACH_POD_NAME}.test-cluster.$(awk -v s=search '{if($1 == s)print $2}' /etc/resolv.conf)) --logtostderr=INFO --insecure --http-port=8080
           --port=26257 --cache=30% --max-sql-memory=2GB'
         - --temp-dir=/tmp
         env:

--- a/pkg/resource/testdata/TestStatefulSetBuilder/insecure_statefulset_cli_args.golden
+++ b/pkg/resource/testdata/TestStatefulSetBuilder/insecure_statefulset_cli_args.golden
@@ -26,7 +26,7 @@ spec:
         - shell
         - -ecx
         - '>- exec /cockroach/cockroach start --join=test-cluster-0.test-cluster.test-ns:26257
-          --advertise-host=$(hostname -f) --logtostderr=INFO --insecure --http-port=8080
+          --advertise-host=$(echo $HOSTNAME) --logtostderr=INFO --insecure --http-port=8080
           --port=26257 --cache=30% --max-sql-memory=2GB'
         - --temp-dir=/tmp
         env:

--- a/pkg/resource/testdata/TestStatefulSetBuilder/insecure_statefulset_with_resources.golden
+++ b/pkg/resource/testdata/TestStatefulSetBuilder/insecure_statefulset_with_resources.golden
@@ -26,7 +26,7 @@ spec:
         - shell
         - -ecx
         - '>- exec /cockroach/cockroach start --join=test-cluster-0.test-cluster.test-ns:26257
-          --advertise-host=$(hostname -f) --logtostderr=INFO --insecure --http-port=8080
+          --advertise-host=$(echo $HOSTNAME) --logtostderr=INFO --insecure --http-port=8080
           --port=26257 --cache=25% --max-sql-memory=25%'
         env:
         - name: COCKROACH_CHANNEL

--- a/pkg/resource/testdata/TestStatefulSetBuilder/insecure_statefulset_with_resources.golden
+++ b/pkg/resource/testdata/TestStatefulSetBuilder/insecure_statefulset_with_resources.golden
@@ -26,7 +26,7 @@ spec:
         - shell
         - -ecx
         - '>- exec /cockroach/cockroach start --join=test-cluster-0.test-cluster.test-ns:26257
-          --advertise-host=$(echo $HOSTNAME) --logtostderr=INFO --insecure --http-port=8080
+          --advertise-host=$(echo ${COCKROACH_POD_NAME}.test-cluster.$(awk -v s=search '{if($1 == s)print $2}' /etc/resolv.conf)) --logtostderr=INFO --insecure --http-port=8080
           --port=26257 --cache=25% --max-sql-memory=25%'
         env:
         - name: COCKROACH_CHANNEL


### PR DESCRIPTION
Instead of using the hostname -f command to determine the Pod's
hostname. We are using the HOSTNAME environment variable in the
cockroach command.  Various K8s distros and container distros
cannot use hostname -f.