### PR TITLE
Added test.sh script for Developer Install Instructions in Developer.md

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -1,5 +1,5 @@
-# This script is for installing the Operator in development
-# Bazel has go rules that require root access because of Big Sur (Mac OS).
+# This script installs the Operator in development.
+# Bazel has go rules that require root access because of Big Sur (macOS).
 # When running with sudo/root access, it opens a new shell, so the environment variables are not used with the existing Developer Install Instructions (https://github.com/cockroachdb/cockroach-operator/blob/master/DEVELOPER.md#developer-install-instructions).
 # This script injects the required environment variables to allow the "make k8s/apply" command to succeed.
 sudo \

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,10 @@
+# This script is for installing the Operator in development
+# Bazel has go rules that require root access because of Big Sur (Mac OS).
+# When running with sudo/root access, it opens a new shell, so the environment variables are not used with the existing Developer Install Instructions (https://github.com/cockroachdb/cockroach-operator/blob/master/DEVELOPER.md#developer-install-instructions).
+# This script injects the required environment variables to allow the "make k8s/apply" command to succeed.
+sudo \
+CLUSTER_NAME=john-test \
+GCP_ZONE=us-east1-c \
+DEV_REGISTRY=us.gcr.io/cockroach-john-277713 \
+GCP_PROJECT=cockroach-john-277713 \
+make k8s/apply


### PR DESCRIPTION
To address this issue (Unable to Install Operator Using the Developer Install Instructions
#373), @chrislovecnm and I created this test.sh script to allow one to successfully install the latest Operator in development.