### PR TITLE
fix e2e tests for macos

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,9 @@
 #
 
 # values used in workspace-status.sh
+
 DOCKER_REGISTRY?=us.gcr.io/chris-love-operator-playground
+# DOCKER_REGISTRY?=gcr.io/og-lab-project/alina-playground
 DOCKER_IMAGE_REPOSITORY?=cockroach-operator
 APP_VERSION?=v1.0.0-alpha.1
 
@@ -42,6 +44,12 @@ test/pkg:
 .PHONY: test/verify
 test/verify:
 	bazel test //hack/...
+
+# This target uses kind to start a k8s cluster  and runs the e2e tests
+# against that cluster.
+.PHONY: test/e2e-short
+test/e2e: 
+	bazel test //e2e/... --test_arg=--test.short
 
 # This target uses kind to start a k8s cluster  and runs the e2e tests
 # against that cluster.
@@ -96,3 +104,15 @@ release/image:
 	APP_VERSION=$(APP_VERSION) \
 	bazel run --stamp --platforms=@io_bazel_rules_go//go/toolchain:linux_amd64 \
 		//:push_operator_image 
+
+#
+# Dev target that
+#
+.PHONY: dev/syncdeps
+dev/syncdeps:
+	bazel run //hack:update-deps \
+	bazel run //hack:update-bazel \
+	bazel run //:gazelle -- update-repos -from_file=go.mod
+
+
+		

--- a/Makefile
+++ b/Makefile
@@ -106,7 +106,7 @@ release/image:
 		//:push_operator_image 
 
 #
-# Dev target that
+# Dev target that updates bazel files and dependecies
 #
 .PHONY: dev/syncdeps
 dev/syncdeps:

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,6 @@
 # values used in workspace-status.sh
 
 DOCKER_REGISTRY?=us.gcr.io/chris-love-operator-playground
-# DOCKER_REGISTRY?=gcr.io/og-lab-project/alina-playground
 DOCKER_IMAGE_REPOSITORY?=cockroach-operator
 APP_VERSION?=v1.0.0-alpha.1
 

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -97,7 +97,6 @@ func TestMain(m *testing.M) {
 	}
 	os.Exit(code)
 }
-
 func TestCreatesInsecureCluster(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping test in short mode.")

--- a/hack/bin/BUILD.bazel
+++ b/hack/bin/BUILD.bazel
@@ -101,6 +101,7 @@ genrule(
 genrule(
     name = "fetch_kubetest2",
     srcs = select({
+        ":darwin": ["@kubetest2_darwin//file"],
         ":k8": ["@kubetest2_linux//file"],
     }),
     outs = ["kubetest2"],
@@ -111,6 +112,7 @@ genrule(
 genrule(
     name = "fetch_kubetest2_kind",
     srcs = select({
+        ":darwin": ["@kubetest2_kind_darwin//file"],
         ":k8": ["@kubetest2_kind_linux//file"],
     }),
     outs = ["kubetest2-kind"],

--- a/hack/bin/BUILD.bazel
+++ b/hack/bin/BUILD.bazel
@@ -87,6 +87,7 @@ workspace_binary(
     cmd = "@go_sdk//:bin/go",
 )
 
+# fetch_kind rules to fetch the kind binary from github
 genrule(
     name = "fetch_kind",
     srcs = select({
@@ -97,7 +98,7 @@ genrule(
     cmd = "cp $(SRCS) $@",
     visibility = ["//visibility:public"],
 )
-
+# fetch_kubetest2 rules to fetch the binary for kubetest2 used on e2e tests that are saved on a google cloud bucket
 genrule(
     name = "fetch_kubetest2",
     srcs = select({
@@ -108,7 +109,7 @@ genrule(
     cmd = "cp $(SRCS) $@",
     visibility = ["//visibility:public"],
 )
-
+# fetch_kubetest2_kind rules to fetch the binary for kubetest2_kind used on e2e tests that are saved on a google cloud bucket 
 genrule(
     name = "fetch_kubetest2_kind",
     srcs = select({

--- a/hack/bin/deps.bzl
+++ b/hack/bin/deps.bzl
@@ -240,36 +240,36 @@ def install_kind():
 def install_kubetest2():
     # install kubetest2 binary
     # TODO osx support
-    #http_file(
-    #    name = "kubetest2_darwin",
-    #    executable = 1,
-    #    sha256 = "11b8a7fda7c9d6230f0f28ffe57831a7227c0655dfb8d38e838e8f03db6612de",
-    #    urls = ["https://github.com/kubernetes-sigs/kind/releases/download/v0.7.0/kind-darwin-amd64"],
-    #)
+    http_file(
+       name = "kubetest2_darwin",
+       executable = 1,
+       sha256 = "54b7f35575467b6bea173117f693959635c297ec89fc8011a964da8702cde50f",
+       urls = ["https://storage.googleapis.com/crdb-bazel-artifacts/macos/kubetest2"],
+    )
 
     http_file(
         name = "kubetest2_linux",
         executable = 1,
-        sha256 = "a2617f5c65e8edcc49dcb72ec79c4d21043ef4ee6278e7179fe76ff362192054",
-        urls = ["https://storage.googleapis.com/crdb-bazel-artifacts/kubetest2"],
+        sha256 = "6f1a0e2d67857e761ccde1247452af8ac38c7213f7e000ef08b3d282beb7bfaa",
+        urls = ["https://storage.googleapis.com/crdb-bazel-artifacts/linux/kubetest2"],
     )
 
 ## Fetch kubetest2-kind binary used during e2e tests
 def install_kubetest2_kind():
-    # install kubetest2 binary
+    # install kubetest2-kind binary
     # TODO osx support
-    #http_file(
-    #    name = "kubetest2_darwin",
-    #    executable = 1,
-    #    sha256 = "11b8a7fda7c9d6230f0f28ffe57831a7227c0655dfb8d38e838e8f03db6612de",
-    #    urls = ["https://github.com/kubernetes-sigs/kind/releases/download/v0.7.0/kind-darwin-amd64"],
-    #)
+    http_file(
+       name = "kubetest2_kind_darwin",
+       executable = 1,
+       sha256 = "d89aa58feaaafcec82f9b5ffb92954dce157d8eb6dea6015fd3da85449840d7c",
+       urls = ["https://storage.googleapis.com/crdb-bazel-artifacts/macos/kubetest2-kind"],
+    )
 
     http_file(
         name = "kubetest2_kind_linux",
         executable = 1,
-        sha256 = "b8d570ce69155beb9f882489b096583676f69afb4cd2a5061106264b45b5d113",
-        urls = ["https://storage.googleapis.com/crdb-bazel-artifacts/kubetest2-kind"],
+        sha256 = "c97f5f05bca4bfee2c9d24bdaeb617c2a2a0b6df5730664814c90033aa7f801b",
+        urls = ["https://storage.googleapis.com/crdb-bazel-artifacts/linux/kubetest2-kind"],
     )
 
 

--- a/hack/bin/deps.bzl
+++ b/hack/bin/deps.bzl
@@ -250,7 +250,7 @@ def install_kubetest2():
     http_file(
         name = "kubetest2_linux",
         executable = 1,
-        sha256 = "6f1a0e2d67857e761ccde1247452af8ac38c7213f7e000ef08b3d282beb7bfaa",
+        sha256 = "c9c386dd46f3d26f91fc095b9970f57c34e2c54e443958bc097b3ec711e80b58",
         urls = ["https://storage.googleapis.com/crdb-bazel-artifacts/linux/kubetest2"],
     )
 
@@ -268,7 +268,7 @@ def install_kubetest2_kind():
     http_file(
         name = "kubetest2_kind_linux",
         executable = 1,
-        sha256 = "c97f5f05bca4bfee2c9d24bdaeb617c2a2a0b6df5730664814c90033aa7f801b",
+        sha256 = "e1b7ce0eec0c3db97b4fce3659e25f6190188c9c53f81ae3d090da47265a7599",
         urls = ["https://storage.googleapis.com/crdb-bazel-artifacts/linux/kubetest2-kind"],
     )
 


### PR DESCRIPTION
1. Added  dev/syncdeps target on makefile
2. Rebuild and replace binaries for kubetest2 and kubetest2_kind
3. We still need core-utils for macos install because of the usage of realpath