### PR TITLE
Updating Command and Arguments for CR Pods

### DIFF
--- a/e2e/testdata/TestCreatesInsecureCluster/creates_3-node_insecure_cluster.golden
+++ b/e2e/testdata/TestCreatesInsecureCluster/creates_3-node_insecure_cluster.golden
@@ -25,14 +25,25 @@ spec:
   automountServiceAccountToken: false
   containers:
   - args:
-    - shell
-    - -ecx
-    - '>- exec /cockroach/cockroach start --join=crdb-0.crdb.[sandbox_namespace]:26257,crdb-1.crdb.[sandbox_namespace]:26257,crdb-2.crdb.[sandbox_namespace]:26257
-      --advertise-host=$(hostname -f) --logtostderr=INFO --insecure --http-port=8080
-      --port=26257 --cache=25% --max-sql-memory=25%'
+    - start
+    - --join=crdb-0.crdb.[sandbox_namespace]:26257,crdb-1.crdb.[sandbox_namespace]:26257,crdb-2.crdb.[sandbox_namespace]:26257
+    - --advertise-host=$(POD_NAME).crdb.[sandbox_namespace]
+    - --logtostderr=INFO
+    - --insecure
+    - --http-port=8080
+    - --port=26257
+    - --cache=25%
+    - --max-sql-memory=25%
+    command:
+    - /cockroach/cockroach
     env:
     - name: COCKROACH_CHANNEL
       value: kubernetes-operator
+    - name: POD_NAME
+      valueFrom:
+        fieldRef:
+          apiVersion: v1
+          fieldPath: metadata.name
     image: cockroachdb/cockroach:v19.2.6
     imagePullPolicy: IfNotPresent
     livenessProbe:
@@ -106,14 +117,25 @@ spec:
   automountServiceAccountToken: false
   containers:
   - args:
-    - shell
-    - -ecx
-    - '>- exec /cockroach/cockroach start --join=crdb-0.crdb.[sandbox_namespace]:26257,crdb-1.crdb.[sandbox_namespace]:26257,crdb-2.crdb.[sandbox_namespace]:26257
-      --advertise-host=$(hostname -f) --logtostderr=INFO --insecure --http-port=8080
-      --port=26257 --cache=25% --max-sql-memory=25%'
+    - start
+    - --join=crdb-0.crdb.[sandbox_namespace]:26257,crdb-1.crdb.[sandbox_namespace]:26257,crdb-2.crdb.[sandbox_namespace]:26257
+    - --advertise-host=$(POD_NAME).crdb.[sandbox_namespace]
+    - --logtostderr=INFO
+    - --insecure
+    - --http-port=8080
+    - --port=26257
+    - --cache=25%
+    - --max-sql-memory=25%
+    command:
+    - /cockroach/cockroach
     env:
     - name: COCKROACH_CHANNEL
       value: kubernetes-operator
+    - name: POD_NAME
+      valueFrom:
+        fieldRef:
+          apiVersion: v1
+          fieldPath: metadata.name
     image: cockroachdb/cockroach:v19.2.6
     imagePullPolicy: IfNotPresent
     livenessProbe:
@@ -187,14 +209,25 @@ spec:
   automountServiceAccountToken: false
   containers:
   - args:
-    - shell
-    - -ecx
-    - '>- exec /cockroach/cockroach start --join=crdb-0.crdb.[sandbox_namespace]:26257,crdb-1.crdb.[sandbox_namespace]:26257,crdb-2.crdb.[sandbox_namespace]:26257
-      --advertise-host=$(hostname -f) --logtostderr=INFO --insecure --http-port=8080
-      --port=26257 --cache=25% --max-sql-memory=25%'
+    - start
+    - --join=crdb-0.crdb.[sandbox_namespace]:26257,crdb-1.crdb.[sandbox_namespace]:26257,crdb-2.crdb.[sandbox_namespace]:26257
+    - --advertise-host=$(POD_NAME).crdb.[sandbox_namespace]
+    - --logtostderr=INFO
+    - --insecure
+    - --http-port=8080
+    - --port=26257
+    - --cache=25%
+    - --max-sql-memory=25%
+    command:
+    - /cockroach/cockroach
     env:
     - name: COCKROACH_CHANNEL
       value: kubernetes-operator
+    - name: POD_NAME
+      valueFrom:
+        fieldRef:
+          apiVersion: v1
+          fieldPath: metadata.name
     image: cockroachdb/cockroach:v19.2.6
     imagePullPolicy: IfNotPresent
     livenessProbe:
@@ -368,14 +401,25 @@ spec:
       automountServiceAccountToken: false
       containers:
       - args:
-        - shell
-        - -ecx
-        - '>- exec /cockroach/cockroach start --join=crdb-0.crdb.[sandbox_namespace]:26257,crdb-1.crdb.[sandbox_namespace]:26257,crdb-2.crdb.[sandbox_namespace]:26257
-          --advertise-host=$(hostname -f) --logtostderr=INFO --insecure --http-port=8080
-          --port=26257 --cache=25% --max-sql-memory=25%'
+        - start
+        - --join=crdb-0.crdb.[sandbox_namespace]:26257,crdb-1.crdb.[sandbox_namespace]:26257,crdb-2.crdb.[sandbox_namespace]:26257
+        - --advertise-host=$(POD_NAME).crdb.[sandbox_namespace]
+        - --logtostderr=INFO
+        - --insecure
+        - --http-port=8080
+        - --port=26257
+        - --cache=25%
+        - --max-sql-memory=25%
+        command:
+        - /cockroach/cockroach
         env:
         - name: COCKROACH_CHANNEL
           value: kubernetes-operator
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.name
         image: cockroachdb/cockroach:v19.2.6
         imagePullPolicy: IfNotPresent
         livenessProbe:

--- a/e2e/testdata/TestCreatesSecureClusterWithGeneratedCert/creates_1-node_secure_cluster.golden
+++ b/e2e/testdata/TestCreatesSecureClusterWithGeneratedCert/creates_1-node_secure_cluster.golden
@@ -26,14 +26,25 @@ spec:
   automountServiceAccountToken: false
   containers:
   - args:
-    - shell
-    - -ecx
-    - '>- exec /cockroach/cockroach start --join=crdb-0.crdb.[sandbox_namespace]:26257
-      --advertise-host=$(hostname -f) --logtostderr=INFO --certs-dir=/cockroach/cockroach-certs/
-      --http-port=8080 --port=26257 --cache=25% --max-sql-memory=25%'
+    - start
+    - --join=crdb-0.crdb.[sandbox_namespace]:26257
+    - --advertise-host=$(POD_NAME).crdb.[sandbox_namespace]
+    - --logtostderr=INFO
+    - --certs-dir=/cockroach/cockroach-certs/
+    - --http-port=8080
+    - --port=26257
+    - --cache=25%
+    - --max-sql-memory=25%
+    command:
+    - /cockroach/cockroach
     env:
     - name: COCKROACH_CHANNEL
       value: kubernetes-operator
+    - name: POD_NAME
+      valueFrom:
+        fieldRef:
+          apiVersion: v1
+          fieldPath: metadata.name
     image: cockroachdb/cockroach:v19.2.6
     imagePullPolicy: IfNotPresent
     livenessProbe:
@@ -232,14 +243,25 @@ spec:
       automountServiceAccountToken: false
       containers:
       - args:
-        - shell
-        - -ecx
-        - '>- exec /cockroach/cockroach start --join=crdb-0.crdb.[sandbox_namespace]:26257
-          --advertise-host=$(hostname -f) --logtostderr=INFO --certs-dir=/cockroach/cockroach-certs/
-          --http-port=8080 --port=26257 --cache=25% --max-sql-memory=25%'
+        - start
+        - --join=crdb-0.crdb.[sandbox_namespace]:26257
+        - --advertise-host=$(POD_NAME).crdb.[sandbox_namespace]
+        - --logtostderr=INFO
+        - --certs-dir=/cockroach/cockroach-certs/
+        - --http-port=8080
+        - --port=26257
+        - --cache=25%
+        - --max-sql-memory=25%
+        command:
+        - /cockroach/cockroach
         env:
         - name: COCKROACH_CHANNEL
           value: kubernetes-operator
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              apiVersion: v1
+              fieldPath: metadata.name
         image: cockroachdb/cockroach:v19.2.6
         imagePullPolicy: IfNotPresent
         livenessProbe:

--- a/pkg/actor/initialize.go
+++ b/pkg/actor/initialize.go
@@ -77,7 +77,7 @@ func (init initialize) Act(ctx context.Context, cluster *resource.Cluster) error
 	cmd := []string{
 		"/bin/bash",
 		"-c",
-		">- /cockroach/cockroach init" + cluster.SecureMode(),
+		">- /cockroach/cockroach init " + cluster.SecureMode(),
 	}
 
 	_, stderr, err := kube.ExecInPod(init.scheme, init.config, cluster.Namespace(),

--- a/pkg/resource/cluster.go
+++ b/pkg/resource/cluster.go
@@ -119,10 +119,10 @@ func (cluster Cluster) Domain() string {
 
 func (cluster Cluster) SecureMode() string {
 	if cluster.Spec().TLSEnabled {
-		return " --certs-dir=/cockroach/cockroach-certs/"
+		return "--certs-dir=/cockroach/cockroach-certs/"
 	}
 
-	return " --insecure"
+	return "--insecure"
 }
 
 func (cluster Cluster) IsFresh(fetcher Fetcher) (bool, error) {

--- a/pkg/resource/testdata/TestStatefulSetBuilder/default_insecure_statefulset.golden
+++ b/pkg/resource/testdata/TestStatefulSetBuilder/default_insecure_statefulset.golden
@@ -23,14 +23,24 @@ spec:
       automountServiceAccountToken: false
       containers:
       - args:
-        - shell
-        - -ecx
-        - '>- exec /cockroach/cockroach start --join=test-cluster-0.test-cluster.test-ns:26257
-          --advertise-host=$(hostname -f) --logtostderr=INFO --insecure --http-port=8080
-          --port=26257 --cache=25% --max-sql-memory=25%'
+        - start
+        - --join=test-cluster-0.test-cluster.test-ns:26257
+        - --advertise-host=$(POD_NAME).test-cluster.test-ns
+        - --logtostderr=INFO
+        - --insecure
+        - --http-port=8080
+        - --port=26257
+        - --cache=25%
+        - --max-sql-memory=25%
+        command:
+        - /cockroach/cockroach
         env:
         - name: COCKROACH_CHANNEL
           value: kubernetes-operator
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
         image: cockroachdb/cockroach:v19.2.6
         imagePullPolicy: IfNotPresent
         livenessProbe:

--- a/pkg/resource/testdata/TestStatefulSetBuilder/default_secure.golden
+++ b/pkg/resource/testdata/TestStatefulSetBuilder/default_secure.golden
@@ -23,14 +23,24 @@ spec:
       automountServiceAccountToken: false
       containers:
       - args:
-        - shell
-        - -ecx
-        - '>- exec /cockroach/cockroach start --join=test-cluster-0.test-cluster.test-ns:26257
-          --advertise-host=$(hostname -f) --logtostderr=INFO --certs-dir=/cockroach/cockroach-certs/
-          --http-port=8080 --port=26257 --cache=25% --max-sql-memory=25%'
+        - start
+        - --join=test-cluster-0.test-cluster.test-ns:26257
+        - --advertise-host=$(POD_NAME).test-cluster.test-ns
+        - --logtostderr=INFO
+        - --certs-dir=/cockroach/cockroach-certs/
+        - --http-port=8080
+        - --port=26257
+        - --cache=25%
+        - --max-sql-memory=25%
+        command:
+        - /cockroach/cockroach
         env:
         - name: COCKROACH_CHANNEL
           value: kubernetes-operator
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
         image: cockroachdb/cockroach:v19.2.6
         imagePullPolicy: IfNotPresent
         livenessProbe:

--- a/pkg/resource/testdata/TestStatefulSetBuilder/insecure_statefulset_cli_args.golden
+++ b/pkg/resource/testdata/TestStatefulSetBuilder/insecure_statefulset_cli_args.golden
@@ -23,15 +23,25 @@ spec:
       automountServiceAccountToken: false
       containers:
       - args:
-        - shell
-        - -ecx
-        - '>- exec /cockroach/cockroach start --join=test-cluster-0.test-cluster.test-ns:26257
-          --advertise-host=$(hostname -f) --logtostderr=INFO --insecure --http-port=8080
-          --port=26257 --cache=30% --max-sql-memory=2GB'
+        - start
+        - --join=test-cluster-0.test-cluster.test-ns:26257
+        - --advertise-host=$(POD_NAME).test-cluster.test-ns
+        - --logtostderr=INFO
+        - --insecure
+        - --http-port=8080
+        - --port=26257
+        - --cache=30%
+        - --max-sql-memory=2GB
         - --temp-dir=/tmp
+        command:
+        - /cockroach/cockroach
         env:
         - name: COCKROACH_CHANNEL
           value: kubernetes-operator
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
         image: cockroachdb/cockroach:v19.2.6
         imagePullPolicy: IfNotPresent
         livenessProbe:

--- a/pkg/resource/testdata/TestStatefulSetBuilder/insecure_statefulset_with_resources.golden
+++ b/pkg/resource/testdata/TestStatefulSetBuilder/insecure_statefulset_with_resources.golden
@@ -23,14 +23,24 @@ spec:
       automountServiceAccountToken: false
       containers:
       - args:
-        - shell
-        - -ecx
-        - '>- exec /cockroach/cockroach start --join=test-cluster-0.test-cluster.test-ns:26257
-          --advertise-host=$(hostname -f) --logtostderr=INFO --insecure --http-port=8080
-          --port=26257 --cache=25% --max-sql-memory=25%'
+        - start
+        - --join=test-cluster-0.test-cluster.test-ns:26257
+        - --advertise-host=$(POD_NAME).test-cluster.test-ns
+        - --logtostderr=INFO
+        - --insecure
+        - --http-port=8080
+        - --port=26257
+        - --cache=25%
+        - --max-sql-memory=25%
+        command:
+        - /cockroach/cockroach
         env:
         - name: COCKROACH_CHANNEL
           value: kubernetes-operator
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
         image: cockroachdb/cockroach:v19.2.6
         imagePullPolicy: IfNotPresent
         livenessProbe:


### PR DESCRIPTION
This is a cleanup and general change of how we are starting the
CR Pods, and also how we are createing the advertise-host option.
Moreover we are not using a shell command, but are directly running
the coachroach command.  This change is required due to the fact
that the ubi redhat container does not have the hostname command.