### PR TITLE
Decommission needs to run first

### DIFF
--- a/pkg/actor/actor.go
+++ b/pkg/actor/actor.go
@@ -80,6 +80,8 @@ type Actor interface {
 func NewOperatorActions(scheme *runtime.Scheme, cl client.Client, config *rest.Config) []Actor {
 
 	var update Actor
+        // move decommission to top to avoid conflict with other actors
+	decommission := newDecommission(scheme, cl, config)
 
 	// entry point for new PartitionUpdate upgrades
 	// this feature is controlled by a featuregate
@@ -89,7 +91,7 @@ func NewOperatorActions(scheme *runtime.Scheme, cl client.Client, config *rest.C
 		update = newUpgrade(scheme, cl, config)
 	}
 
-	decommission := newDecommission(scheme, cl, config)
+
 	versionChecker := newVersionChecker(scheme, cl, config)
 	var certs Actor
 	// entry point for new GenerateCert
@@ -110,10 +112,11 @@ func NewOperatorActions(scheme *runtime.Scheme, cl client.Client, config *rest.C
 	// Actors that controlled by featuregates
 	// have the featuregate check above or in there handles
 	// func.
+        // decommission needs to be first, it is not dependant on versionchecker
 	return []Actor{
+		decommission,
 		versionChecker,
 		certs,
-		decommission,
 		update,
 		newResizePVC(scheme, cl, config),
 		newDeploy(scheme, cl, config, kd),

--- a/pkg/actor/actor.go
+++ b/pkg/actor/actor.go
@@ -80,8 +80,6 @@ type Actor interface {
 func NewOperatorActions(scheme *runtime.Scheme, cl client.Client, config *rest.Config) []Actor {
 
 	var update Actor
-        // move decommission to top to avoid conflict with other actors
-	decommission := newDecommission(scheme, cl, config)
 
 	// entry point for new PartitionUpdate upgrades
 	// this feature is controlled by a featuregate
@@ -91,8 +89,8 @@ func NewOperatorActions(scheme *runtime.Scheme, cl client.Client, config *rest.C
 		update = newUpgrade(scheme, cl, config)
 	}
 
-
 	versionChecker := newVersionChecker(scheme, cl, config)
+    decommission := newDecommission(scheme, cl, config)
 	var certs Actor
 	// entry point for new GenerateCert
 	// this feature is controlled by a featuregate
@@ -112,11 +110,12 @@ func NewOperatorActions(scheme *runtime.Scheme, cl client.Client, config *rest.C
 	// Actors that controlled by featuregates
 	// have the featuregate check above or in there handles
 	// func.
-        // decommission needs to be first, it is not dependant on versionchecker
+	// decommission needs to be first, it is not dependant on versionchecker
+
 	return []Actor{
-		decommission,
 		versionChecker,
 		certs,
+		decommission,
 		update,
 		newResizePVC(scheme, cl, config),
 		newDeploy(scheme, cl, config, kd),

--- a/pkg/actor/actor.go
+++ b/pkg/actor/actor.go
@@ -90,7 +90,7 @@ func NewOperatorActions(scheme *runtime.Scheme, cl client.Client, config *rest.C
 	}
 
 	versionChecker := newVersionChecker(scheme, cl, config)
-    decommission := newDecommission(scheme, cl, config)
+	decommission := newDecommission(scheme, cl, config)
 	var certs Actor
 	// entry point for new GenerateCert
 	// this feature is controlled by a featuregate


### PR DESCRIPTION
Adjusting the order that the actors run to execute Decommission first so that upgrade doesn't interrupt it. 