### PR TITLE
Adding PreStop Hook - Removing LivenessProbe

### DIFF
--- a/pkg/resource/testdata/TestStatefulSetBuilder/default_insecure_statefulset.golden
+++ b/pkg/resource/testdata/TestStatefulSetBuilder/default_insecure_statefulset.golden
@@ -48,13 +48,13 @@ spec:
               resource: limits.memory
         image: cockroachdb/cockroach:v20.2.7
         imagePullPolicy: IfNotPresent
-        livenessProbe:
-          httpGet:
-            path: /health
-            port: http
-            scheme: HTTP
-          initialDelaySeconds: 30
-          periodSeconds: 5
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - sh
+              - -c
+              - /cockroach/cockroach node drain --insecure || exit 0
         name: db
         ports:
         - containerPort: 26258

--- a/pkg/resource/testdata/TestStatefulSetBuilder/default_secure.golden
+++ b/pkg/resource/testdata/TestStatefulSetBuilder/default_secure.golden
@@ -48,13 +48,13 @@ spec:
               resource: limits.memory
         image: cockroachdb/cockroach:v20.2.7
         imagePullPolicy: IfNotPresent
-        livenessProbe:
-          httpGet:
-            path: /health
-            port: http
-            scheme: HTTPS
-          initialDelaySeconds: 30
-          periodSeconds: 5
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - sh
+              - -c
+              - /cockroach/cockroach node drain --certs-dir=/cockroach/cockroach-certs/ || exit 0
         name: db
         ports:
         - containerPort: 26258

--- a/pkg/resource/testdata/TestStatefulSetBuilder/insecure_statefulset_cli_args.golden
+++ b/pkg/resource/testdata/TestStatefulSetBuilder/insecure_statefulset_cli_args.golden
@@ -48,13 +48,13 @@ spec:
               resource: limits.memory
         image: cockroachdb/cockroach:v20.2.7
         imagePullPolicy: IfNotPresent
-        livenessProbe:
-          httpGet:
-            path: /health
-            port: http
-            scheme: HTTP
-          initialDelaySeconds: 30
-          periodSeconds: 5
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - sh
+              - -c
+              - /cockroach/cockroach node drain --insecure || exit 0
         name: db
         ports:
         - containerPort: 26258

--- a/pkg/resource/testdata/TestStatefulSetBuilder/insecure_statefulset_with_resources.golden
+++ b/pkg/resource/testdata/TestStatefulSetBuilder/insecure_statefulset_with_resources.golden
@@ -48,13 +48,13 @@ spec:
               resource: limits.memory
         image: cockroachdb/cockroach:v20.2.7
         imagePullPolicy: IfNotPresent
-        livenessProbe:
-          httpGet:
-            path: /health
-            port: http
-            scheme: HTTP
-          initialDelaySeconds: 30
-          periodSeconds: 5
+        lifecycle:
+          preStop:
+            exec:
+              command:
+              - sh
+              - -c
+              - /cockroach/cockroach node drain --insecure || exit 0
         name: db
         ports:
         - containerPort: 26258


### PR DESCRIPTION
Adding the drain PreStop Hook for CRDB.
Removed LivenessProbe probe due to problems when pods are resource constrained.