### PR TITLE
fix certs path in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Each pod should have `READY` status soon after being created.
 Get a shell into one of the pods and start the CockroachDB built-in SQL client:
 
 ```
-kubectl exec -it cockroachdb-2 -- ./cockroach sql --certs-dir=/cockroach-certs
+kubectl exec -it cockroachdb-2 -- ./cockroach sql --certs-dir=/cockroach/cockroach-certs
 ```
 
 If you want to [access the Admin UI](#access-the-admin-ui), create a SQL user with a password while you're here:


### PR DESCRIPTION
small nit in readme when running any command in built-in SQL client 

```
#
# Welcome to the CockroachDB SQL shell.
# All statements must be terminated by a semicolon.
# To exit, type: \q.
#
ERROR: cannot load certificates.
Check your certificate settings, set --certs-dir, or use --insecure for insecure clusters.
```

but works with `/cockroach/cockroach-certs`