### PR TITLE
Using shellscript entrypoint

### DIFF
--- a/pkg/resource/job.go
+++ b/pkg/resource/job.go
@@ -32,7 +32,7 @@ import (
 const (
 	// JobContainerName used on spec for teh container
 	JobContainerName     = "crdb"
-	GetTagVersionCommand = "/cockroach/cockroach version | grep 'Build Tag:'| awk '{print $3}'"
+	GetTagVersionCommand = "/cockroach/cockroach.sh version | grep 'Build Tag:'| awk '{print $3}'"
 )
 
 type JobBuilder struct {

--- a/pkg/resource/statefulset.go
+++ b/pkg/resource/statefulset.go
@@ -201,7 +201,7 @@ func (b StatefulSetBuilder) MakeContainers() []corev1.Container {
 			Image:           image,
 			ImagePullPolicy: *b.Spec().Image.PullPolicyName,
 			Resources:       b.Spec().Resources,
-			Command:         []string{"/cockroach/cockroach"},
+			Command:         []string{"/cockroach/cockroach.sh"},
 			Args:            b.dbArgs(),
 			Env: []corev1.EnvVar{
 				{


### PR DESCRIPTION
In order to not have the crdb run as PID 0 we are using the
shell script now.