### PR TITLE
Fixing crdb binary in OSX

### DIFF
--- a/hack/bin/deps.bzl
+++ b/hack/bin/deps.bzl
@@ -350,7 +350,7 @@ def install_crdb():
 filegroup(
     name = "file",
     srcs = [
-        "cockroach-v20.2.5.darwin-amd64/cockroach",
+        "cockroach-v20.2.5.darwin-10.9-amd64/cockroach",
     ],
     visibility = ["//visibility:public"],
 )
@@ -366,6 +366,7 @@ filegroup(
     name = "file",
     srcs = [
         "cockroach-v20.2.5.linux-amd64/cockroach",
+cockroach-v20.2.5.darwin-10.9-amd64
     ],
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
I missed a path with downloading the crdb binary when running
OSX.  We should probably not have the rule the way it is, but it
is fine for now.