### PR TITLE
Add ability to pass extra params to openshift

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,7 @@ COCKROACH_DATABASE_VERSION=v20.2.5
 PULL_SECRET?=
 GCP_REGION?=
 BASE_DOMAIN?=
+EXTRA_KUBETEST2_PARAMS?=
 
 #
 # Unit Testing Targets
@@ -162,6 +163,7 @@ test/e2e/openshift:
 	     --gcp-region=$(GCP_REGION) \
 	     --base-domain=$(BASE_DOMAIN) \
 	     --pull-secret-file=$(PULL_SECRET) \
+	     $(EXTRA_KUBETEST2_PARAMS) \
 	     --up --down --test=exec -- make test/e2e/testrunner-openshift
 
 # This testrunner launchs the openshift packaging e2e test

--- a/e2e/kubetest2-openshift/README.md
+++ b/e2e/kubetest2-openshift/README.md
@@ -30,7 +30,7 @@ The flags that we are most concered about are:
    --pull-secret-file string          flag for the location of the pull secrete file downloaded from the RedHat site
    --sa-token string                  flag to set the path to the service account token
    --do-not-enable-services bool      flag to set to NOT enable services on the project
-   --do-not-delete-sa                 flag to set to NOT remove the service account
+   --do-not-delete-sa bool            flag to set to NOT remove the service account
 ```
 
 The `--base-domain` flag is set to the TLD domain that you want the `openshift-install` to use and must be hosted


### PR DESCRIPTION
With #651 merged, we can disable service account and service operations.
In order to do this, we would need to change the TeamCity configuration
and pass `--do-not-enable-services=true --do-not-delete-sa=true` as
`EXTRA_KUBETEST2_PARAMS`.