### PR TITLE
Fixing Version Checker panic

### DIFF
--- a/pkg/actor/validate_version.go
+++ b/pkg/actor/validate_version.go
@@ -37,9 +37,11 @@ import (
 	"go.uber.org/zap/zapcore"
 	kbatch "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
+	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
+
 	kubetypes "k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -70,12 +72,20 @@ func (v *versionChecker) Handles(conds []api.ClusterCondition) bool {
 	return utilfeature.DefaultMutableFeatureGate.Enabled(features.CrdbVersionValidator) && (condition.True(api.InitializedCondition, conds) || condition.False(api.InitializedCondition, conds)) && condition.False(api.CrdbVersionChecked, conds)
 }
 
+// Act will create a job that will try to extract the crdb version using the image field or the CockroachDBVersion field
+// Initially version checker job was created to have a unique name, the same name as the CR
+// This was the mechanism that assured a single job was created for each CR
+// To run the tests in parallel we change the name of the job to use a timestamp
+// We want to run different test scenarios in parallel with the same CR.
+// But for the crdb container to run in our version checker we need also requestcerts action.
+// The timestamp from the nameing of the job will ensure for a short period that the name of the job will be the same,
+// We need a better mechanism to avoid creation of duplicate version checkers when the requestcerts finish
+// and version checker needs to complete the work.
 func (v *versionChecker) Act(ctx context.Context, cluster *resource.Cluster) error {
 	log := v.log.WithValues("CrdbCluster", cluster.ObjectKey())
 	log.V(DEBUGLEVEL).Info("starting to check the crdb version of the container provided")
 
 	r := resource.NewManagedKubeResource(ctx, v.client, cluster, kube.AnnotatingPersister)
-	owner := cluster.Unwrap()
 
 	// If the image.name is set use that value and do not check that the
 	// version is set in the supported versions.
@@ -95,9 +105,9 @@ func (v *versionChecker) Act(ctx context.Context, cluster *resource.Cluster) err
 			log.Error(err, "The cockroachDBVersion API value is set to a value that is not supported by the operator. Supported versions are set via the RELATED_IMAGE env variables in the operator manifest.")
 			return err
 		}
-		log.V(int(zapcore.DebugLevel)).Info(fmt.Sprintf("supported CockroachDBVersion %s", cluster.Spec().CockroachDBVersion))
+		log.V(DEBUGLEVEL).Info(fmt.Sprintf("supported CockroachDBVersion %s", cluster.Spec().CockroachDBVersion))
 	} else {
-		log.V(int(zapcore.DebugLevel)).Info("User set image.name, using that field instead of cockroachDBVersion")
+		log.V(DEBUGLEVEL).Info("User set image.name, using that field instead of cockroachDBVersion")
 	}
 
 	var calVersion, containerImage string
@@ -106,65 +116,81 @@ func (v *versionChecker) Act(ctx context.Context, cluster *resource.Cluster) err
 	cluster.SetAnnotationVersion(calVersion)
 	cluster.SetCrdbContainerImage(containerImage)
 	cluster.SetAnnotationContainerImage(containerImage)
+
 	jobName := cluster.JobName()
-	changed, err := (resource.Reconciler{
-		ManagedResource: r,
-		Builder: resource.JobBuilder{
-			Cluster:  cluster,
-			Selector: r.Labels.Selector(),
-			JobName:  jobName,
-		},
-		Owner:  owner,
-		Scheme: v.scheme,
-	}).Reconcile()
-	if err != nil && kube.IgnoreNotFound(err) == nil {
-		err := errors.Wrap(err, "failed to reconcile job not found")
-		log.Error(err, "failed to reconcile job")
-		return err
-	} else if err != nil {
-		log.Error(err, "failed to reconcile job only err")
-	}
-
-	if changed {
-		log.V(int(zapcore.DebugLevel)).Info("created/updated job, stopping request processing")
-		CancelLoop(ctx)
-		return nil
-	}
-
-	log.V(int(zapcore.DebugLevel)).Info("version checker", "job", jobName)
+	job := &kbatch.Job{}
 	key := kubetypes.NamespacedName{
 		Namespace: cluster.Namespace(),
 		Name:      jobName,
 	}
-	job := &kbatch.Job{}
 
 	clientset, err := kubernetes.NewForConfig(v.config)
 	if err != nil {
 		log.Error(err, "cannot create k8s client")
 		return errors.Wrapf(err, "check version failed to create kubernetes clientset")
 	}
+	//we get the job to see it already exists
 	if err := v.client.Get(ctx, key, job); err != nil {
-		err := WaitUntilJobPodIsRunning(ctx, clientset, job, log)
-		if err != nil {
-			log.Error(err, "job not found")
+		//if job does not exist we create it
+		if err = reconcileJob(cluster, v.scheme, r, jobName, log); err != nil {
 			return err
 		}
+	} else {
+		// if job exists check if image changed
+		if dbContainer, err := kube.FindContainer(resource.JobContainerName, &job.Spec.Template.Spec); err != nil {
+			// this will fix the reconcile on job on immutable prop, somehow the job probably terminates
+			log.Error(err, "the job already exists but no container was found")
+			return nil
+		} else if dbContainer.Image != cluster.GetCockroachDBImageName() {
+			log.V(DEBUGLEVEL).Info("The job image name is out of date", "job", jobName, "dbContainer.Image", dbContainer.Image, "spec image", cluster.GetCockroachDBImageName())
+			if err = reconcileJob(cluster, v.scheme, r, jobName, log); err != nil {
+				return err
+			}
+		}
+	}
+	// we comment this because after reconcile the object it is modified in k8s and
+	// this will trigger a restart.
+	// TODO: we need to delete this lines
+	// if changed {
+	// 	log.V(DEBUGLEVEL).Info("created/updated job, stopping request processing")
+	// 	CancelLoop(ctx)
+	// 	return nil
+	// }
+	log.V(DEBUGLEVEL).Info("version checker", "job", jobName)
+
+	// sometimes the Get on the job will return an error and an empty job struct.
+	// this is especially valid for kind cluster in our e2e
+	// To fix this we wait for the pod of the job to run and than get the job.
+	if err := waitUntilJobPodIsRunning(ctx, clientset, jobName, job.Namespace, r.Labels.Selector(), log); err != nil {
+		log.Error(err, "job pod not found")
+		return err
 	}
 
-	// check if the job is completed or failed before EXEC
+	//we get the job after we checked that the pod is running
+	if err := v.client.Get(ctx, key, job); err != nil {
+		msg := fmt.Sprintf("failure: retrieved job%+v", *job)
+		log.Error(err, msg)
+		return err
+	}
+
+	// check if the job is completed or failed before getting the logs from the pod
 	if finished, _ := isJobCompletedOrFailed(job); !finished {
-		if err := WaitUntilJobPodIsRunning(ctx, clientset, job, v.log); err != nil {
+		//we check first to see that the job pod it is running
+		if err := waitUntilJobPodIsRunning(ctx, clientset, jobName, job.Namespace, r.Labels.Selector(), v.log); err != nil {
 			// if after 2 minutes the job pod is not ready and container status is ImagePullBackoff
 			// We need to stop requeueing until further changes on the CR
 			image := cluster.GetCockroachDBImageName()
-			if errBackoff := IsContainerStatusImagePullBackoff(ctx, clientset, job, log, image); errBackoff != nil {
+			if errBackoff := isContainerStatusImagePullBackoff(ctx, clientset, job, log, image); errBackoff != nil {
 				err := InvalidContainerVersionError{Err: errBackoff}
-				return LogError("job image incorrect", err, log)
+				msg := "job image incorrect"
+				log.V(DEBUGLEVEL).Info(msg)
+				return errors.Wrapf(err, msg)
 			}
 			return errors.Wrapf(err, "failed to check the version of the crdb")
 		}
 		podLogOpts := corev1.PodLogOptions{}
 		//get pod for the job we created
+		//we should add a label for the job  in the selector
 		pods, err := clientset.CoreV1().Pods(job.Namespace).List(ctx, metav1.ListOptions{
 			LabelSelector: labels.Set(job.Spec.Selector.MatchLabels).AsSelector().String(),
 		})
@@ -174,24 +200,43 @@ func (v *versionChecker) Act(ctx context.Context, cluster *resource.Cluster) err
 			return errors.Wrapf(err, "failed to list running pod for job")
 		}
 		if len(pods.Items) == 0 {
-			log.V(int(zapcore.DebugLevel)).Info("No running pods yet for version checker... we will retry later")
+			log.V(DEBUGLEVEL).Info("No running pods yet for version checker... we will retry later")
 			return nil
 		}
-		tmpPod := &pods.Items[0]
+		log.V(DEBUGLEVEL).Info(fmt.Sprintf("We found %v pods to extract logs", len(pods.Items)))
+		//the selector will get all the pods including crdb, we need to filter only for job pods
+		vcheckpods := make([]corev1.Pod, 0)
+		for _, po := range pods.Items {
+			if strings.HasPrefix(po.Name, jobName) {
+				vcheckpods = append(vcheckpods, po)
+			}
+		}
+		if len(vcheckpods) == 0 {
+			log.V(DEBUGLEVEL).Info("No running pods yet for version checker... retry")
+			return nil
+		}
+		pod := vcheckpods[0]
+		if !kube.IsPodReady(&pod) {
+			msg := fmt.Sprintf("job pod %s is not ready ... retry", pod.Name)
+			log.V(DEBUGLEVEL).Info(msg)
+			return nil
+		}
+
+		tmpPod := &vcheckpods[0]
 		// when we have more jobs take the latest in consideration
-		if len(pods.Items) > 1 {
-			for _, po := range pods.Items {
+		if len(vcheckpods) > 1 {
+			for _, po := range vcheckpods {
 				if !po.CreationTimestamp.Before(&tmpPod.CreationTimestamp) {
 					tmpPod = &po
 				}
 			}
 		}
 		podName := tmpPod.Name
-
+		log.V(DEBUGLEVEL).Info(fmt.Sprintf("geting logs from pod %s", podName))
 		req := clientset.CoreV1().Pods(job.Namespace).GetLogs(podName, &podLogOpts)
 		podLogs, err := req.Stream(ctx)
 		if err != nil {
-			msg := "error in opening stream"
+			msg := fmt.Sprintf("error in opening stream for pod %s", podName)
 			log.Error(err, msg)
 			return errors.Wrapf(err, msg)
 		}
@@ -200,7 +245,7 @@ func (v *versionChecker) Act(ctx context.Context, cluster *resource.Cluster) err
 		buf := new(bytes.Buffer)
 		_, err = io.Copy(buf, podLogs)
 		if err != nil {
-			msg := "error in copy information from podLogs to buf"
+			msg := fmt.Sprintf("error in copy information from podLogs to buf for pod %s", podName)
 			log.Error(err, msg)
 			return errors.Wrapf(err, msg)
 		}
@@ -233,11 +278,11 @@ func (v *versionChecker) Act(ctx context.Context, cluster *resource.Cluster) err
 		}
 		containerImage = dbContainer.Image
 		if strings.EqualFold(cluster.GetVersionAnnotation(), calVersion) {
-			log.V(int(zapcore.DebugLevel)).Info("No update on version annotation -> nothing changed")
+			log.V(DEBUGLEVEL).Info("No update on version annotation -> nothing changed")
 			return nil
 		}
 		if strings.EqualFold(cluster.GetAnnotationContainerImage(), containerImage) {
-			log.V(int(zapcore.DebugLevel)).Info("No update on container image annotation -> nothing changed")
+			log.V(DEBUGLEVEL).Info("No update on container image annotation -> nothing changed")
 			return nil
 		}
 		//we refresh the resource to make sure we use the latest version
@@ -296,11 +341,12 @@ func (v *versionChecker) Act(ctx context.Context, cluster *resource.Cluster) err
 		log.Error(err, "failed saving cluster status on version checker")
 		return err
 	}
-	log.V(int(zapcore.DebugLevel)).Info("completed version checker", "calVersion", calVersion, "containerImage", containerImage)
+	log.V(DEBUGLEVEL).Info("completed version checker", "calVersion", calVersion, "containerImage", containerImage)
 	CancelLoop(ctx)
 	return nil
 }
 
+//isJobCompletedOrFailed checks if a job is in state completed of failed
 func isJobCompletedOrFailed(job *kbatch.Job) (bool, kbatch.JobConditionType) {
 	for _, c := range job.Status.Conditions {
 		if (c.Type == kbatch.JobComplete || c.Type == kbatch.JobFailed) && c.Status == corev1.ConditionTrue {
@@ -310,32 +356,61 @@ func isJobCompletedOrFailed(job *kbatch.Job) (bool, kbatch.JobConditionType) {
 	return false, ""
 }
 
-func IsJobPodRunning(
+//isJobPodRunning checks that the version checker pod it is in state running
+func isJobPodRunning(
 	ctx context.Context,
 	clientset kubernetes.Interface,
-	job *kbatch.Job,
+	jobName, jobNamespace string,
+	labelsSel map[string]string,
 	l logr.Logger,
 ) error {
-	//get pod for the job we created
-	pods, err := clientset.CoreV1().Pods(job.Namespace).List(ctx, metav1.ListOptions{
-		LabelSelector: labels.Set(job.Spec.Selector.MatchLabels).AsSelector().String(),
-	})
+	labelSelector := metav1.LabelSelector{
+		MatchLabels: labelsSel,
+	}
 
-	if err != nil {
-		return LogError("error getting pod in job", err, l)
+	//get pod for the job we created
+	pods, err := clientset.CoreV1().Pods(jobNamespace).List(ctx, metav1.ListOptions{
+		LabelSelector: labels.Set(labelSelector.MatchLabels).AsSelector().String(),
+	})
+	if k8sErrors.IsNotFound(err) { // this is not an error
+		l.V(DEBUGLEVEL).Info("cannot find pods for vcheck job", "jobName", jobName, "namespace", jobNamespace)
+		return err
+	} else if statusError, isStatus := err.(*k8sErrors.StatusError); isStatus { // this is an error
+		l.Error(statusError, fmt.Sprintf("status error getting pod %v", statusError.ErrStatus.Message))
+		return err
+	} else if err != nil {
+		l.V(int(zapcore.ErrorLevel)).Info("error finding pods for vcheck job", "jobName", jobName, "namespace", jobNamespace)
+		return err
 	}
+
 	if len(pods.Items) == 0 {
-		return LogError("job pods are not running yet waiting longer", nil, l)
+		l.V(DEBUGLEVEL).Info("pods are not running yet waiting longer")
+		return err
 	}
-	pod := pods.Items[0]
+	//the selector will get all the pods including crdb, we need to filter only for job pods
+	vcheckpods := make([]corev1.Pod, 0)
+	for _, po := range pods.Items {
+		if strings.HasPrefix(po.Name, jobName) {
+			vcheckpods = append(vcheckpods, po)
+		}
+	}
+	if len(vcheckpods) == 0 {
+		l.V(DEBUGLEVEL).Info("job pods are not running yet waiting longer")
+		return err
+	}
+	pod := vcheckpods[0]
 	if !kube.IsPodReady(&pod) {
-		return LogError("job pod is not ready yet waiting longer", nil, l)
+		msg := fmt.Sprintf("job pod %s is not ready yet waiting longer", pod.ObjectMeta.Name)
+		l.V(DEBUGLEVEL).Info(msg)
+		return errors.New(msg)
 	}
-	l.V(int(zapcore.DebugLevel)).Info("job pod is ready")
+	msg := fmt.Sprintf("job pod '%+v' is ready", pod)
+	l.V(DEBUGLEVEL).Info(msg)
 	return nil
 }
 
-func IsContainerStatusImagePullBackoff(
+//isContainerStatusImagePullBackoff checks that the container status is ImagePullBackOff
+func isContainerStatusImagePullBackoff(
 	ctx context.Context,
 	clientset kubernetes.Interface,
 	job *kbatch.Job,
@@ -346,41 +421,67 @@ func IsContainerStatusImagePullBackoff(
 	pods, err := clientset.CoreV1().Pods(job.Namespace).List(ctx, metav1.ListOptions{
 		LabelSelector: labels.Set(job.Spec.Selector.MatchLabels).AsSelector().String(),
 	})
-	//TO DO: maybe we should check some k8s specific errors here
-	if err != nil {
-		return LogError("error getting pod in job", err, l)
+
+	if k8sErrors.IsNotFound(err) { // this is not an error
+		l.V(DEBUGLEVEL).Info("cannot find pods for vcheck job", "jobName", job.ObjectMeta.Name, "namespace", job.Namespace)
+		return err
+	} else if statusError, isStatus := err.(*k8sErrors.StatusError); isStatus { // this is an error
+		l.Error(statusError, fmt.Sprintf("status error getting pod %v", statusError.ErrStatus.Message))
+		return err
+	} else if err != nil {
+		l.V(int(zapcore.ErrorLevel)).Info("error finding pods for vcheck job", "jobName", job.ObjectMeta.Name, "namespace", job.Namespace)
+		return err
 	}
+
 	if len(pods.Items) == 0 {
-		return LogError("job pods are not running.", nil, l)
+		l.V(DEBUGLEVEL).Info("job pods are not running.")
+		return nil
 	}
 	pod := pods.Items[0]
 	if !kube.IsPodReady(&pod) && kube.IsImagePullBackOff(&pod, image) {
-		return LogError(fmt.Sprintf("Back-off pulling image %s", image), nil, l)
+		l.V(DEBUGLEVEL).Info(fmt.Sprintf("Back-off pulling image %s", image))
+		return nil
 	}
-	l.V(int(zapcore.DebugLevel)).Info("job pod is ready")
+	l.V(int(DEBUGLEVEL)).Info("job pod is ready")
 	return nil
 }
 
-func WaitUntilJobPodIsRunning(ctx context.Context, clientset kubernetes.Interface, job *kbatch.Job, l logr.Logger) error {
-	if job == nil {
-		return errors.New("job cannot be nil")
+// waitUntilJobPodIsRunning will retry until the versionchecker pod it is running
+func waitUntilJobPodIsRunning(ctx context.Context, clientset kubernetes.Interface, jobName, jobNamespace string, labelSelector map[string]string, l logr.Logger) error {
+	if labelSelector == nil {
+		return errors.New("selector cannot be nil")
 	}
 	f := func() error {
-		return IsJobPodRunning(ctx, clientset, job, l)
+		return isJobPodRunning(ctx, clientset, jobName, jobNamespace, labelSelector, l)
 	}
 	b := backoff.NewExponentialBackOff()
 	b.MaxElapsedTime = 120 * time.Second
 	b.MaxInterval = 10 * time.Second
 	if err := backoff.Retry(f, b); err != nil {
-		return errors.Wrapf(err, "pod is not running for job: %s", job.Name)
+		return errors.Wrapf(err, "pod is not running for job: %s", jobName)
 	}
 	return nil
 }
+func reconcileJob(cluster *resource.Cluster, scheme *runtime.Scheme, r resource.ManagedResource, jobName string, log logr.Logger) error {
+	owner := cluster.Unwrap()
+	log.V(DEBUGLEVEL).Info(fmt.Sprintf("Reconcile jobName= %s", jobName))
+	_, err := (resource.Reconciler{
+		ManagedResource: r,
+		Builder: resource.JobBuilder{
+			Cluster:  cluster,
+			Selector: r.Labels.Selector(),
+			JobName:  jobName,
+		},
+		Owner:  owner,
+		Scheme: scheme,
+	}).Reconcile()
 
-func LogError(msg string, err error, l logr.Logger) error {
-	l.V(int(zapcore.DebugLevel)).Info(msg)
-	if err == nil {
-		return errors.New(msg)
+	if err != nil && kube.IgnoreNotFound(err) == nil {
+		err := errors.Wrap(err, "failed to reconcile job not found")
+		log.Error(err, "failed to reconcile job")
+		return err
+	} else if err != nil {
+		log.Error(err, "failed to reconcile job only err")
 	}
-	return errors.Wrapf(err, msg)
+	return nil
 }


### PR DESCRIPTION
The version checker was getting the job and occasionally the job was
returning selectors that are nil.

- Refactored version checker to use DEBUGLEVEL var and
remove unnecessary interruptions in the flow
- waiting for the job pod to run first and then gets the job
to cover the scenario where the get for the version checker
job that was previously created fails.

Closes: https://github.com/cockroachdb/cockroach-operator/issues/529

This is a copy of #584 