### PR TITLE
Split CI

### DIFF
--- a/.github/workflows/e2e-kind-create.yaml
+++ b/.github/workflows/e2e-kind-create.yaml
@@ -1,0 +1,49 @@
+# Copyright 2021 The Cockroach Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: e2e-kind-create
+
+on:
+  # Triggers the workflow on push or pull request events but only for the master branch
+  push:
+    branches: [ master ]
+    paths-ignore:
+      - "**.md"
+      - "docs/**"
+  pull_request:
+    branches: [ master ]
+    paths-ignore:
+      - "**.md"
+      - "docs/**"
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  e2e-kind-create:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        bazel: ["4.0.0"]
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup Bazel
+        uses: abhinavsingh/setup-bazel@v3
+        with:
+          version: ${{ matrix.bazel }}
+
+      - name: End-to-end (kind)
+        run: make test/e2e/kind-create

--- a/.github/workflows/e2e-kind-decomission.yaml
+++ b/.github/workflows/e2e-kind-decomission.yaml
@@ -1,0 +1,49 @@
+# Copyright 2021 The Cockroach Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: e2e-kind-decomission
+
+on:
+  # Triggers the workflow on push or pull request events but only for the master branch
+  push:
+    branches: [ master ]
+    paths-ignore:
+      - "**.md"
+      - "docs/**"
+  pull_request:
+    branches: [ master ]
+    paths-ignore:
+      - "**.md"
+      - "docs/**"
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  e2e-kind-decomission:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        bazel: ["4.0.0"]
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup Bazel
+        uses: abhinavsingh/setup-bazel@v3
+        with:
+          version: ${{ matrix.bazel }}
+
+      - name: End-to-end (kind)
+        run: make test/e2e/kind-decomission

--- a/.github/workflows/e2e-kind-upgrades.yaml
+++ b/.github/workflows/e2e-kind-upgrades.yaml
@@ -1,0 +1,49 @@
+# Copyright 2021 The Cockroach Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: e2e-kind-upgrades
+
+on:
+  # Triggers the workflow on push or pull request events but only for the master branch
+  push:
+    branches: [ master ]
+    paths-ignore:
+      - "**.md"
+      - "docs/**"
+  pull_request:
+    branches: [ master ]
+    paths-ignore:
+      - "**.md"
+      - "docs/**"
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+jobs:
+  e2e-kind-upgrades:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        bazel: ["4.0.0"]
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup Bazel
+        uses: abhinavsingh/setup-bazel@v3
+        with:
+          version: ${{ matrix.bazel }}
+
+      - name: End-to-end (kind)
+        run: make test/e2e/kind-upgrades

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: CI
+name: Tests
 
 on:
   # Triggers the workflow on push or pull request events but only for the master branch
@@ -31,57 +31,6 @@ on:
   workflow_dispatch:
 
 jobs:
-  e2e-kind-upgrades:
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        bazel: ["4.0.0"]
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: Setup Bazel
-        uses: abhinavsingh/setup-bazel@v3
-        with:
-          version: ${{ matrix.bazel }}
-
-      - name: End-to-end (kind)
-        run: make test/e2e/kind-upgrades
-
-  e2e-kind-create:
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        bazel: ["4.0.0"]
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: Setup Bazel
-        uses: abhinavsingh/setup-bazel@v3
-        with:
-          version: ${{ matrix.bazel }}
-
-      - name: End-to-end (kind)
-        run: make test/e2e/kind-create
-
-  e2e-kind-decomission:
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        bazel: ["4.0.0"]
-    steps:
-      - uses: actions/checkout@v2
-
-      - name: Setup Bazel
-        uses: abhinavsingh/setup-bazel@v3
-        with:
-          version: ${{ matrix.bazel }}
-
-      - name: End-to-end (kind)
-        run: make test/e2e/kind-decomission
-
   tests:
     runs-on: ubuntu-latest
     strategy:
@@ -97,4 +46,4 @@ jobs:
           version: ${{ matrix.bazel }}
 
       - name: Tests
-        run: make test/all 
+        run: make test/all


### PR DESCRIPTION
Splitting CI into separate files makes it possible to rerun a single
workflow without rerunning all at once.