### PR TITLE
use cockroachdb namespace

### DIFF
--- a/manifests/operator.yaml
+++ b/manifests/operator.yaml
@@ -29,7 +29,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: cockroach-database-sa
-  namespace: default
+  namespace: cockroachdb
   annotations:
   labels:
     app: cockroach-operator
@@ -46,7 +46,7 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: cockroach-database-sa
-    namespace: default
+    namespace: cockroachdb
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
@@ -72,7 +72,7 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: cockroach-operator-sa
-    namespace: default
+    namespace: cockroachdb
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -220,7 +220,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: cockroach-operator-sa
-  namespace: default
+  namespace: cockroachdb
   annotations:
   labels:
     app: cockroach-operator
@@ -237,7 +237,7 @@ roleRef:
   name: cockroach-operator-role
 subjects:
   - name: cockroach-operator-sa
-    namespace: default
+    namespace: cockroachdb
     kind: ServiceAccount
 
 # Operator Deployment Definition:
@@ -246,7 +246,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: cockroach-operator
-  namespace: default
+  namespace: cockroachdb
   labels:
     app: cockroach-operator
 spec:


### PR DESCRIPTION
Change the Operator manifest to use `cockroachdb` instead of `default` namespace.