### PR TITLE
Retrying if we have a conflict with an update

### DIFF
--- a/pkg/update/BUILD.bazel
+++ b/pkg/update/BUILD.bazel
@@ -25,6 +25,7 @@ go_library(
         "@io_k8s_apimachinery//pkg/api/errors:go_default_library",
         "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
         "@io_k8s_client_go//kubernetes:go_default_library",
+        "@io_k8s_client_go//util/retry:go_default_library",
         "@org_uber_go_zap//zapcore:go_default_library",
     ],
 )


### PR DESCRIPTION
The intial update of the sts returned that we cannot update the
sts since the sts is newer.  We then get the sts again and retry to
update it again.