### PR TITLE
Clean up bazel cache for release builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -183,6 +183,7 @@ release/versionbump:
 
 .PHONY: release/image
 release/image:
+	bazel clean --expunge
 	DOCKER_REGISTRY=$(DOCKER_REGISTRY) \
 	DOCKER_IMAGE_REPOSITORY=$(DOCKER_IMAGE_REPOSITORY) \
 	APP_VERSION=$(APP_VERSION) \


### PR DESCRIPTION
When the `release/image` target is run multiple times, it doesn't
refresh the base RedHat UBI image. As a result we may end up with an
image without security updates.

This change ensures that we run `bazel clean --expunge` for the release
target.