### PR TITLE
Add GitHub action to update CRDB versions

### DIFF
--- a/.github/workflows/update-crdb-versions.yaml
+++ b/.github/workflows/update-crdb-versions.yaml
@@ -1,0 +1,37 @@
+# Copyright 2021 The Cockroach Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+on:
+  schedule:
+     - cron: 0 0 * * *
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+
+name: Update CRDB versions
+jobs:
+  update:
+    name: Update crdb versions
+    runs-on: ubuntu-latest
+    steps:
+      - name: Update CRDB versions
+        uses: technote-space/create-pr-action@v2
+        with:
+          EXECUTE_COMMANDS: |
+            ./hack/update-crdb-versions.sh
+          COMMIT_MESSAGE: 'Update CRDB versions'
+          COMMIT_NAME: 'GitHub Actions'
+          COMMIT_EMAIL: 'dev-inf+github-cockroach-dev-inf@cockroachlabs.com'
+          PR_BRANCH_NAME: 'crdb-update-${PR_ID}'
+          PR_TITLE: 'Update CRDB versions'

--- a/hack/update-crdb-versions.sh
+++ b/hack/update-crdb-versions.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+
+# Copyright 2021 The Cockroach Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o nounset
+set -o pipefail
+
+
+# TODO(rail): we may need to add pagination handling in case we pass 500 versions
+# Use anonymous API to get the list of published images from the RedHat Catalog.
+URL="https://catalog.redhat.com/api/containers/v1/repositories/registry/registry.connect.redhat.com/repository/cockroachdb/cockroach/images?exclude=data.repositories.comparison.advisory_rpm_mapping,data.brew,data.cpe_ids,data.top_layer_id&page_size=500&page=0"
+
+
+cat > crdb-versions.yaml << EOF
+# Copyright 2021 The Cockroach Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Supported CockroachDB versions.
+#
+# This file contains a list of CockroachDB versions that are supported by the
+# operator. hack/crdbversions/main.go uses this list to generate various
+# manifests.
+# Please update this file when CockroachDB releases new versions.
+
+CrdbVersions:
+EOF
+
+# Skip unsupported versions and the latest tag
+for version in $(curl $URL | jq -r '.data[] .repositories[] .tags[] .name' | grep -v ^v19 | grep -v latest | grep -v ubi$ | sort --version-sort); do
+    echo "  - $version" >> crdb-versions.yaml
+done


### PR DESCRIPTION
Previously, we had to manually track CRDB releases and update the
corresponding file in this repo.

This patch uses the RedHat Catalog API to fetch all published CRDB
images and regenerate the `crdb-versions.yaml` file. If the file is
changed, the GitHub action would create a PR.

Example PR: https://github.com/rail/cockroach-operator/pull/3