### PR TITLE
StatefulSet Changes - CR Cache, Memory, and sts pod management

### DIFF
--- a/pkg/resource/BUILD.bazel
+++ b/pkg/resource/BUILD.bazel
@@ -29,6 +29,7 @@ go_library(
         "@io_k8s_api//core/v1:go_default_library",
         "@io_k8s_api//policy/v1beta1:go_default_library",
         "@io_k8s_apimachinery//pkg/api/meta:go_default_library",
+        "@io_k8s_apimachinery//pkg/api/resource:go_default_library",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/runtime:go_default_library",
         "@io_k8s_apimachinery//pkg/types:go_default_library",

--- a/pkg/resource/testdata/TestStatefulSetBuilder/default_insecure_statefulset.golden
+++ b/pkg/resource/testdata/TestStatefulSetBuilder/default_insecure_statefulset.golden
@@ -7,7 +7,7 @@ metadata:
   creationTimestamp: null
   name: test-cluster
 spec:
-  podManagementPolicy: OrderedReady
+  podManagementPolicy: Parallel
   replicas: 1
   selector:
     matchLabels:
@@ -25,19 +25,10 @@ spec:
     spec:
       automountServiceAccountToken: false
       containers:
-      - args:
-        - start
-        - --join=test-cluster-0.test-cluster.test-ns:26258
-        - --advertise-host=$(POD_NAME).test-cluster.test-ns
-        - --logtostderr=INFO
-        - --insecure
-        - --http-port=8080
-        - --cache=25%
-        - --max-sql-memory=25%
-        - --sql-addr=:26257
-        - --listen-addr=:26258
-        command:
-        - /cockroach/cockroach.sh
+      - command:
+        - /bin/bash
+        - -ecx
+        - exec /cockroach/cockroach.sh start --join=test-cluster-0.test-cluster.test-ns:26258 --advertise-host=$(POD_NAME).test-cluster.test-ns --logtostderr=INFO --insecure --http-port=8080 --sql-addr=:26257 --listen-addr=:26258 --cache=25% --max-sql-memory=25%
         env:
         - name: COCKROACH_CHANNEL
           value: kubernetes-operator-gke
@@ -45,6 +36,16 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              divisor: "1"
+              resource: limits.cpu
+        - name: MEMORY_LIMIT_MIB
+          valueFrom:
+            resourceFieldRef:
+              divisor: 1Mi
+              resource: limits.memory
         image: cockroachdb/cockroach:v20.2.7
         imagePullPolicy: IfNotPresent
         livenessProbe:

--- a/pkg/resource/testdata/TestStatefulSetBuilder/default_secure.golden
+++ b/pkg/resource/testdata/TestStatefulSetBuilder/default_secure.golden
@@ -7,7 +7,7 @@ metadata:
   creationTimestamp: null
   name: test-cluster
 spec:
-  podManagementPolicy: OrderedReady
+  podManagementPolicy: Parallel
   replicas: 1
   selector:
     matchLabels:
@@ -25,19 +25,10 @@ spec:
     spec:
       automountServiceAccountToken: false
       containers:
-      - args:
-        - start
-        - --join=test-cluster-0.test-cluster.test-ns:26258
-        - --advertise-host=$(POD_NAME).test-cluster.test-ns
-        - --logtostderr=INFO
-        - --certs-dir=/cockroach/cockroach-certs/
-        - --http-port=8080
-        - --cache=25%
-        - --max-sql-memory=25%
-        - --sql-addr=:26257
-        - --listen-addr=:26258
-        command:
-        - /cockroach/cockroach.sh
+      - command:
+        - /bin/bash
+        - -ecx
+        - exec /cockroach/cockroach.sh start --join=test-cluster-0.test-cluster.test-ns:26258 --advertise-host=$(POD_NAME).test-cluster.test-ns --logtostderr=INFO --certs-dir=/cockroach/cockroach-certs/ --http-port=8080 --sql-addr=:26257 --listen-addr=:26258 --cache=25% --max-sql-memory=25%
         env:
         - name: COCKROACH_CHANNEL
           value: kubernetes-operator-gke
@@ -45,6 +36,16 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              divisor: "1"
+              resource: limits.cpu
+        - name: MEMORY_LIMIT_MIB
+          valueFrom:
+            resourceFieldRef:
+              divisor: 1Mi
+              resource: limits.memory
         image: cockroachdb/cockroach:v20.2.7
         imagePullPolicy: IfNotPresent
         livenessProbe:

--- a/pkg/resource/testdata/TestStatefulSetBuilder/insecure_statefulset_cli_args.golden
+++ b/pkg/resource/testdata/TestStatefulSetBuilder/insecure_statefulset_cli_args.golden
@@ -7,7 +7,7 @@ metadata:
   creationTimestamp: null
   name: test-cluster
 spec:
-  podManagementPolicy: OrderedReady
+  podManagementPolicy: Parallel
   replicas: 1
   selector:
     matchLabels:
@@ -25,20 +25,10 @@ spec:
     spec:
       automountServiceAccountToken: false
       containers:
-      - args:
-        - start
-        - --join=test-cluster-0.test-cluster.test-ns:26258
-        - --advertise-host=$(POD_NAME).test-cluster.test-ns
-        - --logtostderr=INFO
-        - --insecure
-        - --http-port=8080
-        - --cache=30%
-        - --max-sql-memory=2GB
-        - --sql-addr=:26257
-        - --listen-addr=:26258
-        - --temp-dir=/tmp
-        command:
-        - /cockroach/cockroach.sh
+      - command:
+        - /bin/bash
+        - -ecx
+        - exec /cockroach/cockroach.sh start --join=test-cluster-0.test-cluster.test-ns:26258 --advertise-host=$(POD_NAME).test-cluster.test-ns --logtostderr=INFO --insecure --http-port=8080 --sql-addr=:26257 --listen-addr=:26258 --cache=30% --max-sql-memory=2GB --temp-dir=/tmp
         env:
         - name: COCKROACH_CHANNEL
           value: kubernetes-operator-gke
@@ -46,6 +36,16 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              divisor: "1"
+              resource: limits.cpu
+        - name: MEMORY_LIMIT_MIB
+          valueFrom:
+            resourceFieldRef:
+              divisor: 1Mi
+              resource: limits.memory
         image: cockroachdb/cockroach:v20.2.7
         imagePullPolicy: IfNotPresent
         livenessProbe:

--- a/pkg/resource/testdata/TestStatefulSetBuilder/insecure_statefulset_with_resources.golden
+++ b/pkg/resource/testdata/TestStatefulSetBuilder/insecure_statefulset_with_resources.golden
@@ -7,7 +7,7 @@ metadata:
   creationTimestamp: null
   name: test-cluster
 spec:
-  podManagementPolicy: OrderedReady
+  podManagementPolicy: Parallel
   replicas: 1
   selector:
     matchLabels:
@@ -25,19 +25,10 @@ spec:
     spec:
       automountServiceAccountToken: false
       containers:
-      - args:
-        - start
-        - --join=test-cluster-0.test-cluster.test-ns:26258
-        - --advertise-host=$(POD_NAME).test-cluster.test-ns
-        - --logtostderr=INFO
-        - --insecure
-        - --http-port=8080
-        - --cache=25%
-        - --max-sql-memory=25%
-        - --sql-addr=:26257
-        - --listen-addr=:26258
-        command:
-        - /cockroach/cockroach.sh
+      - command:
+        - /bin/bash
+        - -ecx
+        - exec /cockroach/cockroach.sh start --join=test-cluster-0.test-cluster.test-ns:26258 --advertise-host=$(POD_NAME).test-cluster.test-ns --logtostderr=INFO --insecure --http-port=8080 --sql-addr=:26257 --listen-addr=:26258 --cache=25% --max-sql-memory=25%
         env:
         - name: COCKROACH_CHANNEL
           value: kubernetes-operator-gke
@@ -45,6 +36,16 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        - name: GOMAXPROCS
+          valueFrom:
+            resourceFieldRef:
+              divisor: "1"
+              resource: limits.cpu
+        - name: MEMORY_LIMIT_MIB
+          valueFrom:
+            resourceFieldRef:
+              divisor: 1Mi
+              resource: limits.memory
         image: cockroachdb/cockroach:v20.2.7
         imagePullPolicy: IfNotPresent
         livenessProbe:


### PR DESCRIPTION
1. Dynamically set cache and max sql memory if the user does
not set a CRD value
2. sts is set to Parallel pod management

We are making changes to use `exec` and bash directly in order to
start the Pods and set the cache values dynamically.  We are also
adding environment variables in to the Pods that set the GOPROCSMAX
and also MEMORY_LIMIT_MIB which is used to set CR cachee and
max sql memory values.