### PR TITLE
fix decommision e2e test to use host

### DIFF
--- a/pkg/testutil/require.go
+++ b/pkg/testutil/require.go
@@ -349,10 +349,6 @@ func makeDrainStatusChecker(t *testing.T, sb testenv.DiffingSandbox, b ClusterBu
 			return errors.Wrap(err, "failed to extract node id from string")
 		}
 
-		if err != nil {
-			return errors.Wrapf(err, "failed to get node draining status")
-		}
-
 		isLive, replicasStr, isDecommissioning := record[8], record[9], record[10]
 		t.Logf("draining node do to decommission test\n")
 		t.Logf("id=%s\n ", idStr)

--- a/pkg/testutil/require.go
+++ b/pkg/testutil/require.go
@@ -338,6 +338,10 @@ func makeDrainStatusChecker(t *testing.T, sb testenv.DiffingSandbox, b ClusterBu
 			break
 		}
 
+		if err != nil {
+			return errors.Wrapf(err, "failed to get node draining status")
+		}
+
 		idStr, address := record[0], record[1]
 
 		if !strings.Contains(address, host) {

--- a/pkg/testutil/require.go
+++ b/pkg/testutil/require.go
@@ -327,26 +327,36 @@ func makeDrainStatusChecker(t *testing.T, sb testenv.DiffingSandbox, b ClusterBu
 	if _, err := r.Read(); err != nil {
 		return err
 	}
+	// We are using the host to filter the decommissioned node.
+	// Currently the id does not match the pod index because of the
+	// pod parallel strategy
+	host := fmt.Sprintf("%s-%d.%s.%s", cluster.StatefulSetName(),
+		numNodes, cluster.StatefulSetName(), sb.Namespace)
 	for {
 		record, err := r.Read()
 		if err == io.EOF {
 			break
 		}
 
-		if err != nil {
-			return errors.Wrapf(err, "failed to get node draining status")
-		}
+		idStr, address := record[0], record[1]
 
-		idStr, isLive, replicasStr, isDecommissioning := record[0], record[8], record[9], record[10]
+		if !strings.Contains(address, host) {
+			continue
+		}
+		//if the address is for the last pod that was decommissioned we are checking the replicas
 		id, err := strconv.ParseUint(idStr, 10, 32)
 		if err != nil {
 			return errors.Wrap(err, "failed to extract node id from string")
 		}
-		if id <= numNodes {
-			continue
+
+		if err != nil {
+			return errors.Wrapf(err, "failed to get node draining status")
 		}
+
+		isLive, replicasStr, isDecommissioning := record[8], record[9], record[10]
 		t.Logf("draining node do to decommission test\n")
 		t.Logf("id=%s\n ", idStr)
+		t.Logf("address=%s\n ", address)
 		t.Logf("isLive=%s\n ", isLive)
 		t.Logf("replicas=%s\n", replicasStr)
 		t.Logf("isDecommissioning=%v\n", isDecommissioning)


### PR DESCRIPTION
In the e2e tests for decommission we used the index of the pod to check the replicas of the decommissioned nodes. 
Since we are using Pod Parallel Strategy the index of the pod and the  id are not the same anymore, so now I am filtering using the address that contains the host of the last node that was decommissioned to get the replicas.