### PR TITLE
Fix link to example.yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ cockroach-operator-6f7b86ffc4-9ppkv   1/1     Running   0          54s
 
 ## Start CockroachDB
 
-Download [`example.yaml`](https://github.com/cockroachdb/cockroach-operator/examples/example.yaml) and optionally modify the default configuration as outlined below.
+Download [`example.yaml`](https://raw.githubusercontent.com/cockroachdb/cockroach-operator/master/examples/example.yaml) and optionally modify the default configuration as outlined below.
 
 ```
 apiVersion: crdb.cockroachlabs.com/v1alpha1


### PR DESCRIPTION
The current link is a 404.