### PR TITLE
Implementing kubetest2-eks

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -65,6 +65,7 @@ filegroup(
         "//deploy/certified-metadata-bundle/cockroach-operator/latest/metadata:all-srcs",
         "//e2e/create:all-srcs",
         "//e2e/decomission:all-srcs",
+        "//e2e/kubetest2-eks:all-srcs",
         "//e2e/kubetest2-openshift:all-srcs",
         "//e2e/openshift:all-srcs",
         "//e2e/pvcresize:all-srcs",

--- a/e2e/kubetest2-eks/BUILD.bazel
+++ b/e2e/kubetest2-eks/BUILD.bazel
@@ -1,0 +1,35 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = ["main.go"],
+    importpath = "github.com/cockroachdb/cockroach-operator/e2e/kubetest2-eks",
+    visibility = ["//visibility:private"],
+    deps = [
+        "//e2e/kubetest2-eks/deployer:go_default_library",
+        "@io_k8s_sigs_kubetest2//pkg/app:go_default_library",
+    ],
+)
+
+go_binary(
+    name = "kubetest2-eks",
+    embed = [":go_default_library"],
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [
+        ":package-srcs",
+        "//e2e/kubetest2-eks/deployer:all-srcs",
+    ],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/e2e/kubetest2-eks/deployer/BUILD.bazel
+++ b/e2e/kubetest2-eks/deployer/BUILD.bazel
@@ -1,0 +1,35 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "build.go",
+        "deployer.go",
+        "down.go",
+        "dumplogs.go",
+        "up.go",
+    ],
+    importpath = "github.com/cockroachdb/cockroach-operator/e2e/kubetest2-eks/deployer",
+    visibility = ["//visibility:public"],
+    deps = [
+        "@com_github_octago_sflags//gen/gpflag:go_default_library",
+        "@com_github_spf13_pflag//:go_default_library",
+        "@io_k8s_klog_v2//:go_default_library",
+        "@io_k8s_sigs_kubetest2//pkg/process:go_default_library",
+        "@io_k8s_sigs_kubetest2//pkg/types:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/e2e/kubetest2-eks/deployer/build.go
+++ b/e2e/kubetest2-eks/deployer/build.go
@@ -1,0 +1,27 @@
+/*
+Copyright 2021 The Cockroach Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package deployer
+
+import "errors"
+
+// Build is used to deploy kubernetes to the cluster
+// and is not supported by this deployer. It is required
+// by the kubetest2 interface and cannot be used to deploy
+// a built version of aws.
+func (d *deployer) Build() error {
+	return errors.New("this deployer does not support building and deploying Kubernetes")
+}

--- a/e2e/kubetest2-eks/deployer/deployer.go
+++ b/e2e/kubetest2-eks/deployer/deployer.go
@@ -1,0 +1,100 @@
+/*
+Copyright 2021 The Cockroach Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package deployer
+
+import (
+	"flag"
+	"os"
+	"path/filepath"
+	"sync"
+
+	"github.com/octago/sflags/gen/gpflag"
+	"github.com/spf13/pflag"
+
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/kubetest2/pkg/types"
+)
+
+// Name is the name of the deployer
+const Name = "eks"
+
+// deployer is the base struct that
+// defines flags for this deployer.
+type deployer struct {
+	// generic parts
+	commonOptions types.Options
+	// doInit helps to make sure the initialization is performed only once
+	doInit sync.Once
+
+	// Todo I am not certian we need KubeconfigPath
+
+	KubeconfigPath string `flag:"kubeconfig" desc:"flag for the kubeconfig path"`
+
+	ClusterName string `flag:"cluster-name" desc:"flag for the cluster name"`
+
+	InstanceType string `flag:"instance-type" desc:"flag for the aws instance type name"`
+	NumOfNodes   string `flag:"node-count" desc:"flag for the number of nodes"`
+}
+
+// assert that New implements types.NewDeployer
+var _ types.NewDeployer = New
+
+// assert that deployer implements types.Deployer
+var _ types.DeployerWithKubeconfig = &deployer{}
+
+// Provider returns the name of the deployer
+func (d *deployer) Provider() string {
+	return Name
+}
+
+// New implements deployer.New for EKS
+func New(opts types.Options) (types.Deployer, *pflag.FlagSet) {
+
+	// create a deployer object and set fields that are not flag controlled
+	d := &deployer{
+		commonOptions: opts,
+	}
+
+	// register flags
+	fs := bindFlags(d)
+
+	klog.InitFlags(nil)
+	fs.AddGoFlagSet(flag.CommandLine)
+	return d, fs
+}
+
+func bindFlags(d *deployer) *pflag.FlagSet {
+	flags, err := gpflag.Parse(d)
+	if err != nil {
+		klog.Fatalf("unable to generate flags from deployer: %v", err)
+		return nil
+	}
+	return flags
+}
+
+// Kubeconfig returns the path to the kubeconfig.
+func (d *deployer) Kubeconfig() (string, error) {
+
+	if d.KubeconfigPath != "" {
+		return d.KubeconfigPath, nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".kube", "config"), nil
+}

--- a/e2e/kubetest2-eks/deployer/down.go
+++ b/e2e/kubetest2-eks/deployer/down.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2021 The Cockroach Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package deployer
+
+import (
+	"errors"
+	"os"
+
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/kubetest2/pkg/process"
+)
+
+// Down destroys a eks cluster
+func (d *deployer) Down() error {
+	if d.ClusterName == "" {
+		return errors.New("flag cluster-name is not set")
+	}
+
+	file, err := getClusterFile(d.ClusterName)
+	if err != nil {
+		klog.Fatalf("unable to get yaml cluster file name %v", err)
+		return err
+	}
+
+	args := []string{
+		"eks", "delete", "cluster",
+		"-p", file,
+		"--enable-prompt=false",
+	}
+
+	// we want to see the output so use process.ExecJUnit
+	// use the aws-k8s-tester binary to destroy the cluster
+	if err := process.ExecJUnit("aws-k8s-tester", args, os.Environ()); err != nil {
+		klog.Fatalf("unable to destroy eks cluster: %v", err)
+		return err
+	}
+
+	return nil
+}

--- a/e2e/kubetest2-eks/deployer/dumplogs.go
+++ b/e2e/kubetest2-eks/deployer/dumplogs.go
@@ -1,0 +1,25 @@
+/*
+Copyright 2021 The Cockroach Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package deployer
+
+import "errors"
+
+// DumpClusterLogs is required by the kubetest2 interface
+// but is not currently supported.
+func (d *deployer) DumpClusterLogs() error {
+	return errors.New("this deployer does not support dumping logs from the eks cluster")
+}

--- a/e2e/kubetest2-eks/deployer/up.go
+++ b/e2e/kubetest2-eks/deployer/up.go
@@ -1,0 +1,103 @@
+/*
+Copyright 2021 The Cockroach Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package deployer
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"errors"
+
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/kubetest2/pkg/process"
+)
+
+var home = os.Getenv("HOME")
+
+// all of the tests that we disable that aws-k8s-tester will run
+var disable = []string{
+	"AWS_K8S_TESTER_EKS_ADD_ON_KUBERNETES_DASHBOARD_ENABLE",
+	"AWS_K8S_TESTER_EKS_ADD_ON_PROMETHEUS_GRAFANA_ENABLE",
+	"AWS_K8S_TESTER_EKS_ADD_ON_NLB_HELLO_WORLD_ENABLE",
+	"AWS_K8S_TESTER_EKS_ADD_ON_NLB_GUESTBOOK_ENABLE",
+	"AWS_K8S_TESTER_EKS_ADD_ON_ALB_2048_ENABLE",
+	"AWS_K8S_TESTER_EKS_ADD_ON_JOBS_PI_ENABLE",
+	"AWS_K8S_TESTER_EKS_ADD_ON_JOBS_ECHO_ENABLE",
+	"AWS_K8S_TESTER_EKS_ADD_ON_CRON_JOBS_ENABLE",
+	"AWS_K8S_TESTER_EKS_ADD_ON_CSRS_LOCAL_ENABLE",
+	"AWS_K8S_TESTER_EKS_ADD_ON_CONFIGMAPS_LOCAL_ENABLE",
+	"AWS_K8S_TESTER_EKS_ADD_ON_SECRETS_LOCAL_ENABLE",
+	"AWS_K8S_TESTER_EKS_ADD_ON_WORDPRESS_ENABLE",
+	"AWS_K8S_TESTER_EKS_ADD_ON_JUPYTER_HUB_ENABLE",
+	"AWS_K8S_TESTER_EKS_ADD_ON_CUDA_VECTOR_ADD_ENABLE",
+	"AWS_K8S_TESTER_EKS_ADD_ON_CLUSTER_LOADER_LOCAL_ENABLE",
+	"AWS_K8S_TESTER_EKS_ADD_ON_HOLLOW_NODES_LOCAL_ENABLE",
+	"AWS_K8S_TESTER_EKS_ADD_ON_STRESSER_LOCAL_ENABLE",
+}
+
+// Up creates an EKS cluster.
+func (d *deployer) Up() error {
+
+	// disable the various tests
+	for _, e := range disable {
+		os.Setenv(e, "false")
+	}
+
+	// enable node groups so a ASG is created, and we have
+	// worker nodes
+	os.Setenv("AWS_K8S_TESTER_EKS_ADD_ON_NODE_GROUPS_ENABLE", "true")
+
+	if d.ClusterName == "" {
+		return errors.New("flag cluster-name is not set")
+	}
+
+	file, err := getClusterFile(d.ClusterName)
+	if err != nil {
+		klog.Fatalf("unable to get yaml cluster file name %v", err)
+		return err
+	}
+
+	args := []string{
+		"eks", "create", "cluster",
+		"-p", file,
+		"--enable-prompt=false",
+	}
+
+	// we want to see the output so use process.ExecJUnit
+	if err := process.ExecJUnit("aws-k8s-tester", args, os.Environ()); err != nil {
+		klog.Fatalf("unable to create eks cluster %v", err)
+		return err
+	}
+
+	return nil
+}
+
+// IsUp is required by the kubetest2 interface, but the
+// eks binary does this as part of the cluster creation.
+func (d *deployer) IsUp() (up bool, err error) {
+	return true, nil
+}
+
+func getClusterFile(clusterName string) (string, error) {
+	if clusterName == "" {
+		return "", errors.New("flag cluster-name is not set")
+	}
+
+	clusterYaml := fmt.Sprintf("%s-eks.yaml", clusterName)
+	return filepath.Join(os.TempDir(), clusterYaml), nil
+}

--- a/e2e/kubetest2-eks/main.go
+++ b/e2e/kubetest2-eks/main.go
@@ -1,0 +1,29 @@
+/*
+Copyright 2021 The Cockroach Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+// Main entry point for building an running kubetest2-eks
+
+import (
+	"sigs.k8s.io/kubetest2/pkg/app"
+
+	"github.com/cockroachdb/cockroach-operator/e2e/kubetest2-eks/deployer"
+)
+
+func main() {
+	app.Main(deployer.Name, deployer.New)
+}

--- a/hack/bin/BUILD.bazel
+++ b/hack/bin/BUILD.bazel
@@ -236,6 +236,17 @@ genrule(
     visibility = ["//visibility:public"],
 )
 
+genrule(
+    name = "fetch-aws-k8s-tester",
+    srcs = select({
+        ":darwin": ["@aws-k8s-tester-darwin//file"],
+        ":k8": ["@aws-k8s-tester-linux//file"],
+    }),
+    outs = ["aws-k8s-tester"],
+    cmd = "cp $(SRCS) $@",
+    visibility = ["//visibility:public"],
+)
+
 config_setting(
     name = "k8",
     values = {"host_cpu": "k8"},

--- a/hack/bin/deps.bzl
+++ b/hack/bin/deps.bzl
@@ -34,6 +34,7 @@ def install():
     install_opm()
     install_crdb()
     install_openshift()
+    install_aws_kubetest2()
 
     # Install golang.org/x/build as kubernetes/repo-infra requires it for the
     # build-tar bazel target.
@@ -458,4 +459,17 @@ filegroup(
 """,
    )
 
-
+# fetch binaries for aws kubetest2
+def install_aws_kubetest2():
+    http_file(
+        name = "aws-k8s-tester-linux",
+        executable = 1,
+        sha256 = "f6a95feef94ab9a96145fff812eeebae14f974edfead98046351f3098808df54",
+        urls = ["https://github.com/aws/aws-k8s-tester/releases/download/v1.6.1/aws-k8s-tester-v1.6.1-linux-amd64"],
+    )
+    http_file(
+        name = "aws-k8s-tester-darwin",
+        executable = 1,
+        sha256 = "a724288e8f2b87df89c711ed59fa2a09db5ad2b50a35cb3039fa610408b99b32",
+        urls = ["https://github.com/aws/aws-k8s-tester/releases/download/v1.6.1/aws-k8s-tester-v1.6.1-darwin-amd64"],
+    )

--- a/hack/eks-storageclass.yaml
+++ b/hack/eks-storageclass.yaml
@@ -1,0 +1,24 @@
+# Copyright 2021 The Cockroach Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+kind: StorageClass
+apiVersion: storage.k8s.io/v1
+metadata:
+  name: standard
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
+provisioner: kubernetes.io/aws-ebs
+parameters:
+  type: gp2
+  fsType: ext4


### PR DESCRIPTION
Using aws-k8s-tester and kubetest2 to create an eks cluster,
run the e2e tests and then tear down the cluster.