### PR TITLE
Enabling Decommission

### DIFF
--- a/pkg/actor/decommission_test.go
+++ b/pkg/actor/decommission_test.go
@@ -28,9 +28,10 @@ import (
 )
 
 func TestDecommisionFeatureFlag(t *testing.T) {
-	// FeatureGate is currently disabled
-	assert.False(t, utilfeature.DefaultMutableFeatureGate.Enabled(features.Decommission))
-	assert.False(t, utilfeature.DefaultMutableFeatureGate.Enabled(features.AutoPrunePVC))
+	// FeatureGate is currently enabled as of 1.7.13 GA release
+	assert.True(t, utilfeature.DefaultMutableFeatureGate.Enabled(features.Decommission), "deco is enabled for GA")
+	// FeatureGate is currently disabled and is in alpha
+	assert.False(t, utilfeature.DefaultMutableFeatureGate.Enabled(features.AutoPrunePVC), "AutoPrunePVc is disabled for GA")
 
 	cluster := testutil.NewBuilder("cockroachdb").
 		Namespaced("default").
@@ -43,6 +44,6 @@ func TestDecommisionFeatureFlag(t *testing.T) {
 	client := testutil.NewFakeClient(scheme)
 	deco := newDecommission(scheme, client, nil)
 
-	require.False(t, deco.Handles(cluster.Status().Conditions))
+	require.True(t, deco.Handles(cluster.Status().Conditions))
 
 }

--- a/pkg/features/operator_features.go
+++ b/pkg/features/operator_features.go
@@ -32,28 +32,33 @@ const (
 	// owner: @chrislovecnm
 	// alpha: v0.1
 	// beta: v1.0
+	// ga: v1.7.13
 	// PartitionedUpdate controls how the statefulset is updated
 	PartitionedUpdate featuregate.Feature = "PartitionedUpdate"
 
 	// owner: @alina
 	// alpha: v0.1
 	// beta: v1.0
+	// ga: v1.7.13
 	// Decommission controls how the statefulset scales down
 	Decommission featuregate.Feature = "UseDecommission"
 
 	// alpha: v0.1
 	// beta: v1.0
+	// ga: v1.7.13
 	// Upgrades controls upgrade mechanism
 	Upgrade featuregate.Feature = "Upgrade"
 
 	// owner: @chrislovecnm
 	// alpha: v0.1
 	// beta: v1.0
+	// ga: v1.7.13
 	// ResizePVC allows for the resizing of PVC Volumes
 	ResizePVC featuregate.Feature = "ResizePVC"
 
 	// alpha: v0.1
 	// beta: v1.0
+	// ga: v1.7.13
 	// CrdbVersionValidator controls upgrade mechanism
 	CrdbVersionValidator featuregate.Feature = "CrdbVersionValidator"
 
@@ -63,14 +68,16 @@ const (
 	// GA: v1.7.7
 	// GenerateCerts uses crdb binary to generate self signed certifcates
 	GenerateCerts featuregate.Feature = "GenerateCerts"
+
 	// owner: @alina
 	// alpha: v0.1
 	// beta: v1.0
+	// ga: v1.7.13
 	// RestartCluster uses crdb binary to generate self signed certifcates
 	ClusterRestart featuregate.Feature = "ClusterRestart"
+
 	// owner: @alina
-	// alpha: v0.1
-	// beta: v1.0
+	// alpha: v1.7.13
 	// AutoPrunePVC uses crdb binary to prune PVC on decommission
 	AutoPrunePVC featuregate.Feature = "AutoPrunePVC"
 )
@@ -83,12 +90,16 @@ func init() {
 // To add a new feature, define a key for it above and add it here. The features will be
 // available throughout Kubernetes binaries.
 var defaultOperatorFeatureGates = map[featuregate.Feature]featuregate.FeatureSpec{
-	PartitionedUpdate: {Default: true, PreRelease: featuregate.Beta},
-	// Turing of Decomission because of design bug at this point
-	Decommission:         {Default: false, PreRelease: featuregate.Alpha},
-	ResizePVC:            {Default: true, PreRelease: featuregate.Beta},
-	CrdbVersionValidator: {Default: true, PreRelease: featuregate.Beta},
+	PartitionedUpdate:    {Default: true, PreRelease: featuregate.GA},
+	Decommission:         {Default: true, PreRelease: featuregate.GA},
+	ResizePVC:            {Default: true, PreRelease: featuregate.GA},
+	CrdbVersionValidator: {Default: true, PreRelease: featuregate.GA},
 	GenerateCerts:        {Default: true, PreRelease: featuregate.GA},
-	ClusterRestart:       {Default: true, PreRelease: featuregate.Beta},
-	AutoPrunePVC:         {Default: false, PreRelease: featuregate.Beta},
+	ClusterRestart:       {Default: true, PreRelease: featuregate.GA},
+
+	// We are leaving this in alpha because it can delete data at this point.
+	// We are still testing decommision, and are concerned that if a deco fails
+	// data is deleted and the database is corrupted.
+	// You can enable the feature by setting the feature gate
+	AutoPrunePVC: {Default: false, PreRelease: featuregate.Alpha},
 }


### PR DESCRIPTION
- enabled deco via changing feature gate
- changed unit test, to test that it is enabled
- updated operator_features comments
- moved prune pvc to alpha
- we have two e2e tests, one that prunes PVCs and another that
  does not prune pvcs.