### PR TITLE
Removing Bazel 3

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        bazel: ["4.0.0", "3.7.2"]
+        bazel: ["4.0.0"]
     steps:
       - uses: actions/checkout@v2
 
@@ -47,7 +47,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        bazel: ["4.0.0", "3.7.2"]
+        bazel: ["4.0.0"]
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Bazel 4.0.0 is working just fine, no need to have both bazel 3
and bazel 4 run with e2e.