### PR TITLE
Capability to set environment variables and telemetry

### DIFF
--- a/apis/v1alpha1/cluster_types.go
+++ b/apis/v1alpha1/cluster_types.go
@@ -97,6 +97,10 @@ type CrdbClusterSpec struct {
 	// Default: ""
 	// +optional
 	CockroachDBVersion string `json:"cockroachDBVersion,omitempty"`
+	// (Optional) PodEnvVariables is a slice of Environment Variables that are added to the pods
+	// Default: ""
+	// +optional
+	PodEnvVariables []corev1.EnvVar `json:"podEnvVariables,omitempty"`
 }
 
 // +k8s:openapi-gen=true

--- a/apis/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/v1alpha1/zz_generated.deepcopy.go
@@ -156,6 +156,13 @@ func (in *CrdbClusterSpec) DeepCopyInto(out *CrdbClusterSpec) {
 	}
 	in.Resources.DeepCopyInto(&out.Resources)
 	in.DataStore.DeepCopyInto(&out.DataStore)
+	if in.PodEnvVariables != nil {
+		in, out := &in.PodEnvVariables, &out.PodEnvVariables
+		*out = make([]v1.EnvVar, len(*in))
+		for i := range *in {
+			(*in)[i].DeepCopyInto(&(*out)[i])
+		}
+	}
 	return
 }
 

--- a/config/crd/bases/crdb.cockroachlabs.com_crdbclusters.yaml
+++ b/config/crd/bases/crdb.cockroachlabs.com_crdbclusters.yaml
@@ -224,6 +224,86 @@ spec:
                 description: Number of nodes (pods) in the cluster
                 format: int32
                 type: integer
+              podEnvVariables:
+                description: '(Optional) PodEnvVariables is a slice of Environment Variables that are added to the pods Default: ""'
+                items:
+                  description: EnvVar represents an environment variable present in a Container.
+                  properties:
+                    name:
+                      description: Name of the environment variable. Must be a C_IDENTIFIER.
+                      type: string
+                    value:
+                      description: 'Variable references $(VAR_NAME) are expanded using the previous defined environment variables in the container and any service environment variables. If a variable cannot be resolved, the reference in the input string will be unchanged. The $(VAR_NAME) syntax can be escaped with a double $$, ie: $$(VAR_NAME). Escaped references will never be expanded, regardless of whether the variable exists or not. Defaults to "".'
+                      type: string
+                    valueFrom:
+                      description: Source for the environment variable's value. Cannot be used if value is not empty.
+                      properties:
+                        configMapKeyRef:
+                          description: Selects a key of a ConfigMap.
+                          properties:
+                            key:
+                              description: The key to select.
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                            optional:
+                              description: Specify whether the ConfigMap or its key must be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                        fieldRef:
+                          description: 'Selects a field of the pod: supports metadata.name, metadata.namespace, `metadata.labels[''<KEY>'']`, `metadata.annotations[''<KEY>'']`, spec.nodeName, spec.serviceAccountName, status.hostIP, status.podIP, status.podIPs.'
+                          properties:
+                            apiVersion:
+                              description: Version of the schema the FieldPath is written in terms of, defaults to "v1".
+                              type: string
+                            fieldPath:
+                              description: Path of the field to select in the specified API version.
+                              type: string
+                          required:
+                          - fieldPath
+                          type: object
+                        resourceFieldRef:
+                          description: 'Selects a resource of the container: only resources limits and requests (limits.cpu, limits.memory, limits.ephemeral-storage, requests.cpu, requests.memory and requests.ephemeral-storage) are currently supported.'
+                          properties:
+                            containerName:
+                              description: 'Container name: required for volumes, optional for env vars'
+                              type: string
+                            divisor:
+                              anyOf:
+                              - type: integer
+                              - type: string
+                              description: Specifies the output format of the exposed resources, defaults to "1"
+                              pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                              x-kubernetes-int-or-string: true
+                            resource:
+                              description: 'Required: resource to select'
+                              type: string
+                          required:
+                          - resource
+                          type: object
+                        secretKeyRef:
+                          description: Selects a key of a secret in the pod's namespace
+                          properties:
+                            key:
+                              description: The key of the secret to select from.  Must be a valid secret key.
+                              type: string
+                            name:
+                              description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names TODO: Add other useful fields. apiVersion, kind, uid?'
+                              type: string
+                            optional:
+                              description: Specify whether the Secret or its key must be defined
+                              type: boolean
+                          required:
+                          - key
+                          type: object
+                      type: object
+                  required:
+                  - name
+                  type: object
+                type: array
               resources:
                 description: '(Optional) Database container resource limits. Any container limits can be specified. Default: (not specified)'
                 properties:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -105,6 +105,12 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - nodes
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
   - pods
   verbs:
   - get

--- a/manifests/operator.yaml
+++ b/manifests/operator.yaml
@@ -138,6 +138,12 @@ rules:
   - apiGroups:
       - ""
     resources:
+      - nodes
+    verbs:
+      - "get"
+  - apiGroups:
+      - ""
+    resources:
       - configmaps/status
     verbs:
       - "*"

--- a/pkg/actor/BUILD.bazel
+++ b/pkg/actor/BUILD.bazel
@@ -66,6 +66,7 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//apis/v1alpha1:go_default_library",
+        "//pkg/kube:go_default_library",
         "//pkg/testutil:go_default_library",
         "@com_github_go_logr_zapr//:go_default_library",
         "@com_github_pkg_errors//:go_default_library",

--- a/pkg/actor/actor.go
+++ b/pkg/actor/actor.go
@@ -21,6 +21,7 @@ import (
 
 	api "github.com/cockroachdb/cockroach-operator/apis/v1alpha1"
 	"github.com/cockroachdb/cockroach-operator/pkg/features"
+	"github.com/cockroachdb/cockroach-operator/pkg/kube"
 	"github.com/cockroachdb/cockroach-operator/pkg/resource"
 	"github.com/cockroachdb/cockroach-operator/pkg/utilfeature"
 	"github.com/go-logr/logr"
@@ -99,6 +100,8 @@ func NewOperatorActions(scheme *runtime.Scheme, cl client.Client, config *rest.C
 		certs = newRequestCert(scheme, cl, config)
 	}
 
+	kd := kube.NewKubernetesDistribution()
+
 	// The order of these actors MATTERS.
 	// We need to have update before deploy so that
 	// updates run before the deploy actor, or
@@ -113,11 +116,10 @@ func NewOperatorActions(scheme *runtime.Scheme, cl client.Client, config *rest.C
 		decommission,
 		update,
 		newResizePVC(scheme, cl, config),
-		newDeploy(scheme, cl),
+		newDeploy(scheme, cl, config, kd),
 		newInitialize(scheme, cl, config),
 		newClusterRestart(scheme, cl, config),
 	}
-
 }
 
 //Log var

--- a/pkg/actor/deploy.go
+++ b/pkg/actor/deploy.go
@@ -23,17 +23,20 @@ import (
 	"github.com/cockroachdb/cockroach-operator/pkg/condition"
 	"github.com/cockroachdb/cockroach-operator/pkg/features"
 	"github.com/cockroachdb/cockroach-operator/pkg/kube"
+	"github.com/cockroachdb/cockroach-operator/pkg/logging"
 	"github.com/cockroachdb/cockroach-operator/pkg/resource"
 	"github.com/cockroachdb/cockroach-operator/pkg/utilfeature"
 	"github.com/pkg/errors"
-	"go.uber.org/zap/zapcore"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func newDeploy(scheme *runtime.Scheme, cl client.Client) Actor {
+func newDeploy(scheme *runtime.Scheme, cl client.Client, config *rest.Config, kd kube.KubernetesDistribution) Actor {
 	return &deploy{
 		action: newAction("deploy", scheme, cl),
+		config: config,
+		kd:     kd,
 	}
 }
 
@@ -41,6 +44,9 @@ func newDeploy(scheme *runtime.Scheme, cl client.Client) Actor {
 // services, a statefulset and a pod disruption budget
 type deploy struct {
 	action
+	config *rest.Config
+
+	kd kube.KubernetesDistribution
 }
 
 // GetActionType returns the  api.DeployAction value used to set the cluster status errors
@@ -56,12 +62,18 @@ func (d deploy) Handles(conds []api.ClusterCondition) bool {
 }
 
 func (d deploy) Act(ctx context.Context, cluster *resource.Cluster) error {
-	log := d.log.WithValues("CrdbCluster", cluster.ObjectKey())
-	log.V(int(zapcore.DebugLevel)).Info("reconciling resources on deploy action")
+	log := logging.NewLogging(d.log.WithValues("CrdbCluster", cluster.ObjectKey()))
+	log.Debug("reconciling resources on deploy action")
 
 	r := resource.NewManagedKubeResource(ctx, d.client, cluster, kube.AnnotatingPersister)
 
 	owner := cluster.Unwrap()
+	kubernetesDistro, err := d.kd.Get(ctx, d.config, log)
+	if err != nil {
+		return errors.Wrap(err, "failed to get Kubernetes distribution")
+	}
+
+	kubernetesDistro = "kubernetes-operator-" + kubernetesDistro
 
 	changed, err := (resource.Reconciler{
 		ManagedResource: r,
@@ -77,7 +89,7 @@ func (d deploy) Act(ctx context.Context, cluster *resource.Cluster) error {
 	}
 
 	if changed {
-		log.V(int(zapcore.DebugLevel)).Info("created/updated discovery service, stopping request processing")
+		log.Info("created/updated discovery service, stopping request processing")
 		CancelLoop(ctx)
 		return nil
 	}
@@ -96,15 +108,17 @@ func (d deploy) Act(ctx context.Context, cluster *resource.Cluster) error {
 	}
 
 	if changed {
-		log.V(int(zapcore.DebugLevel)).Info("created/updated public service, stopping request processing")
+		log.Info("created/updated public service, stopping request processing")
 		CancelLoop(ctx)
 		return nil
 	}
+
 	changed, err = (resource.Reconciler{
 		ManagedResource: r,
 		Builder: resource.StatefulSetBuilder{
-			Cluster:  cluster,
-			Selector: r.Labels.Selector(),
+			Cluster:   cluster,
+			Selector:  r.Labels.Selector(),
+			Telemetry: kubernetesDistro,
 		},
 		Owner:  owner,
 		Scheme: d.scheme,
@@ -114,7 +128,7 @@ func (d deploy) Act(ctx context.Context, cluster *resource.Cluster) error {
 	}
 
 	if changed {
-		log.V(int(zapcore.DebugLevel)).Info("created/updated statefulset, stopping request processing")
+		log.Info("created/updated statefulset, stopping request processing")
 		CancelLoop(ctx)
 		return nil
 	}
@@ -136,12 +150,12 @@ func (d deploy) Act(ctx context.Context, cluster *resource.Cluster) error {
 		}
 
 		if changed {
-			log.V(int(zapcore.DebugLevel)).Info("created/updated pdb, stopping request processing")
+			log.Info("created/updated pdb, stopping request processing")
 			CancelLoop(ctx)
 			return nil
 		}
 	}
 
-	log.V(int(zapcore.DebugLevel)).Info("deployed database")
+	log.Info("deployed database")
 	return nil
 }

--- a/pkg/actor/deploy_test.go
+++ b/pkg/actor/deploy_test.go
@@ -22,6 +22,7 @@ import (
 
 	api "github.com/cockroachdb/cockroach-operator/apis/v1alpha1"
 	"github.com/cockroachdb/cockroach-operator/pkg/actor"
+	"github.com/cockroachdb/cockroach-operator/pkg/kube"
 	"github.com/cockroachdb/cockroach-operator/pkg/testutil"
 	"github.com/go-logr/zapr"
 	"github.com/pkg/errors"
@@ -74,7 +75,8 @@ func TestDeploysNotInitalizedClusterAfterVersionChecker(t *testing.T) {
 		WithNodeCount(1).Cluster()
 	cluster.SetTrue(api.CrdbVersionChecked)
 
-	deploy := actor.NewDeploy(scheme, client)
+	mock := kube.MockKubernetesDistribution()
+	deploy := actor.NewDeploy(scheme, client, nil, mock)
 	t.Log(cluster.Status().Conditions)
 	require.True(t, deploy.Handles(cluster.Status().Conditions))
 

--- a/pkg/controller/cluster_controller.go
+++ b/pkg/controller/cluster_controller.go
@@ -58,6 +58,7 @@ type ClusterReconciler struct {
 // +kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;watch;create;update;patch
 // +kubebuilder:rbac:groups=core,resources=pods/exec,verbs=create
 // +kubebuilder:rbac:groups=core,resources=pods,verbs=get
+// +kubebuilder:rbac:groups=core,resources=nodes,verbs=get
 // +kubebuilder:rbac:groups=apps,resources=statefulsets,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=apps,resources=statefulsets/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=apps,resources=statefulsets/finalizers,verbs=get;list;watch

--- a/pkg/kube/BUILD.bazel
+++ b/pkg/kube/BUILD.bazel
@@ -6,10 +6,12 @@ go_library(
         "aliases.go",
         "dialer.go",
         "helpers.go",
+        "kubernetes_distro.go",
     ],
     importpath = "github.com/cockroachdb/cockroach-operator/pkg/kube",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/logging:go_default_library",
         "@com_github_banzaicloud_k8s_objectmatcher//patch:go_default_library",
         "@com_github_pkg_errors//:go_default_library",
         "@io_k8s_api//apps/v1:go_default_library",

--- a/pkg/kube/kubernetes_distro.go
+++ b/pkg/kube/kubernetes_distro.go
@@ -1,0 +1,91 @@
+/*
+Copyright 2021 The Cockroach Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kube
+
+import (
+	"context"
+	"strings"
+
+	"github.com/cockroachdb/cockroach-operator/pkg/logging"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+)
+
+type KubernetesDistribution interface {
+	Get(ctx context.Context, config *rest.Config, log *logging.Logging) (string, error)
+}
+
+type kubernetesDistribution struct{}
+
+func NewKubernetesDistribution() KubernetesDistribution {
+	return &kubernetesDistribution{}
+}
+
+// Get the Kubernetes Distribution Type
+func (kd kubernetesDistribution) Get(ctx context.Context, config *rest.Config, log *logging.Logging) (string, error) {
+	// TODO RBAC
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return "", log.LogAndWrapError(err, "cannot create k8s client")
+	}
+
+	nodes, err := clientset.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return "", log.LogAndWrapError(err, "cannot get nodes")
+	} else if len(nodes.Items) == 0 {
+		return "", log.LogAndWrapError(err, "node length is zero")
+	}
+
+	nodeName := nodes.Items[0].Name
+
+	// Get node object
+	node, err := clientset.CoreV1().Nodes().Get(ctx, nodeName, metav1.GetOptions{})
+	if err != nil {
+		return "", log.LogAndWrapError(err, "cannot get node")
+	}
+
+	// You can read Kubernetes version from either KubeletVersion or KubeProxyVersion
+	kubeletVersion := node.Status.NodeInfo.KubeletVersion
+
+	if strings.Contains(kubeletVersion, "gke") {
+		return "gke", nil
+	} else if strings.Contains(kubeletVersion, "aks") {
+		return "aks", nil
+	} else if strings.Contains(kubeletVersion, "eks") {
+		return "eks", nil
+	} else {
+		for key := range node.Annotations {
+			if strings.Contains("openshift", key) {
+				return "openshift", nil
+			}
+		}
+	}
+
+	return "unknown", nil
+}
+
+type mockKubernetesDistribution struct{}
+
+func MockKubernetesDistribution() KubernetesDistribution {
+	return &mockKubernetesDistribution{}
+}
+
+// Get the Kubernetes Distribution Type
+func (mock mockKubernetesDistribution) Get(ctx context.Context, config *rest.Config, log *logging.Logging) (string, error) {
+	return "GKE", nil
+}

--- a/pkg/resource/statefulset_test.go
+++ b/pkg/resource/statefulset_test.go
@@ -64,8 +64,9 @@ func TestStatefulSetBuilder(t *testing.T) {
 			actual := &appsv1.StatefulSet{}
 
 			err := resource.StatefulSetBuilder{
-				Cluster:  &cluster,
-				Selector: commonLabels.Selector(),
+				Cluster:   &cluster,
+				Selector:  commonLabels.Selector(),
+				Telemetry: "kubernetes-operator-gke",
 			}.Build(actual)
 			require.NoError(t, err)
 

--- a/pkg/resource/testdata/TestStatefulSetBuilder/default_insecure_statefulset.golden
+++ b/pkg/resource/testdata/TestStatefulSetBuilder/default_insecure_statefulset.golden
@@ -40,7 +40,7 @@ spec:
         - /cockroach/cockroach.sh
         env:
         - name: COCKROACH_CHANNEL
-          value: kubernetes-operator
+          value: kubernetes-operator-gke
         - name: POD_NAME
           valueFrom:
             fieldRef:
@@ -77,6 +77,18 @@ spec:
         volumeMounts:
         - mountPath: /cockroach/cockroach-data/
           name: datadir
+      initContainers:
+      - command:
+        - /bin/sh
+        - -c
+        - '>- cp -p /cockroach/cockroach-certs-prestage/..data/* /cockroach/cockroach-certs/ && chmod 700 /cockroach/cockroach-certs/*.key && chown 10001:10001 /cockroach/cockroach-certs/*.key'
+        image: cockroachdb/cockroach:v20.2.7
+        imagePullPolicy: IfNotPresent
+        name: db-init
+        resources: {}
+        securityContext:
+          allowPrivilegeEscalation: false
+          runAsUser: 0
       securityContext:
         fsGroup: 10001
         runAsUser: 10001
@@ -86,28 +98,10 @@ spec:
       - name: datadir
         persistentVolumeClaim:
           claimName: ""
-      initContainers:
-        - command:
-          - /bin/sh
-          - -c
-          - '>- cp -p /cockroach/cockroach-certs-prestage/..data/* /cockroach/cockroach-certs/
-            && chmod 700 /cockroach/cockroach-certs/*.key && chown 10001:10001 /cockroach/cockroach-certs/*.key'
-          image: cockroachdb/cockroach:v20.2.7
-          imagePullPolicy: IfNotPresent
-          name: db-init
-          resources: {}
-          securityContext:
-            allowPrivilegeEscalation: false
-            runAsUser: 0
   updateStrategy:
     rollingUpdate: {}
-  securityContext:
-    fsGroup: 10001
-    runAsUser: 10001
   volumeClaimTemplates:
-  - apiVersion: v1
-    kind: PersistentVolumeClaim
-    metadata:
+  - metadata:
       creationTimestamp: null
       name: datadir
     spec:
@@ -117,5 +111,6 @@ spec:
         requests:
           storage: 1Gi
       volumeMode: Filesystem
+    status: {}
 status:
   replicas: 0

--- a/pkg/resource/testdata/TestStatefulSetBuilder/default_secure.golden
+++ b/pkg/resource/testdata/TestStatefulSetBuilder/default_secure.golden
@@ -40,7 +40,7 @@ spec:
         - /cockroach/cockroach.sh
         env:
         - name: COCKROACH_CHANNEL
-          value: kubernetes-operator
+          value: kubernetes-operator-gke
         - name: POD_NAME
           valueFrom:
             fieldRef:
@@ -79,6 +79,23 @@ spec:
           name: datadir
         - mountPath: /cockroach/cockroach-certs/
           name: emptydir
+      initContainers:
+      - command:
+        - /bin/sh
+        - -c
+        - '>- cp -p /cockroach/cockroach-certs-prestage/..data/* /cockroach/cockroach-certs/ && chmod 700 /cockroach/cockroach-certs/*.key && chown 10001:10001 /cockroach/cockroach-certs/*.key'
+        image: cockroachdb/cockroach:v20.2.7
+        imagePullPolicy: IfNotPresent
+        name: db-init
+        resources: {}
+        securityContext:
+          allowPrivilegeEscalation: false
+          runAsUser: 0
+        volumeMounts:
+        - mountPath: /cockroach/cockroach-certs-prestage/
+          name: certs
+        - mountPath: /cockroach/cockroach-certs/
+          name: emptydir
       securityContext:
         fsGroup: 10001
         runAsUser: 10001
@@ -115,33 +132,10 @@ spec:
                 mode: 400
                 path: client.root.key
               name: test-cluster-root
-      initContainers:
-        - command:
-          - /bin/sh
-          - -c
-          - '>- cp -p /cockroach/cockroach-certs-prestage/..data/* /cockroach/cockroach-certs/
-            && chmod 700 /cockroach/cockroach-certs/*.key && chown 10001:10001 /cockroach/cockroach-certs/*.key'
-          image: cockroachdb/cockroach:v20.2.7
-          imagePullPolicy: IfNotPresent
-          name: db-init
-          resources: {}
-          securityContext:
-            allowPrivilegeEscalation: false
-            runAsUser: 0
-          volumeMounts:
-          - mountPath: /cockroach/cockroach-certs-prestage/
-            name: certs
-          - mountPath: /cockroach/cockroach-certs/
-            name: emptydir
   updateStrategy:
     rollingUpdate: {}
-  securityContext:
-    fsGroup: 10001
-    runAsUser: 10001
   volumeClaimTemplates:
-  - apiVersion: v1
-    kind: PersistentVolumeClaim
-    metadata:
+  - metadata:
       creationTimestamp: null
       name: datadir
     spec:
@@ -151,5 +145,6 @@ spec:
         requests:
           storage: 1Gi
       volumeMode: Filesystem
+    status: {}
 status:
   replicas: 0

--- a/pkg/resource/testdata/TestStatefulSetBuilder/insecure_statefulset_cli_args.golden
+++ b/pkg/resource/testdata/TestStatefulSetBuilder/insecure_statefulset_cli_args.golden
@@ -41,7 +41,7 @@ spec:
         - /cockroach/cockroach.sh
         env:
         - name: COCKROACH_CHANNEL
-          value: kubernetes-operator
+          value: kubernetes-operator-gke
         - name: POD_NAME
           valueFrom:
             fieldRef:
@@ -78,6 +78,18 @@ spec:
         volumeMounts:
         - mountPath: /cockroach/cockroach-data/
           name: datadir
+      initContainers:
+      - command:
+        - /bin/sh
+        - -c
+        - '>- cp -p /cockroach/cockroach-certs-prestage/..data/* /cockroach/cockroach-certs/ && chmod 700 /cockroach/cockroach-certs/*.key && chown 10001:10001 /cockroach/cockroach-certs/*.key'
+        image: cockroachdb/cockroach:v20.2.7
+        imagePullPolicy: IfNotPresent
+        name: db-init
+        resources: {}
+        securityContext:
+          allowPrivilegeEscalation: false
+          runAsUser: 0
       securityContext:
         fsGroup: 10001
         runAsUser: 10001
@@ -87,29 +99,10 @@ spec:
       - name: datadir
         persistentVolumeClaim:
           claimName: ""
-        name: datadir
-      initContainers:
-        - command:
-          - /bin/sh
-          - -c
-          - '>- cp -p /cockroach/cockroach-certs-prestage/..data/* /cockroach/cockroach-certs/
-            && chmod 700 /cockroach/cockroach-certs/*.key && chown 10001:10001 /cockroach/cockroach-certs/*.key'
-          image: cockroachdb/cockroach:v20.2.7
-          imagePullPolicy: IfNotPresent
-          name: db-init
-          resources: {}
-          securityContext:
-            allowPrivilegeEscalation: false
-            runAsUser: 0
   updateStrategy:
     rollingUpdate: {}
-  securityContext:
-    fsGroup: 10001
-    runAsUser: 10001
   volumeClaimTemplates:
-  - apiVersion: v1
-    kind: PersistentVolumeClaim
-    metadata:
+  - metadata:
       creationTimestamp: null
       name: datadir
     spec:
@@ -119,5 +112,6 @@ spec:
         requests:
           storage: 1Gi
       volumeMode: Filesystem
+    status: {}
 status:
   replicas: 0

--- a/pkg/resource/testdata/TestStatefulSetBuilder/insecure_statefulset_with_resources.golden
+++ b/pkg/resource/testdata/TestStatefulSetBuilder/insecure_statefulset_with_resources.golden
@@ -40,7 +40,7 @@ spec:
         - /cockroach/cockroach.sh
         env:
         - name: COCKROACH_CHANNEL
-          value: kubernetes-operator
+          value: kubernetes-operator-gke
         - name: POD_NAME
           valueFrom:
             fieldRef:
@@ -81,6 +81,18 @@ spec:
         volumeMounts:
         - mountPath: /cockroach/cockroach-data/
           name: datadir
+      initContainers:
+      - command:
+        - /bin/sh
+        - -c
+        - '>- cp -p /cockroach/cockroach-certs-prestage/..data/* /cockroach/cockroach-certs/ && chmod 700 /cockroach/cockroach-certs/*.key && chown 10001:10001 /cockroach/cockroach-certs/*.key'
+        image: cockroachdb/cockroach:v20.2.7
+        imagePullPolicy: IfNotPresent
+        name: db-init
+        resources: {}
+        securityContext:
+          allowPrivilegeEscalation: false
+          runAsUser: 0
       securityContext:
         fsGroup: 10001
         runAsUser: 10001
@@ -90,29 +102,10 @@ spec:
       - name: datadir
         persistentVolumeClaim:
           claimName: ""
-        name: datadir
-      initContainers:
-        - command:
-          - /bin/sh
-          - -c
-          - '>- cp -p /cockroach/cockroach-certs-prestage/..data/* /cockroach/cockroach-certs/
-            && chmod 700 /cockroach/cockroach-certs/*.key && chown 10001:10001 /cockroach/cockroach-certs/*.key'
-          image: cockroachdb/cockroach:v20.2.7
-          imagePullPolicy: IfNotPresent
-          name: db-init
-          resources: {}
-          securityContext:
-            allowPrivilegeEscalation: false
-            runAsUser: 0
   updateStrategy:
     rollingUpdate: {}
-  securityContext:
-    fsGroup: 10001
-    runAsUser: 10001
   volumeClaimTemplates:
-  - apiVersion: v1
-    kind: PersistentVolumeClaim
-    metadata:
+  - metadata:
       creationTimestamp: null
       name: datadir
     spec:
@@ -122,5 +115,6 @@ spec:
         requests:
           storage: 1Gi
       volumeMode: Filesystem
+    status: {}
 status:
   replicas: 0


### PR DESCRIPTION
This PR does three things.

1. Any env prefixed with CRDB that is in the operator is now
passed into the pods.
2. Telemetry now adds the dynamic value of the k8s distro that
it is running on.
3. Adds a new CRD field that allows the user to set one of more Pod environment variables.