### PR TITLE
Fixing K8S Cluster Stamping

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -60,14 +60,14 @@ the next section.
 
 Install the operator
 
-```
-git clone https://github.com/cockroachdb/cockroach-operator.git
-export CLUSTER=test
+```console
+$ git clone https://github.com/cockroachdb/cockroach-operator.git
+$ export CLUSTER=test
 # create a gke cluster
-./hack/create-gke-cluster.sh -c $CLUSTER
+$ ./hack/create-gke-cluster.sh -c $CLUSTER
 
-export IMAGE_REGISTRY=us.gcr.io/$(gcloud config get-value project)
-export K8S_CLUSTER=$(kubectl config view --minify -o=jsonpath='{.contexts[0].context.cluster}')
+$ DEV_REGISTRY=us.gcr.io/$(gcloud config get-value project) \
+K8S_CLUSTER=$(kubectl config view --minify -o=jsonpath='{.contexts[0].context.cluster}') \
 bazel run --stamp --platforms=@io_bazel_rules_go//go/toolchain:linux_amd64 \
                  //manifests:install_operator.apply
 ```

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -118,6 +118,9 @@ load("@io_bazel_rules_k8s//k8s:k8s.bzl", "k8s_defaults")
 
 # Setting up the defaults for rules k8s.  The varible values
 # are replaced by hack/build/print-workspace-status.sh
+# Using environment variables that are prefixed with the word
+# 'STAMP_' causes the rules_k8s files to rebuild when the
+# --stamp and evn values change.
 k8s_defaults(
     # This becomes the name of the @repository and the rule
     # you will import in your BUILD files.

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -126,7 +126,7 @@ k8s_defaults(
     # This is the name of the cluster as it appears in:
     #   kubectl config view --minify -o=jsonpath='{.contexts[0].context.cluster}'
     # You are able to override the default cluster by setting the env variable K8S_CLUSTER
-    cluster = "{CLUSTER}",
+    cluster = "{STABLE_CLUSTER}",
     # You are able to override the default registry by setting the env variable IMAGE_REGISTRY
-    image_chroot = "{IMAGE_REGISTRY}",
+    image_chroot = "{STABLE_IMAGE_REGISTRY}",
 )

--- a/hack/build/print-workspace-status.sh
+++ b/hack/build/print-workspace-status.sh
@@ -50,9 +50,9 @@ RH_DEPLOY_PATH ${RH_DEPLOY_PATH:-deploy/certified-metadata-bundle/cockroach-oper
 RH_BUNDLE_VERSION ${RH_BUNDLE_VERSION:-""}
 RH_BUNDLE_IMAGE_TAG ${RH_BUNDLE_IMAGE_TAG:-${RH_BUNDLE_VERSION:-""}}
   
-IMAGE_REGISTRY ${DEV_REGISTRY:-us.gcr.io/chris-love-operator-playground}
+STABLE_IMAGE_REGISTRY ${DEV_REGISTRY:-us.gcr.io/chris-love-operator-playground}
 
-CLUSTER ${K8S_CLUSTER:-gke_chris-love-operator-playground_us-central1-a_test}
+STABLE_CLUSTER ${K8S_CLUSTER:-gke_chris-love-operator-playground_us-central1-a_test}
 NUMBER_COMMITS_ON_BRANCH $(git rev-list $(git rev-parse --abbrev-ref HEAD) | wc -l)
 
 gitCommit ${KUBE_GIT_COMMIT-}


### PR DESCRIPTION
This PR addresses the updating of --stamp variables
via moving the stamp variables to "STABLE" values.
Moving the values to "STABLE" seems to force the updating
of rules_k8s files better.

Secondly, since this is working I fixed applying the GKE manifest
during the e2e cluster.

Lastly I added setting a missing environment variable to the apply
commands when running rules_k8s bazel commands.