### PR TITLE
Logging changes for operator

### DIFF
--- a/cmd/cockroach-operator/main.go
+++ b/cmd/cockroach-operator/main.go
@@ -48,15 +48,21 @@ func init() {
 func main() {
 	var metricsAddr, featureGatesString string
 	var enableLeaderElection bool
+
+	// use zap logging cli options
+	opts := zap.Options{}
+	opts.BindFlags(flag.CommandLine)
+
 	flag.StringVar(&metricsAddr, "metrics-addr", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&featureGatesString, "feature-gates", "", "Feature gate to enable, format is a command separated list enabling features, for instance RunAsNonRoot=false")
 	flag.BoolVar(&enableLeaderElection, "enable-leader-election", false,
 		"Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager.")
 	flag.Parse()
 
-	ctrl.SetLogger(zap.New(func(o *zap.Options) {
-		o.Development = true
-	}))
+	// create logger using zap cli options
+	// for instance --zap-log-level=debug
+	logger := zap.New(zap.UseFlagOptions(&opts))
+	ctrl.SetLogger(logger)
 
 	// If features gates are passed to the command line, use it (otherwise use featureGates from configuration)
 	if featureGatesString != "" {

--- a/manifests/BUILD.bazel
+++ b/manifests/BUILD.bazel
@@ -6,8 +6,8 @@ k8s_deploy(
     images = {
         # TODO how do we do this?
         # "{STABLE_DOCKER_REGISTRY}/{STABLE_IMAGE_REPOSITORY}:{STABLE_DOCKER_TAG}"
-        #"cockroachdb/cockroach-operator:v1.16.12-rc.2": "//cmd/cockroach-operator:operator_image",
-        "cockroach-operator:bazel": "//cmd/cockroach-operator:operator_image",
+        # "cockroachdb/cockroach-operator:v1.16.12-rc.2": "//cmd/cockroach-operator:operator_image",
+        "cockroachdb:bazel": "//cmd/cockroach-operator:operator_image",
     },
     template = ":operator.yaml",
 )

--- a/manifests/operator.yaml
+++ b/manifests/operator.yaml
@@ -263,7 +263,7 @@ spec:
           imagePullPolicy: IfNotPresent
           # uncomment this to enable different new features
           # args: ["-feature-gates","PartitionedUpdate=true,UseDecommission=true,Upgrade=false, CrdbVersionValidator=false"]
-          args: ["-feature-gates","Upgrade=false"]
+          args: ["-feature-gates","Upgrade=false","--zap-log-level","info"]
           env:
             - name: WATCH_NAMESPACE
               valueFrom:

--- a/pkg/actor/BUILD.bazel
+++ b/pkg/actor/BUILD.bazel
@@ -46,6 +46,7 @@ go_library(
         "@io_k8s_client_go//rest:go_default_library",
         "@io_k8s_sigs_controller_runtime//pkg/client:go_default_library",
         "@io_k8s_sigs_controller_runtime//pkg/log:go_default_library",
+        "@org_uber_go_zap//zapcore:go_default_library",
     ],
 )
 

--- a/pkg/actor/deploy.go
+++ b/pkg/actor/deploy.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cockroachdb/cockroach-operator/pkg/resource"
 	"github.com/cockroachdb/cockroach-operator/pkg/utilfeature"
 	"github.com/pkg/errors"
+	"go.uber.org/zap/zapcore"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -56,7 +57,7 @@ func (d deploy) Handles(conds []api.ClusterCondition) bool {
 
 func (d deploy) Act(ctx context.Context, cluster *resource.Cluster) error {
 	log := d.log.WithValues("CrdbCluster", cluster.ObjectKey())
-	log.Info("reconciling resources on deploy action")
+	log.V(int(zapcore.DebugLevel)).Info("reconciling resources on deploy action")
 
 	r := resource.NewManagedKubeResource(ctx, d.client, cluster, kube.AnnotatingPersister)
 
@@ -76,7 +77,7 @@ func (d deploy) Act(ctx context.Context, cluster *resource.Cluster) error {
 	}
 
 	if changed {
-		log.Info("created/updated discovery service, stopping request processing")
+		log.V(int(zapcore.DebugLevel)).Info("created/updated discovery service, stopping request processing")
 		CancelLoop(ctx)
 		return nil
 	}
@@ -95,7 +96,7 @@ func (d deploy) Act(ctx context.Context, cluster *resource.Cluster) error {
 	}
 
 	if changed {
-		log.Info("created/updated public service, stopping request processing")
+		log.V(int(zapcore.DebugLevel)).Info("created/updated public service, stopping request processing")
 		CancelLoop(ctx)
 		return nil
 	}
@@ -113,7 +114,7 @@ func (d deploy) Act(ctx context.Context, cluster *resource.Cluster) error {
 	}
 
 	if changed {
-		log.Info("created/updated statefulset, stopping request processing")
+		log.V(int(zapcore.DebugLevel)).Info("created/updated statefulset, stopping request processing")
 		CancelLoop(ctx)
 		return nil
 	}
@@ -135,12 +136,12 @@ func (d deploy) Act(ctx context.Context, cluster *resource.Cluster) error {
 		}
 
 		if changed {
-			log.Info("created/updated pdb, stopping request processing")
+			log.V(int(zapcore.DebugLevel)).Info("created/updated pdb, stopping request processing")
 			CancelLoop(ctx)
 			return nil
 		}
 	}
 
-	log.Info("completed")
+	log.V(int(zapcore.DebugLevel)).Info("deployed database")
 	return nil
 }

--- a/pkg/controller/BUILD.bazel
+++ b/pkg/controller/BUILD.bazel
@@ -19,6 +19,7 @@ go_library(
         "@io_k8s_apimachinery//pkg/runtime:go_default_library",
         "@io_k8s_sigs_controller_runtime//:go_default_library",
         "@io_k8s_sigs_controller_runtime//pkg/client:go_default_library",
+        "@org_uber_go_zap//zapcore:go_default_library",
     ],
 )
 

--- a/pkg/resource/job.go
+++ b/pkg/resource/job.go
@@ -30,7 +30,7 @@ import (
 )
 
 const (
-	// JobContainerName used on spec for teh container
+	// JobContainerName used on spec for the container
 	JobContainerName     = "crdb"
 	GetTagVersionCommand = "/cockroach/cockroach version | grep 'Build Tag:'| awk '{print $3}'"
 )

--- a/pkg/scale/BUILD.bazel
+++ b/pkg/scale/BUILD.bazel
@@ -25,6 +25,7 @@ go_library(
         "@io_k8s_client_go//kubernetes/scheme:go_default_library",
         "@io_k8s_client_go//rest:go_default_library",
         "@io_k8s_client_go//tools/remotecommand:go_default_library",
+        "@org_uber_go_zap//zapcore:go_default_library",
     ],
 )
 

--- a/pkg/scale/drainer.go
+++ b/pkg/scale/drainer.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cenkalti/backoff"
 	"github.com/cockroachdb/errors"
 	"github.com/go-logr/logr"
+	"go.uber.org/zap/zapcore"
 
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -80,7 +81,7 @@ func (d *CockroachNodeDrainer) Decommission(ctx context.Context, replica uint) e
 		return err
 	}
 
-	d.Logger.Info("draining node", "NodeID", lastNodeID)
+	d.Logger.V(int(zapcore.InfoLevel)).Info("draining node", "NodeID", lastNodeID)
 
 	if err := d.executeDrainCmd(ctx, lastNodeID); err != nil {
 		return err
@@ -171,8 +172,8 @@ func (d *CockroachNodeDrainer) makeDrainStatusChecker(id uint) func(ctx context.
 
 		isLive, replicasStr, isDecommissioning := record[8], record[9], record[10]
 
-		d.Logger.Info(
-			"node status",
+		d.Logger.V(int(zapcore.InfoLevel)).Info(
+			"draining node do to decommission",
 			"id", id,
 			"isLive", isLive,
 			"replicas", replicasStr,

--- a/pkg/scale/persistent_volume_pruner.go
+++ b/pkg/scale/persistent_volume_pruner.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/cockroachdb/errors"
 	"github.com/go-logr/logr"
+	"go.uber.org/zap/zapcore"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -60,7 +61,7 @@ func (p *PersistentVolumePruner) watchStatefulset(
 		return errors.Wrapf(err, "establishing watch on statefulset %s.%s", p.Namespace, p.StatefulSet)
 	}
 
-	p.Logger.Info("established statefulset watch", "name", p.StatefulSet, "namespace", p.Namespace)
+	p.Logger.V(int(zapcore.InfoLevel)).Info("established statefulset watch", "name", p.StatefulSet, "namespace", p.Namespace)
 
 	go func() {
 		defer w.Stop()
@@ -96,7 +97,7 @@ func (p *PersistentVolumePruner) watchStatefulset(
 					}
 				default:
 					// cancel on any unexpected events.
-					p.Logger.Info("saw an unexpected event", "event", evt)
+					p.Logger.V(int(zapcore.WarnLevel)).Info("saw an unexpected event", "event", evt)
 					cancel()
 				}
 			}
@@ -237,7 +238,7 @@ func (p *PersistentVolumePruner) Prune(ctx context.Context) error {
 		default:
 		}
 
-		p.Logger.Info("deleting PVC", "name", pvc.Name)
+		p.Logger.V(int(zapcore.DebugLevel)).Info("deleting PVC", "name", pvc.Name)
 		if err := p.ClientSet.CoreV1().PersistentVolumeClaims(p.Namespace).Delete(ctx, pvc.Name, metav1.DeleteOptions{
 			GracePeriodSeconds: &gracePeriod,
 			// Wait for the underlying PV to be deleted before moving on to

--- a/pkg/scale/scale.go
+++ b/pkg/scale/scale.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/cockroachdb/errors"
 	"github.com/go-logr/logr"
+	"go.uber.org/zap/zapcore"
 )
 
 //PVCPruner interface
@@ -78,7 +79,7 @@ func (s *Scaler) EnsureScale(ctx context.Context, scale uint) error {
 	for crdbScale > scale {
 		oneOff := crdbScale - 1
 
-		s.Logger.Info("scaling down stateful set", "have", crdbScale, "want", oneOff)
+		s.Logger.V(int(zapcore.DebugLevel)).Info("scaling down stateful set", "have", crdbScale, "want", oneOff)
 
 		// TODO (chrisseto): If decommissioning fails due to a timeout
 		// recommission that node before failing this job.
@@ -128,7 +129,7 @@ func (s *Scaler) EnsureScale(ctx context.Context, scale uint) error {
 	// with cascade = false and recreating them. They will "adopt" the old/existing pods and in theory not
 	// have an affect on the cluster as a whole.
 	for crdbScale < scale {
-		s.Logger.Info("scaling up stateful set", "have", crdbScale, "want", (crdbScale + 1))
+		s.Logger.V(int(zapcore.DebugLevel)).Info("scaling up stateful set", "have", crdbScale, "want", (crdbScale + 1))
 		if err := s.CRDB.SetReplicas(ctx, crdbScale+1); err != nil {
 			return err
 		}

--- a/pkg/update/BUILD.bazel
+++ b/pkg/update/BUILD.bazel
@@ -24,6 +24,7 @@ go_library(
         "@io_k8s_apimachinery//pkg/api/errors:go_default_library",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
         "@io_k8s_client_go//kubernetes:go_default_library",
+        "@org_uber_go_zap//zapcore:go_default_library",
     ],
 )
 


### PR DESCRIPTION
## Synopsis

This PR implement does two things.  First, we are now able to set the log level on the command line.  The operator now accepts the zap logging flags, and you can set the level to say "debug".  The operator framework uses the zap logging library and the best manner to implement logging, which I found was to use the zap library.  We will set the operator to "warn", but the zap library defaults to debug.

The second change is a general audit of which logging level is used for which logging statement.  Several changes were made to include "debug", "info", "warn", and other logs. 

Fixes: https://github.com/cockroachdb/cockroach-operator/issues/304

## TODO

- [ ] PR review - I need someone who is familiar with how the logs worked in the past.
- [ ] Update operator.yaml for production mode - this file is incorrect currently
- [ ] Backout BUILD.bazel changes - this file needs merging (working around an existing issue we have)
- [ ] Run e2e tests by hand

## Next steps

We need information on how to configure logging via the command line included in the documentation - @johnrk 

## Future improvements

I may have missed a couple of logging statements.  I have done a search, but as we improve the operator we need to ensure that it is logging properly.  We need to determine if we are going to use the zap library in its native implementation.  We are using the logr interface backed by zap, and using zap directly gives you more capability.  This should be backlogged and is a medium-level priority.  - @johnrk 