### PR TITLE
Correcting typo for bazel

### DIFF
--- a/manifests/BUILD.bazel
+++ b/manifests/BUILD.bazel
@@ -6,7 +6,7 @@ k8s_deploy(
     images = {
         # TODO how do we do this?
         # "{STABLE_DOCKER_REGISTRY}/{STABLE_IMAGE_REPOSITORY}:{STABLE_DOCKER_TAG}"
-        "cockroach-operator": "//cmd/cockroach-operator:operator_image",
+        "cockroachdb/cockroach-operator": "//cmd/cockroach-operator:operator_image",
     },
     template = ":operator.yaml",
 )


### PR DESCRIPTION
We had a typo in BUILD.bazel file that did not allow k8s apply to work.