### PR TITLE
Getting GKE E2E running and Bazel updates

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -5,4 +5,4 @@ test --test_output=errors
 
 # helpful for dev
 # test --test_output=streamed
-# test --test_arg=-test.v
+test --test_arg=-test.v

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -15,7 +15,7 @@ load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
 
 protobuf_deps()
 
-## Load rules_go and dependencies
+## Load rules_go and dependencies
 http_archive(
     name = "io_bazel_rules_go",
     sha256 = "a8d6b1b354d371a646d2f7927319974e0f9e52f73a2452d2b3877118169eb6bb",
@@ -35,7 +35,7 @@ go_register_toolchains(
     # nogo = "@//hack/build:nogo_vet",
 )
 
-## Load gazelle and dependencies
+## Load gazelle and dependencies
 http_archive(
     name = "bazel_gazelle",
     url = "https://github.com/bazelbuild/bazel-gazelle/releases/download/v0.19.1/bazel-gazelle-v0.19.1.tar.gz",
@@ -43,8 +43,6 @@ http_archive(
 )
 
 load("@bazel_gazelle//:deps.bzl", "gazelle_dependencies")
-
-gazelle_dependencies()
 
 ## Load kubernetes repo-infra for tools like kazel
 http_archive(
@@ -59,9 +57,9 @@ http_archive(
 ## Load rules_docker and dependencies, for working with docker images
 http_archive(
     name = "io_bazel_rules_docker",
-    sha256 = "4521794f0fba2e20f3bf15846ab5e01d5332e587e9ce81629c7f96c793bb7036",
-    strip_prefix = "rules_docker-0.14.4",
-    urls = ["https://github.com/bazelbuild/rules_docker/releases/download/v0.14.4/rules_docker-v0.14.4.tar.gz"],
+    sha256 = "95d39fd84ff4474babaf190450ee034d958202043e366b9fc38f438c9e6c3334",
+    strip_prefix = "rules_docker-0.16.0",
+    urls = ["https://github.com/bazelbuild/rules_docker/releases/download/v0.16.0/rules_docker-v0.16.0.tar.gz"],
 )
 
 load(
@@ -74,10 +72,6 @@ container_repositories()
 load("@io_bazel_rules_docker//repositories:deps.bzl", container_deps = "deps")
 
 container_deps()
-
-load("@io_bazel_rules_docker//repositories:pip_repositories.bzl", "pip_deps")
-
-pip_deps()
 
 load("@io_bazel_rules_docker//container:container.bzl", "container_pull")
 load("@io_bazel_rules_docker//go:image.bzl", _go_image_repos = "repositories")
@@ -104,12 +98,12 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 # This requires rules_docker to be fully instantiated before
 # it is pulled in.
-# Download the rules_k8s repository at release v0.4
+# Download the rules_k8s repository at release v0.5
 http_archive(
     name = "io_bazel_rules_k8s",
-    sha256 = "d91aeb17bbc619e649f8d32b65d9a8327e5404f451be196990e13f5b7e2d17bb",
-    strip_prefix = "rules_k8s-0.4",
-    urls = ["https://github.com/bazelbuild/rules_k8s/releases/download/v0.4/rules_k8s-v0.4.tar.gz"],
+    strip_prefix = "rules_k8s-0.5",
+    sha256 = "773aa45f2421a66c8aa651b8cecb8ea51db91799a405bd7b913d77052ac7261a",
+    urls = ["https://github.com/bazelbuild/rules_k8s/archive/v0.5.tar.gz"],
 )
 
 load("@io_bazel_rules_k8s//k8s:k8s.bzl", "k8s_repositories")

--- a/e2e/BUILD.bazel
+++ b/e2e/BUILD.bazel
@@ -47,7 +47,6 @@ go_test(
         "//pkg/controller:go_default_library",
         "//pkg/testutil:go_default_library",
         "//pkg/testutil/env:go_default_library",
-        "//pkg/testutil/exec:go_default_library",
         "//pkg/testutil/paths:go_default_library",
         "@com_github_go_logr_zapr//:go_default_library",
         "@com_github_stretchr_testify//require:go_default_library",

--- a/e2e/assert.go
+++ b/e2e/assert.go
@@ -375,7 +375,7 @@ func requirePVCToResize(t *testing.T, sb testenv.DiffingSandbox, b testutil.Clus
 	cluster := b.Cluster()
 
 	// TODO rewrite this
-	err := wait.Poll(10*time.Second, 300*time.Second, func() (bool, error) {
+	err := wait.Poll(10*time.Second, 500*time.Second, func() (bool, error) {
 		ss, err := fetchStatefulSet(sb, cluster.StatefulSetName())
 		if err != nil {
 			return false, err

--- a/hack/BUILD.bazel
+++ b/hack/BUILD.bazel
@@ -262,6 +262,7 @@ filegroup(
         "//hack/bin:all-srcs",
         "//hack/boilerplate:all-srcs",
         "//hack/build:all-srcs",
+        "//hack/gke:all-srcs",
     ],
     tags = ["automanaged"],
     visibility = ["//visibility:public"],

--- a/hack/bin/BUILD.bazel
+++ b/hack/bin/BUILD.bazel
@@ -134,6 +134,18 @@ genrule(
     visibility = ["//visibility:public"],
 )
 
+# fetch_kubetest2_gke rules to fetch the binary for kubetest2_kind used on e2e tests that are saved on a google cloud bucket
+genrule(
+    name = "fetch_kubetest2_gke",
+    srcs = select({
+        ":darwin": ["@kubetest2_gke_darwin//file"],
+        ":k8": ["@kubetest2_gke_linux//file"],
+    }),
+    outs = ["kubetest2-gke"],
+    cmd = "cp $(SRCS) $@",
+    visibility = ["//visibility:public"],
+)
+
 genrule(
     name = "fetch_controller-gen",
     srcs = ["@io_k8s_sigs_controller_tools//cmd/controller-gen"],

--- a/hack/bin/deps.bzl
+++ b/hack/bin/deps.bzl
@@ -27,6 +27,7 @@ def install():
     install_kind()
     install_kubetest2()
     install_kubetest2_kind()
+    install_kubetest2_gke()
     install_operator_sdk()
     install_kustomize()
     install_opm()
@@ -261,14 +262,14 @@ def install_kubetest2():
     http_file(
        name = "kubetest2_darwin",
        executable = 1,
-       sha256 = "54b7f35575467b6bea173117f693959635c297ec89fc8011a964da8702cde50f",
-       urls = ["https://storage.googleapis.com/crdb-bazel-artifacts/macos/kubetest2"],
+       sha256 = "5b20aadd05eca47dead180a7c8296d75e81c184aabf182d4a41ef96597db543d",
+       urls = ["https://storage.googleapis.com/crdb-bazel-artifacts/osx/kubetest2"],
     )
 
     http_file(
         name = "kubetest2_linux",
         executable = 1,
-        sha256 = "c9c386dd46f3d26f91fc095b9970f57c34e2c54e443958bc097b3ec711e80b58",
+        sha256 = "7f0b05654fa43ca1c607db297b5f3a775f65eea90355bb6b10137a7fffff5e1a",
         urls = ["https://storage.googleapis.com/crdb-bazel-artifacts/linux/kubetest2"],
     )
 
@@ -279,15 +280,33 @@ def install_kubetest2_kind():
     http_file(
        name = "kubetest2_kind_darwin",
        executable = 1,
-       sha256 = "d89aa58feaaafcec82f9b5ffb92954dce157d8eb6dea6015fd3da85449840d7c",
-       urls = ["https://storage.googleapis.com/crdb-bazel-artifacts/macos/kubetest2-kind"],
+       sha256 = "a68bad1b94fd5e432f0555d699d0ce0470d0bf16f1b087e857d55f16f5373385",
+       urls = ["https://storage.googleapis.com/crdb-bazel-artifacts/osx/kubetest2-kind"],
     )
 
     http_file(
         name = "kubetest2_kind_linux",
         executable = 1,
-        sha256 = "e1b7ce0eec0c3db97b4fce3659e25f6190188c9c53f81ae3d090da47265a7599",
+        sha256 = "b13014d3e1464ce58e2bbbec94bead267936155d537f3232ec0a24727263a2a1",
         urls = ["https://storage.googleapis.com/crdb-bazel-artifacts/linux/kubetest2-kind"],
+    )
+
+## Fetch kubetest2-gke binary used during e2e tests
+def install_kubetest2_gke():
+    # install kubetest2-gke binary
+    # TODO osx support
+    http_file(
+       name = "kubetest2_gke_darwin",
+       executable = 1,
+       sha256 = "a1cbe02f61931dbe6c8d1662442f42cb538c81e4ec8cdd40f548f0e05cbd55a7",
+       urls = ["https://storage.googleapis.com/crdb-bazel-artifacts/osx/kubetest2-gke"],
+    )
+
+    http_file(
+        name = "kubetest2_gke_linux",
+        executable = 1,
+        sha256 = "9ac658234efc7f59968888662dd2d21908587789f6b812392ac5b6766b17c0b4",
+        urls = ["https://storage.googleapis.com/crdb-bazel-artifacts/linux/kubetest2-gke"],
     )
 
 ## Fetch operator-sdk used on generating csv

--- a/hack/gke/BUILD.bazel
+++ b/hack/gke/BUILD.bazel
@@ -1,0 +1,37 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["start_stop_gke.go"],
+    importpath = "github.com/cockroachdb/cockroach-operator/hack/gke",
+    visibility = ["//visibility:private"],
+    deps = ["//pkg/testutil/exec:go_default_library"],
+)
+
+KUBETEST2 = "//hack/bin:kubetest2"
+
+KUBETEST2GKE = "//hack/bin:kubetest2-gke"
+
+go_binary(
+    name = "gke",
+    data = [
+        KUBETEST2,
+        KUBETEST2GKE,
+    ],
+    embed = [":go_default_library"],
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/hack/gke/start_stop_gke.go
+++ b/hack/gke/start_stop_gke.go
@@ -1,0 +1,76 @@
+/*
+Copyright 2021 The Cockroach Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"flag"
+	"os"
+
+	"github.com/cockroachdb/cockroach-operator/pkg/testutil/exec"
+)
+
+// This binary is used to start and stop gke on the command line
+// There is a bazezl target that allows you to do this
+// See the Makefile for example
+
+func main() {
+
+	runFiles := os.Getenv("BUILD_WORKSPACE_DIRECTORY")
+	if runFiles == "" {
+		panic("unable to read BUILD_WORKSPACE_DIRECTORY environment variable")
+	}
+
+	action := flag.String("action", "", "start,stop or kubeconfig")
+	name := flag.String("cluster-name", "", "name of the cluster")
+	zone := flag.String("gcp-zone", "", "gcp zone")
+	project := flag.String("gcp-project", "", "gcp project")
+	flag.Parse()
+
+	if *name == "" {
+		panic("set cluster-name arg")
+	}
+	if *zone == "" {
+		panic("set gcp-zone arg")
+	}
+	if *project == "" {
+		panic("set gcp-project arg")
+	}
+
+	p := "hack/bin" + ":" + os.Getenv("PATH")
+	os.Setenv("PATH", p)
+
+	switch {
+	case *action == "start":
+		err := exec.StartGKEKubeTest2(*name, *zone, *project)
+		if err != nil {
+			panic(err)
+		}
+	case *action == "stop":
+		err := exec.StopGKEKubeTest2(*name, *zone, *project)
+		if err != nil {
+			panic(err)
+		}
+	case *action == "kubeconfig":
+		err := exec.GetGKEKubeConfig(*name, *zone, *project)
+		if err != nil {
+			panic(err)
+		}
+	default:
+		panic("wrong action parameter")
+	}
+
+}

--- a/manifests/BUILD.bazel
+++ b/manifests/BUILD.bazel
@@ -4,11 +4,20 @@ load("@io_bazel_rules_k8s//k8s:objects.bzl", "k8s_objects")
 k8s_deploy(
     name = "operator",
     images = {
-        # TODO how do we do this?
-        # "{STABLE_DOCKER_REGISTRY}/{STABLE_IMAGE_REPOSITORY}:{STABLE_DOCKER_TAG}": "//cmd/cockroach-operator:operator_image",
-        "cockroachdb/cockroach-operator:v1.6.12-rc.2": "//cmd/cockroach-operator:operator_image",
+        # todo use STAMP variable here instead of the gen_rule below
+        "cockroach-operator:latest": "//cmd/cockroach-operator:operator_image",
     },
-    template = ":operator.yaml",
+    template = ":operator_image",
+)
+
+# rewrite the image: YAML stanza with cockroach-operator
+# if we can figure out how to use STAMP variables we can remove this
+genrule(
+    name = "operator_image",
+    srcs = [":operator.yaml"],
+    outs = [":operator-image.yaml"],
+    cmd = "$(location substitute.sh) $< $@",
+    tools = [":substitute.sh"],
 )
 
 k8s_objects(

--- a/manifests/substitute.sh
+++ b/manifests/substitute.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+# Copyright 2021 The Cockroach Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This script is used to replace the image: YAML stanza so that
+# Bazel can match it and deploy using rules_k8s.
+# As I am not able to figure out how to get build stamps working in it
+
+sed "s/image: .*/image: cockroach-operator:latest/" $1 > $2

--- a/pkg/testutil/exec/BUILD.bazel
+++ b/pkg/testutil/exec/BUILD.bazel
@@ -5,7 +5,9 @@ go_library(
     srcs = ["exec.go"],
     importpath = "github.com/cockroachdb/cockroach-operator/pkg/testutil/exec",
     visibility = ["//visibility:public"],
-    deps = ["@io_k8s_sigs_kubetest2//pkg/process:go_default_library"],
+    deps = [
+        "@io_k8s_sigs_kubetest2//pkg/process:go_default_library",
+    ],
 )
 
 filegroup(

--- a/pkg/testutil/exec/exec.go
+++ b/pkg/testutil/exec/exec.go
@@ -48,7 +48,7 @@ func StopKubeTest2(clusterName string) error {
 // StartKubeTest2 starts a kind server.
 func StartKubeTest2(clusterName string) error {
 	args := []string{
-		"kind", "--up", "--cluster-name", clusterName, "--verbosity", "10",
+		"kind", "--up", "--cluster-name", clusterName, "-v", "10",
 	}
 
 	println("Up(): startin kind cluster...\n")


### PR DESCRIPTION
- updated docker bazel rules
- updated k8s bazel rules
- added a script to edit the manifest on the fly so that bazel works
- improving the capability to run GKE
- added make targets
- tested on GKE
- modified e2e testing to not start a cluster automatically
- modified e2e testing to accept a parameter for testing pvc resizing
- updated the kubetest2 builds in gcp

Once we have this in we will need to have the infra team have gcloud and the correct GCP permissions on the teamcity server in order to use this functionality on a nightly build.

TODO
- [x] update osx kubetest2 binaries