### PR TITLE
Specify ":ubi_update" as a layer

### DIFF
--- a/cmd/cockroach-operator/BUILD.bazel
+++ b/cmd/cockroach-operator/BUILD.bazel
@@ -59,6 +59,8 @@ container_image(
     stamp = True,
     tars = [
         ":licenses",
+    ],
+    layers = [
         ":ubi_update",
     ],
 )


### PR DESCRIPTION
After the v1.7.0 was submitted to RedHat Connect, the image failed the
`free_of_important_vulnerabilities`.

According to the
[container_run_and_commit_layer](https://github.com/bazelbuild/rules_docker/blob/8c3a8110a0c519929a7e79c39ac345a0f8c74d04/docker/util/README.md#container_run_and_commit_layer)
documentation, the output should be used in the `layers` attribute.