### PR TITLE
Add pvc check to decommission

### DIFF
--- a/e2e/decomission/decomission_test.go
+++ b/e2e/decomission/decomission_test.go
@@ -95,6 +95,7 @@ func TestDecommissionFunctionalityWithPrune(t *testing.T) {
 				testutil.RequireClusterToBeReadyEventuallyTimeout(t, sb, builder, 500*time.Second)
 				testutil.RequireDecommissionNode(t, sb, builder, 3)
 				testutil.RequireDatabaseToFunction(t, sb, builder)
+				//sb.Get()
 				t.Log("Done with decommision")
 			},
 		},


### PR DESCRIPTION
Added a check to make sure the PVC's are deleted or kept as expected. Also changed the decommission test cases to use the namespace. It was causing some requests like for PVCs to select across all namespaces and was finding extras. [cluster.Namespace()](https://github.com/cockroachdb/cockroach-operator/blob/master/pkg/testutil/require.go#L516) was always `nil`. We might want to check if this is causing issues in other testacases as well.

