### PR TITLE
Add affinity rules feature gate on job resource

### DIFF
--- a/pkg/resource/job.go
+++ b/pkg/resource/job.go
@@ -20,9 +20,11 @@ import (
 	"errors"
 	"fmt"
 
+	"github.com/cockroachdb/cockroach-operator/pkg/features"
 	"github.com/cockroachdb/cockroach-operator/pkg/kube"
 	"github.com/cockroachdb/cockroach-operator/pkg/labels"
 	"github.com/cockroachdb/cockroach-operator/pkg/ptr"
+	"github.com/cockroachdb/cockroach-operator/pkg/utilfeature"
 	kbatch "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -88,6 +90,10 @@ func (b JobBuilder) buildPodTemplate() corev1.PodTemplateSpec {
 			ServiceAccountName:            "cockroach-database-sa",
 			RestartPolicy:                 corev1.RestartPolicyNever,
 		},
+	}
+
+	if utilfeature.DefaultMutableFeatureGate.Enabled(features.AffinityRules) {
+		pod.Spec.Affinity = b.Spec().Affinity
 	}
 
 	secret := b.Spec().Image.PullSecret


### PR DESCRIPTION
This PR adds:
 - Feature gate check for affinity rules on job resource

Why:
- In testing the operator in a home lab setup (4 node k3s cluster; 3 of which are rasp pi) the version check job was not respecting the affinity rules and was getting scheduled on the control plan node. This caused issues as I'm running a custom build of cockroachdb for arm. Adding the feature gate check allows the v check container to be properly scheduled on one of the rasp pi worker nodes. 

Notes:
- I did try to add a test but ran into some issues with getting bazel to recognize the new test. Happy to continue looking into that but would love a nudge here and there on how to do that properly.
- I have tried my best to tear down the cluster and reinstall to make sure this is doing what I think it should. Mainly using `kubectl get pod <cockroach v check container> -o yaml` to confirm the affinity rules are specified. 
- I also recognize that my setup isn't currently supported so there may be reasons this change shouldn't be added. Looking forward to the conversation none the less.

Below is my operator.yaml

```
apiVersion: crdb.cockroachlabs.com/v1alpha1
kind: CrdbCluster
metadata:
  # this translates to the name of the statefulset that is created
  name: cockroachdb
spec:
  dataStore:
    pvc:
      spec:
        accessModes:
          - ReadWriteOnce
        resources:
          requests:
            storage: "60Gi"
        volumeMode: Filesystem
  resources:
    requests:
      #cpu: "2"
      memory: "1Gi"
    limits:
      #cpu: "2"
      memory: "1Gi"
  tlsEnabled: true
# You can set either a version of the db or a specific image name
# cockroachDBVersion: v21.1.5
  image:
    name: blong14/cockroachdb:v20.2.2
    pullPolicy: Always
  # nodes refers to the number of crdb pods that are created
  # via the statefulset 
  nodes: 3
  # affinity is a new API field that is behind a feature gate that is
  # disabled by default.  To enable please enable, see operator.yaml
  # The affinity field will accept any podSpec affinity rule.
  affinity:
    nodeAffinity:
      requiredDuringSchedulingIgnoredDuringExecution:
        nodeSelectorTerms:
        - matchExpressions:
          - key: kubernetes.io/hostname
            operator: In
            values:
            - worker-01
            - worker-02
            - worker-03
```