### PR TITLE
Removing default values

### DIFF
--- a/apis/v1alpha1/cluster_defaults.go
+++ b/apis/v1alpha1/cluster_defaults.go
@@ -46,14 +46,6 @@ func SetClusterSpecDefaults(cs *CrdbClusterSpec) {
 		cs.MaxUnavailable = &DefaultMaxUnavailable
 	}
 
-	if cs.Cache == "" {
-		cs.Cache = "25%"
-	}
-
-	if cs.MaxSQLMemory == "" {
-		cs.MaxSQLMemory = "25%"
-	}
-
 	if cs.Image.PullPolicyName == nil {
 		policy := v1.PullIfNotPresent
 		cs.Image.PullPolicyName = &policy

--- a/apis/v1alpha1/cluster_defaults_test.go
+++ b/apis/v1alpha1/cluster_defaults_test.go
@@ -33,8 +33,6 @@ func TestSetClusterSpecDefaults(t *testing.T) {
 		GRPCPort:       &DefaultGRPCPort,
 		HTTPPort:       &DefaultHTTPPort,
 		SQLPort:        &DefaultSQLPort,
-		Cache:          "25%",
-		MaxSQLMemory:   "25%",
 		MaxUnavailable: &maxUnavailable,
 		Image: PodImage{
 			PullPolicyName: &policy,

--- a/pkg/resource/testdata/TestStatefulSetBuilder/default_insecure_statefulset.golden
+++ b/pkg/resource/testdata/TestStatefulSetBuilder/default_insecure_statefulset.golden
@@ -28,7 +28,7 @@ spec:
       - command:
         - /bin/bash
         - -ecx
-        - exec /cockroach/cockroach.sh start --join=test-cluster-0.test-cluster.test-ns:26258 --advertise-host=$(POD_NAME).test-cluster.test-ns --logtostderr=INFO --insecure --http-port=8080 --sql-addr=:26257 --listen-addr=:26258 --cache=25% --max-sql-memory=25%
+        - exec /cockroach/cockroach.sh start --join=test-cluster-0.test-cluster.test-ns:26258 --advertise-host=$(POD_NAME).test-cluster.test-ns --logtostderr=INFO --insecure --http-port=8080 --sql-addr=:26257 --listen-addr=:26258 --cache $(expr $MEMORY_LIMIT_MIB / 4)MiB --max-sql-memory $(expr $MEMORY_LIMIT_MIB / 4)MiB
         env:
         - name: COCKROACH_CHANNEL
           value: kubernetes-operator-gke

--- a/pkg/resource/testdata/TestStatefulSetBuilder/default_secure.golden
+++ b/pkg/resource/testdata/TestStatefulSetBuilder/default_secure.golden
@@ -28,7 +28,7 @@ spec:
       - command:
         - /bin/bash
         - -ecx
-        - exec /cockroach/cockroach.sh start --join=test-cluster-0.test-cluster.test-ns:26258 --advertise-host=$(POD_NAME).test-cluster.test-ns --logtostderr=INFO --certs-dir=/cockroach/cockroach-certs/ --http-port=8080 --sql-addr=:26257 --listen-addr=:26258 --cache=25% --max-sql-memory=25%
+        - exec /cockroach/cockroach.sh start --join=test-cluster-0.test-cluster.test-ns:26258 --advertise-host=$(POD_NAME).test-cluster.test-ns --logtostderr=INFO --certs-dir=/cockroach/cockroach-certs/ --http-port=8080 --sql-addr=:26257 --listen-addr=:26258 --cache $(expr $MEMORY_LIMIT_MIB / 4)MiB --max-sql-memory $(expr $MEMORY_LIMIT_MIB / 4)MiB
         env:
         - name: COCKROACH_CHANNEL
           value: kubernetes-operator-gke

--- a/pkg/resource/testdata/TestStatefulSetBuilder/insecure_statefulset_with_resources.golden
+++ b/pkg/resource/testdata/TestStatefulSetBuilder/insecure_statefulset_with_resources.golden
@@ -28,7 +28,7 @@ spec:
       - command:
         - /bin/bash
         - -ecx
-        - exec /cockroach/cockroach.sh start --join=test-cluster-0.test-cluster.test-ns:26258 --advertise-host=$(POD_NAME).test-cluster.test-ns --logtostderr=INFO --insecure --http-port=8080 --sql-addr=:26257 --listen-addr=:26258 --cache=25% --max-sql-memory=25%
+        - exec /cockroach/cockroach.sh start --join=test-cluster-0.test-cluster.test-ns:26258 --advertise-host=$(POD_NAME).test-cluster.test-ns --logtostderr=INFO --insecure --http-port=8080 --sql-addr=:26257 --listen-addr=:26258 --cache $(expr $MEMORY_LIMIT_MIB / 4)MiB --max-sql-memory $(expr $MEMORY_LIMIT_MIB / 4)MiB
         env:
         - name: COCKROACH_CHANNEL
           value: kubernetes-operator-gke


### PR DESCRIPTION
Previously we set defaults for cache and max sql memory. We now
set those values based on Pod limits. The cluster_defaults.go
code was removed in a different PR, but the PR that was merged
did not have those changes. These changes are coverred in a
unit test, but the test data was incorrectly updated.