### PR TITLE
Removing initcontainer when TLS is disabled

### DIFF
--- a/pkg/resource/statefulset.go
+++ b/pkg/resource/statefulset.go
@@ -198,11 +198,14 @@ func (b StatefulSetBuilder) makePodTemplate() corev1.PodTemplateSpec {
 				FSGroup:   ptr.Int64(1000581000),
 			},
 			TerminationGracePeriodSeconds: ptr.Int64(60),
-			InitContainers:                b.MakeInitContainers(),
 			Containers:                    b.MakeContainers(),
 			AutomountServiceAccountToken:  ptr.Bool(false),
 			ServiceAccountName:            "cockroach-database-sa",
 		},
+	}
+
+	if b.Spec().TLSEnabled {
+		pod.Spec.InitContainers = b.MakeInitContainers()
 	}
 
 	if utilfeature.DefaultMutableFeatureGate.Enabled(features.AffinityRules) {

--- a/pkg/resource/testdata/TestStatefulSetBuilder/default_insecure_statefulset.golden
+++ b/pkg/resource/testdata/TestStatefulSetBuilder/default_insecure_statefulset.golden
@@ -78,18 +78,6 @@ spec:
         volumeMounts:
         - mountPath: /cockroach/cockroach-data/
           name: datadir
-      initContainers:
-      - command:
-        - /bin/sh
-        - -c
-        - '>- cp -p /cockroach/cockroach-certs-prestage/..data/* /cockroach/cockroach-certs/ && chmod 700 /cockroach/cockroach-certs/*.key && chown 1000581000:1000581000 /cockroach/cockroach-certs/*.key'
-        image: cockroachdb/cockroach:v20.2.7
-        imagePullPolicy: IfNotPresent
-        name: db-init
-        resources: {}
-        securityContext:
-          allowPrivilegeEscalation: false
-          runAsUser: 0
       securityContext:
         fsGroup: 1000581000
         runAsUser: 1000581000

--- a/pkg/resource/testdata/TestStatefulSetBuilder/insecure_statefulset_cli_args.golden
+++ b/pkg/resource/testdata/TestStatefulSetBuilder/insecure_statefulset_cli_args.golden
@@ -90,18 +90,6 @@ spec:
         volumeMounts:
         - mountPath: /cockroach/cockroach-data/
           name: datadir
-      initContainers:
-      - command:
-        - /bin/sh
-        - -c
-        - '>- cp -p /cockroach/cockroach-certs-prestage/..data/* /cockroach/cockroach-certs/ && chmod 700 /cockroach/cockroach-certs/*.key && chown 1000581000:1000581000 /cockroach/cockroach-certs/*.key'
-        image: cockroachdb/cockroach:v20.2.7
-        imagePullPolicy: IfNotPresent
-        name: db-init
-        resources: {}
-        securityContext:
-          allowPrivilegeEscalation: false
-          runAsUser: 0
       securityContext:
         fsGroup: 1000581000
         runAsUser: 1000581000

--- a/pkg/resource/testdata/TestStatefulSetBuilder/insecure_statefulset_with_resources.golden
+++ b/pkg/resource/testdata/TestStatefulSetBuilder/insecure_statefulset_with_resources.golden
@@ -82,18 +82,6 @@ spec:
         volumeMounts:
         - mountPath: /cockroach/cockroach-data/
           name: datadir
-      initContainers:
-      - command:
-        - /bin/sh
-        - -c
-        - '>- cp -p /cockroach/cockroach-certs-prestage/..data/* /cockroach/cockroach-certs/ && chmod 700 /cockroach/cockroach-certs/*.key && chown 1000581000:1000581000 /cockroach/cockroach-certs/*.key'
-        image: cockroachdb/cockroach:v20.2.7
-        imagePullPolicy: IfNotPresent
-        name: db-init
-        resources: {}
-        securityContext:
-          allowPrivilegeEscalation: false
-          runAsUser: 0
       securityContext:
         fsGroup: 1000581000
         runAsUser: 1000581000


### PR DESCRIPTION
Fixing bug where the operator was adding the initcontainer
when TLS was disabled.