### PR TITLE
add secure client pod yaml

### DIFF
--- a/examples/client-secure-operator.yaml
+++ b/examples/client-secure-operator.yaml
@@ -24,7 +24,7 @@ spec:
   serviceAccountName: cockroach-operator-sa
   containers:
   - name: cockroachdb-client-secure
-    image: cockroachdb/cockroach:v20.2.8
+    image: cockroachdb/cockroach:v21.1.0
     imagePullPolicy: IfNotPresent
     volumeMounts:
     - name: client-certs

--- a/examples/client-secure-operator.yaml
+++ b/examples/client-secure-operator.yaml
@@ -1,0 +1,52 @@
+# Copyright 2021 The Cockroach Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: Pod
+metadata:
+  name: cockroachdb-client-secure
+  labels:
+    app.kubernetes.io/component: database
+    app.kubernetes.io/instance: cockroachdb
+    app.kubernetes.io/name: cockroachdb
+spec:
+  serviceAccountName: cockroach-operator-sa
+  containers:
+  - name: cockroachdb-client-secure
+    image: cockroachdb/cockroach:v20.2.8
+    imagePullPolicy: IfNotPresent
+    volumeMounts:
+    - name: client-certs
+      mountPath: /cockroach/cockroach-certs/
+    command:
+    - sleep
+    - "2147483648" # 2^31
+  terminationGracePeriodSeconds: 0
+  volumes:
+  - name: client-certs
+    projected:
+        sources:
+          - secret:
+              name: cockroachdb-node
+              items:
+                - key: ca.crt
+                  path: ca.crt
+          - secret:
+              name: cockroachdb-root
+              items:
+                - key: tls.crt
+                  path: client.root.crt
+                - key: tls.key
+                  path: client.root.key
+        defaultMode: 256


### PR DESCRIPTION
Add YAML for a secure client pod. Verified with @keith-mcclellan and tested that this works.

This will be used in documentation steps.

Relates to https://github.com/cockroachdb/docs/issues/8889