### PR TITLE
Shutting off Decommission Actor by default

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -65,6 +65,7 @@ filegroup(
         "//deploy/certified-metadata-bundle/cockroach-operator/latest/metadata:all-srcs",
         "//e2e/create:all-srcs",
         "//e2e/decomission:all-srcs",
+        "//e2e/kubetest2-openshift:all-srcs",
         "//e2e/pvcresize:all-srcs",
         "//e2e/upgrades:all-srcs",
         "//examples:all-srcs",

--- a/e2e/create/BUILD.bazel
+++ b/e2e/create/BUILD.bazel
@@ -34,10 +34,7 @@ filegroup(
 
 filegroup(
     name = "all-srcs",
-    srcs = [
-        ":package-srcs",
-        "//e2e/kubetest2-openshift:all-srcs",
-    ],
+    srcs = [":package-srcs"],
     tags = ["automanaged"],
     visibility = ["//visibility:public"],
 )

--- a/e2e/decomission/BUILD.bazel
+++ b/e2e/decomission/BUILD.bazel
@@ -19,6 +19,7 @@ go_test(
         "//pkg/controller:go_default_library",
         "//pkg/testutil:go_default_library",
         "//pkg/testutil/env:go_default_library",
+        "//pkg/utilfeature:go_default_library",
         "@com_github_go_logr_zapr//:go_default_library",
         "@com_github_stretchr_testify//require:go_default_library",
         "@org_uber_go_zap//zaptest:go_default_library",
@@ -34,10 +35,7 @@ filegroup(
 
 filegroup(
     name = "all-srcs",
-    srcs = [
-        ":package-srcs",
-        "//e2e/kubetest2-openshift:all-srcs",
-    ],
+    srcs = [":package-srcs"],
     tags = ["automanaged"],
     visibility = ["//visibility:public"],
 )

--- a/e2e/decomission/decomission_test.go
+++ b/e2e/decomission/decomission_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cockroachdb/cockroach-operator/pkg/controller"
 	"github.com/cockroachdb/cockroach-operator/pkg/testutil"
 	testenv "github.com/cockroachdb/cockroach-operator/pkg/testutil/env"
+	"github.com/cockroachdb/cockroach-operator/pkg/utilfeature"
 	"github.com/go-logr/zapr"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zaptest"
@@ -35,9 +36,6 @@ import (
 // deployed in the cluster helps
 // We may have a threadsafe problem where one test starts messing with another test
 var parallel = *flag.Bool("parallel", false, "run tests in parallel")
-
-// run the pvc test
-var pvc = flag.Bool("pvc", false, "run pvc test")
 
 // TODO should we make this an atomic that is created by evn pkg?
 var env *testenv.ActiveEnv
@@ -51,10 +49,15 @@ func TestMain(m *testing.M) {
 	os.Exit(code)
 }
 
+// TestDecomissionFunctionality creates a cluster of 4 nodes and then decomissions on of the CRDB nodes.
+// It then checks that the cluster is stable and that decomissioning is successful.
 func TestDecommissionFunctionality(t *testing.T) {
 
 	// Testing removing and decommisioning a node.  We start at 4 node and then
 	// remove the 4th node
+
+	// turn on featuregate since Decommission is disabled by default currently
+	utilfeature.DefaultMutableFeatureGate.Set("UseDecommission=true")
 
 	if testing.Short() {
 		t.Skip("skipping test in short mode.")

--- a/e2e/pvcresize/BUILD.bazel
+++ b/e2e/pvcresize/BUILD.bazel
@@ -36,10 +36,7 @@ filegroup(
 
 filegroup(
     name = "all-srcs",
-    srcs = [
-        ":package-srcs",
-        "//e2e/kubetest2-openshift:all-srcs",
-    ],
+    srcs = [":package-srcs"],
     tags = ["automanaged"],
     visibility = ["//visibility:public"],
 )

--- a/e2e/upgrades/BUILD.bazel
+++ b/e2e/upgrades/BUILD.bazel
@@ -34,10 +34,7 @@ filegroup(
 
 filegroup(
     name = "all-srcs",
-    srcs = [
-        ":package-srcs",
-        "//e2e/kubetest2-openshift:all-srcs",
-    ],
+    srcs = [":package-srcs"],
     tags = ["automanaged"],
     visibility = ["//visibility:public"],
 )

--- a/pkg/actor/BUILD.bazel
+++ b/pkg/actor/BUILD.bazel
@@ -55,6 +55,7 @@ go_library(
 go_test(
     name = "go_default_test",
     srcs = [
+        "decommission_test.go",
         "deploy_test.go",
         "export_test.go",
         "partitioned_update_test.go",
@@ -62,8 +63,10 @@ go_test(
     embed = [":go_default_library"],
     deps = [
         "//apis/v1alpha1:go_default_library",
+        "//pkg/features:go_default_library",
         "//pkg/kube:go_default_library",
         "//pkg/testutil:go_default_library",
+        "//pkg/utilfeature:go_default_library",
         "@com_github_go_logr_zapr//:go_default_library",
         "@com_github_pkg_errors//:go_default_library",
         "@com_github_stretchr_testify//assert:go_default_library",

--- a/pkg/actor/decommission.go
+++ b/pkg/actor/decommission.go
@@ -57,8 +57,12 @@ func (d decommission) GetActionType() api.ActionType {
 	return api.DecommissionAction
 }
 
+// Handles returns true if the Actor is enabled or can run
 func (d decommission) Handles(conds []api.ClusterCondition) bool {
-	return condition.True(api.InitializedCondition, conds) && utilfeature.DefaultMutableFeatureGate.Enabled(features.Decommission)
+	if !utilfeature.DefaultMutableFeatureGate.Enabled(features.Decommission) {
+		return false
+	}
+	return condition.True(api.InitializedCondition, conds)
 }
 
 func (d decommission) Act(ctx context.Context, cluster *resource.Cluster) error {

--- a/pkg/actor/decommission_test.go
+++ b/pkg/actor/decommission_test.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2021 The Cockroach Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package actor
+
+import (
+	"testing"
+
+	api "github.com/cockroachdb/cockroach-operator/apis/v1alpha1"
+	"github.com/cockroachdb/cockroach-operator/pkg/features"
+	"github.com/cockroachdb/cockroach-operator/pkg/testutil"
+	"github.com/cockroachdb/cockroach-operator/pkg/utilfeature"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDecommisionFeatureFlag(t *testing.T) {
+	// FeatureGate is currently disabled
+	assert.False(t, utilfeature.DefaultMutableFeatureGate.Enabled(features.Decommission))
+
+	cluster := testutil.NewBuilder("cockroachdb").
+		Namespaced("default").
+		WithUID("cockroachdb-uid").
+		WithPVDataStore("1Gi", "standard" /* default storage class in KIND */).
+		WithNodeCount(1).Cluster()
+	cluster.SetTrue(api.InitializedCondition)
+
+	scheme := testutil.InitScheme(t)
+	client := testutil.NewFakeClient(scheme)
+	deco := newDecommission(scheme, client, nil)
+
+	require.False(t, deco.Handles(cluster.Status().Conditions))
+
+}

--- a/pkg/features/operator_features.go
+++ b/pkg/features/operator_features.go
@@ -60,6 +60,7 @@ const (
 	// owner: @chrislovecnm
 	// alpha: v0.1
 	// beta: v1.0
+	// GA: v1.7.7
 	// GenerateCerts uses crdb binary to generate self signed certifcates
 	GenerateCerts featuregate.Feature = "GenerateCerts"
 	// owner: @alina
@@ -77,13 +78,11 @@ func init() {
 // To add a new feature, define a key for it above and add it here. The features will be
 // available throughout Kubernetes binaries.
 var defaultOperatorFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
-	PartitionedUpdate:    {Default: true, PreRelease: featuregate.Alpha},
-	Decommission:         {Default: true, PreRelease: featuregate.Alpha},
-	ResizePVC:            {Default: true, PreRelease: featuregate.Alpha},
-	CrdbVersionValidator: {Default: true, PreRelease: featuregate.Alpha},
-	GenerateCerts:        {Default: true, PreRelease: featuregate.Alpha},
-	ClusterRestart:       {Default: true, PreRelease: featuregate.Alpha},
-
-	// Deprecated
-	Upgrade: {Default: false, PreRelease: featuregate.Alpha},
+	PartitionedUpdate: {Default: true, PreRelease: featuregate.Beta},
+	// Turing of Decomission because of design bug at this point
+	Decommission:         {Default: false, PreRelease: featuregate.Alpha},
+	ResizePVC:            {Default: true, PreRelease: featuregate.Beta},
+	CrdbVersionValidator: {Default: true, PreRelease: featuregate.Beta},
+	GenerateCerts:        {Default: true, PreRelease: featuregate.GA},
+	ClusterRestart:       {Default: true, PreRelease: featuregate.Beta},
 }


### PR DESCRIPTION
We are having issues with the Decommission Actor so we are turning
it off by default.  You can enable the Actor via the feature flag.

The test case for this PR is that Decommission will run when we enable the flag.  Otherwise, it will not run.