### PR TITLE
Creating RBAC objects for Openshift E2E

### DIFF
--- a/pkg/testutil/env/BUILD.bazel
+++ b/pkg/testutil/env/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
         "//pkg/kube:go_default_library",
         "@com_github_pkg_errors//:go_default_library",
         "@io_k8s_api//core/v1:go_default_library",
+        "@io_k8s_api//rbac/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/api/meta:go_default_library",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
         "@io_k8s_apimachinery//pkg/apis/meta/v1/unstructured:go_default_library",


### PR DESCRIPTION
This PR creates the RBAC bindings that are required to run e2e testing
with openshift. We are creating the role binding and role that
allows the operator database service account to a Pod as any UID.

When the e2e test starts the role is created, and when the test
is over the role is destroyed.  This code stop e2e testing
to occur in parallel. But we have other problems with parallel testing
as well.