### PR TITLE
Add kuberecord to enable VCR for K8s API calls

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -87,6 +87,7 @@ filegroup(
         "//pkg/features:all-srcs",
         "//pkg/healthchecker:all-srcs",
         "//pkg/kube:all-srcs",
+        "//pkg/kuberecord:all-srcs",
         "//pkg/labels:all-srcs",
         "//pkg/ptr:all-srcs",
         "//pkg/resource:all-srcs",

--- a/go.mod
+++ b/go.mod
@@ -8,13 +8,13 @@ require (
 	github.com/banzaicloud/k8s-objectmatcher v1.3.2
 	github.com/cenkalti/backoff v2.2.1+incompatible
 	github.com/cockroachdb/errors v1.8.0
+	github.com/dnaeon/go-vcr v1.0.1
 	github.com/dustin/go-humanize v1.0.0
 	github.com/go-logr/logr v0.3.0
 	github.com/go-logr/zapr v0.2.0
 	github.com/google/go-cmp v0.5.4
 	github.com/gosimple/slug v1.9.0
 	github.com/jackc/pgx/v4 v4.9.0
-	github.com/lib/pq v1.3.0
 	github.com/octago/sflags v0.2.0
 	github.com/onsi/ginkgo v1.14.1
 	github.com/onsi/gomega v1.10.3

--- a/go.sum
+++ b/go.sum
@@ -304,6 +304,7 @@ github.com/dgryski/go-farm v0.0.0-20190423205320-6a90982ecee2/go.mod h1:SqUrOPUn
 github.com/dgryski/go-sip13 v0.0.0-20181026042036-e10d5fee7954/go.mod h1:vAd38F8PWV+bWy6jNmig1y/TA+kYO4g3RSRF0IAv0no=
 github.com/dimchansky/utfbom v1.1.0/go.mod h1:rO41eb7gLfo8SF1jd9F8HplJm1Fewwi4mQvIirEdv+8=
 github.com/djherbis/atime v1.0.0/go.mod h1:5W+KBIuTwVGcqjIfaTwt+KSYX1o6uep8dtevevQP/f8=
+github.com/dnaeon/go-vcr v1.0.1 h1:r8L/HqC0Hje5AXMu1ooW8oyQyOFv4GxqpL0nRP7SLLY=
 github.com/dnaeon/go-vcr v1.0.1/go.mod h1:aBB1+wY4s93YsC3HHjMBMrwTj2R9FHDzUr9KyGc8n1E=
 github.com/docker/cli v0.0.0-20191017083524-a8ff7f821017/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=
 github.com/docker/cli v0.0.0-20200130152716-5d0cf8839492/go.mod h1:JLrzqnKDaYBop7H2jaqPtU4hHvMKP+vjCwu2uszcLI8=

--- a/pkg/kuberecord/BUILD.bazel
+++ b/pkg/kuberecord/BUILD.bazel
@@ -1,0 +1,61 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "cassettes.go",
+        "mode.go",
+        "recorder.go",
+    ],
+    importpath = "github.com/cockroachdb/cockroach-operator/pkg/kuberecord",
+    visibility = ["//visibility:public"],
+    deps = [
+        "@com_github_cenkalti_backoff//:go_default_library",
+        "@com_github_cockroachdb_errors//:go_default_library",
+        "@com_github_dnaeon_go_vcr//cassette:go_default_library",
+        "@com_github_dnaeon_go_vcr//recorder:go_default_library",
+        "@com_github_stretchr_testify//require:go_default_library",
+        "@io_k8s_client_go//rest:go_default_library",
+    ],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = [
+        "cassettes_test.go",
+        "mode_test.go",
+        "recorder_test.go",
+    ],
+    data = [
+        "//hack/bin:etcd",
+        "//hack/bin:kube-apiserver",
+        "//hack/bin:kubectl",
+    ] + glob([":testdata/**"]),
+    deps = [
+        ":go_default_library",
+        "//pkg/testutil:go_default_library",
+        "//pkg/testutil/env:go_default_library",
+        "@com_github_cenkalti_backoff//:go_default_library",
+        "@com_github_dnaeon_go_vcr//cassette:go_default_library",
+        "@com_github_dnaeon_go_vcr//recorder:go_default_library",
+        "@com_github_stretchr_testify//require:go_default_library",
+        "@io_k8s_api//core/v1:go_default_library",
+        "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
+        "@io_k8s_sigs_controller_runtime//pkg/client:go_default_library",
+        "@io_k8s_sigs_controller_runtime//pkg/envtest:go_default_library",
+    ],
+)

--- a/pkg/kuberecord/cassettes.go
+++ b/pkg/kuberecord/cassettes.go
@@ -1,0 +1,82 @@
+/*
+Copyright 2021 The Cockroach Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kuberecord
+
+import (
+	"net/http"
+	"net/url"
+
+	"github.com/dnaeon/go-vcr/cassette"
+)
+
+const (
+	// fingerPrintHeader is the header that checksums of outgoing requests are injected into. In replay mode, the
+	// appropriate responses are found by matching on this header.
+	fingerPrintHeader = "X-Kuberecord-Fingerprint"
+
+	// kubernetesHost is a replacement for the kubernetes' API hostname. The hostname may change across test runs but that
+	// doesn't invalidate our interactions. The recording library we use includes the HTTP Host header as a part of its
+	// matching logic. Because of that, we need to have stable hostnames in our recordings. The easiest way to do that is
+	// to simply rewrite the header. We don't care about the real name of whatever Kubernetes API server we're talking to.
+	kubernetesHost = "KUBERNETES"
+	schemeHTTPS    = "HTTPS"
+)
+
+var (
+	prunableRequestHeaders  = []string{"Authorization"}
+	prunableResponseHeaders = []string{"Date", "Audit-Id"}
+)
+
+// Filter modifies the Interaction before saving it to disk. This is necessary to normalize URLs and ensure that flakey
+// and/or sensitive information isn't stored.
+func Filter(i *cassette.Interaction) error {
+	u, err := url.Parse(i.URL)
+	if err != nil {
+		return err
+	}
+
+	// Hostnames and schemes change across kubernetes clusters. Force all URLS to look like HTTPS://KUBERNETES/... to
+	// make matching stable across different kubernetes clusters.
+	u.Host = kubernetesHost
+	u.Scheme = schemeHTTPS
+	i.URL = u.String()
+
+	// Sanitize outgoing requests. We don't want to accidentally check in credentials.
+	for _, header := range prunableRequestHeaders {
+		i.Request.Headers.Del(header)
+	}
+
+	// Remove any non-deterministic headers to reduce the churn of our records.
+	for _, header := range prunableResponseHeaders {
+		i.Response.Headers.Del(header)
+	}
+
+	return nil
+}
+
+// Matcher returns true when the incoming request matches a recorded interactions method, URL, and custom fingerprint
+// header.
+func Matcher(r *http.Request, i cassette.Request) bool {
+	// Force all URLS to looks like https://KUBERNETES/... to make matching stable across different kubernetes clusters.
+	// Hostnames change across kubernetes clusters and the empty rest.Config handed back in replay mode won't use HTTPS
+	// unless it is provided with a TLS cert. Overridding the scheme here happens to be easier and just as affective.
+	r.URL.Host = kubernetesHost
+	r.URL.Scheme = schemeHTTPS
+
+	// Method, URL, and custom fingerprint header must match.
+	return cassette.DefaultMatcher(r, i) && r.Header.Get(fingerPrintHeader) == i.Headers.Get(fingerPrintHeader)
+}

--- a/pkg/kuberecord/cassettes_test.go
+++ b/pkg/kuberecord/cassettes_test.go
@@ -1,0 +1,114 @@
+/*
+Copyright 2021 The Cockroach Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kuberecord_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	. "github.com/cockroachdb/cockroach-operator/pkg/kuberecord"
+	"github.com/dnaeon/go-vcr/cassette"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFilter(t *testing.T) {
+	interaction := &cassette.Interaction{
+		Request: cassette.Request{
+			Method: "GET",
+			URL:    "http://localhost:8080/foo?bar=baz",
+			Headers: http.Header{
+				// Authorization header will be removed
+				"Authorization": []string{"Bearer bogus-token"},
+				"Accept":        []string{"application/json"},
+			},
+		},
+		Response: cassette.Response{
+			Headers: http.Header{
+				// Date and Audit-Id headers not recorded
+				"Date":           []string{"2020-08-17T00.00.000Z"},
+				"Audit-Id":       []string{"12345abcde"},
+				"X-Custom-Value": []string{"Custom Value"},
+			},
+		},
+	}
+
+	require.Nil(t, Filter(interaction))
+	require.Equal(t, "HTTPS://KUBERNETES/foo?bar=baz", interaction.Request.URL)
+	require.Empty(t, interaction.Request.Headers.Get("Authorization"))
+	require.Equal(t, "application/json", interaction.Request.Headers.Get("Accept"))
+
+	require.Empty(t, interaction.Response.Headers.Get("Date"))
+	require.Empty(t, interaction.Response.Headers.Get("Audit-Id"))
+	require.Equal(t, "Custom Value", interaction.Response.Headers.Get("X-Custom-Value"))
+}
+
+func TestMatcher(t *testing.T) {
+	fpHeader := "X-Kuberecord-Fingerprint"
+	makeReq := func(method, url, fp string) *http.Request {
+		req := httptest.NewRequest(method, url, nil)
+		req.Header.Set(fpHeader, fp)
+		return req
+	}
+
+	makeCassette := func(method, url, fp string) cassette.Request {
+		return cassette.Request{
+			Method:  method,
+			URL:     url,
+			Headers: http.Header{fpHeader: []string{fp}},
+		}
+	}
+
+	tests := []struct {
+		name     string
+		req      *http.Request
+		cassette cassette.Request
+		pass     bool
+	}{
+		{
+			name:     "perfect match",
+			req:      makeReq(http.MethodPost, "HTTPS://KUBERNETES", "some-sha"),
+			cassette: makeCassette(http.MethodPost, "HTTPS://KUBERNETES", "some-sha"),
+			pass:     true,
+		},
+		{
+			name:     "fuzzy match with different URLs",
+			req:      makeReq(http.MethodPost, "https://localhost:8080/test", "some-sha"),
+			cassette: makeCassette(http.MethodPost, "HTTPS://KUBERNETES/test", "some-sha"),
+			pass:     true,
+		},
+		{
+			name:     "missing fingerprint",
+			req:      makeReq(http.MethodPost, "https://localhost:8080/test", ""),
+			cassette: makeCassette(http.MethodPost, "HTTPS://KUBERNETES/test", "some-sha"),
+		},
+		{
+			name:     "mismatched fingerprint",
+			req:      makeReq(http.MethodPost, "https://localhost:8080/test", "some-other-sha"),
+			cassette: makeCassette(http.MethodPost, "HTTPS://KUBERNETES/test", "some-sha"),
+		},
+		{
+			name:     "mismatched URL",
+			req:      makeReq(http.MethodPost, "https://localhost:8080/test", "some-sha"),
+			cassette: makeCassette(http.MethodPost, "http://KUBERNETES/test", "some-sha"),
+		},
+	}
+
+	for _, tt := range tests {
+		require.Equal(t, tt.pass, Matcher(tt.req, tt.cassette), tt.name)
+	}
+}

--- a/pkg/kuberecord/mode.go
+++ b/pkg/kuberecord/mode.go
@@ -1,0 +1,98 @@
+/*
+Copyright 2021 The Cockroach Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kuberecord
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/cenkalti/backoff"
+	"github.com/dnaeon/go-vcr/recorder"
+)
+
+const (
+	// ModeReplaying will return a new *rest.Config that will instead generate HTTP responses from a YAML file on disk. No
+	// network calls will be made in this mode.
+	ModeReplaying = recorder.ModeReplaying
+	// ModeRecording will inject fingerprinted headers into all requests and record the resulting request and response to
+	// disk for future playback.
+	ModeRecording = recorder.ModeRecording
+	// ModeDisabled will disable both recording and replaying. Recorder will No-op in this mode.
+	ModeDisabled = recorder.ModeDisabled
+)
+
+var modeString = flag.String(
+	"kuberecord",
+	"replay",
+	"sets the global mode for kuberecord; valid values are disabled, record, and replay",
+)
+
+// Mode returns the globally configured recordMode for kuberecord based on the -kuberecord CLI flag and the KUBERECORD
+// environment variable. If an unexpected value is encountered, Mode will panic.
+//
+// Valid values are "", record, replay, disable, and disabled.
+func Mode() recorder.Mode {
+	// Use environment variable if it exists, else fall back to flag.
+	mode, ok := os.LookupEnv("KUBERECORD")
+	if !ok {
+		mode = *modeString
+	}
+
+	switch mode {
+	case "record", "":
+		return ModeRecording
+	case "replay":
+		return ModeReplaying
+	case "disabled", "disable":
+		return ModeDisabled
+	default:
+		panic(fmt.Sprintf("unknown mode: %s", mode))
+	}
+}
+
+// IsEnabled is a helper method that returns true if Mode() is not disabled.
+func IsEnabled() bool {
+	return Mode() != ModeDisabled
+}
+
+// MaxBackOffInterval is a convenience method that returns the amount of time that backoff logic in tests should sleep
+// between polling attempts (e.g. to see if a K8s resource is ready). In ModeReplaying, this function returns 0, so that
+// replays will run as fast as possible. Otherwise, it returns the specified default value.
+func MaxBackOffInterval(defaultVal time.Duration) time.Duration {
+	if Mode() == ModeReplaying {
+		return 0
+	}
+	return defaultVal
+}
+
+// BackOff is a convenience method meant to be used with kube.Options.BackOff.  In ModeReplaying, a backoff function
+// that does not ever sleep is returned.  Otherwise, nil is returned, indicating that the default backoff option should
+// be used.
+func BackOff() func() backoff.BackOff {
+	if Mode() == ModeReplaying {
+		return zeroBackOffFunc
+	}
+	return nil
+}
+
+// backoff.ZeroBackOff is thread-safe, so return global instance.
+var zeroBackOff = &backoff.ZeroBackOff{}
+var zeroBackOffFunc = func() backoff.BackOff {
+	return zeroBackOff
+}

--- a/pkg/kuberecord/mode_test.go
+++ b/pkg/kuberecord/mode_test.go
@@ -1,0 +1,130 @@
+/*
+Copyright 2021 The Cockroach Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kuberecord_test
+
+import (
+	"flag"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/cenkalti/backoff"
+	. "github.com/cockroachdb/cockroach-operator/pkg/kuberecord"
+	"github.com/cockroachdb/cockroach-operator/pkg/testutil"
+	"github.com/dnaeon/go-vcr/recorder"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMode(t *testing.T) {
+	tests := []struct {
+		name string
+		arg  string
+		env  string
+		exp  recorder.Mode
+	}{
+		{name: "neither flag nor env set", exp: ModeReplaying},
+		{name: "flag is set to record", arg: "record", exp: ModeRecording},
+		{name: "flag is set to replay", arg: "replay", exp: ModeReplaying},
+		{name: "flag is set to disabled", arg: "disabled", exp: ModeDisabled},
+		{name: "env is set to record", env: "record", exp: ModeRecording},
+		{name: "env is set to replay", env: "replay", exp: ModeReplaying},
+		{name: "env is set to disabled", env: "disabled", exp: ModeDisabled},
+		{name: "both are set", arg: "record", env: "replay", exp: ModeReplaying},
+	}
+
+	for _, tt := range tests {
+		env := map[string]string{}
+		if tt.env != "" {
+			env["KUBERECORD"] = tt.env
+		}
+
+		testutil.WithEnv(env, func() {
+			if tt.arg != "" {
+				defer setFlag(tt.arg)()
+			}
+
+			require.Equal(t, tt.exp, Mode(), tt.name)
+		})
+	}
+
+	t.Run("invalid values", func(t *testing.T) {
+		require.Panics(t, func() {
+			testutil.WithEnv(map[string]string{"KUBERECORD": "unknown"}, func() {
+				Mode()
+			})
+		})
+	})
+}
+
+func TestIsEnabled(t *testing.T) {
+	tests := map[string]bool{
+		"record":   true,
+		"replay":   true,
+		"disabled": false,
+	}
+
+	for env, res := range tests {
+		testutil.WithEnv(map[string]string{"KUBERECORD": env}, func() {
+			require.Equal(t, res, IsEnabled())
+		})
+	}
+}
+
+func TestMaxBackOffInterval(t *testing.T) {
+	tests := map[string]time.Duration{
+		"record":   10,
+		"replay":   0,
+		"disabled": 10,
+	}
+
+	for env, dur := range tests {
+		testutil.WithEnv(map[string]string{"KUBERECORD": env}, func() {
+			require.Equal(t, dur, MaxBackOffInterval(10), env)
+		})
+	}
+}
+
+func TestBackoff(t *testing.T) {
+	tests := map[string]backoff.BackOff{
+		"record":   nil,
+		"replay":   new(backoff.ZeroBackOff),
+		"disabled": nil,
+	}
+
+	for env, expT := range tests {
+		testutil.WithEnv(map[string]string{"KUBERECORD": env}, func() {
+			fn := BackOff()
+			if expT == nil {
+				require.Nil(t, fn)
+				return
+			}
+
+			require.IsType(t, expT, fn())
+		})
+	}
+}
+
+func setFlag(v string) func() {
+	oldArgs := os.Args
+	os.Args = append(os.Args, "-kuberecord", v)
+	flag.Parse()
+
+	return func() {
+		os.Args = oldArgs
+		flag.Parse()
+	}
+}

--- a/pkg/kuberecord/recorder.go
+++ b/pkg/kuberecord/recorder.go
@@ -1,0 +1,219 @@
+/*
+Copyright 2021 The Cockroach Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package kuberecord provides record and playback functionality for testing Kubernetes calls. Think VCR, but
+// specifically for K8s.
+package kuberecord
+
+import (
+	"bytes"
+	"crypto/sha1"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/cockroachdb/errors"
+	"github.com/dnaeon/go-vcr/cassette"
+	"github.com/dnaeon/go-vcr/recorder"
+	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/rest"
+)
+
+const (
+	// when replaying, bump rate limit params
+	replayQueriesPerSecond = 10000
+	replayBurst            = 100000000
+)
+
+// Option defines a an option for running a Recorder.
+type Option interface {
+	apply(*options)
+}
+
+type options struct {
+	name        string
+	mode        recorder.Mode
+	cassetteDir string
+}
+
+type optFunc func(*options)
+
+func (f optFunc) apply(o *options) { f(o) }
+
+// WithName sets the recording name for the cassette.
+func WithName(name string) Option {
+	return optFunc(func(o *options) { o.name = name })
+}
+
+// WithCassetteDir sets the directory in which to store recorded interactions.
+func WithCassetteDir(path string) Option {
+	return optFunc(func(o *options) { o.cassetteDir = path })
+}
+
+// WithMode sets the playback mode to use (e.g. ModeReplaying).
+func WithMode(mode recorder.Mode) Option {
+	return optFunc(func(o *options) { o.mode = mode })
+}
+
+// Recorder wraps and returns a *rest.Config according the mode returned by Mode.
+//
+// In ModeDisabled, restCfg is returned unmodified. In ModeRecording, all HTTP traffic will be recorded and written to
+// a YAML file when the test is cleaned up. In ModeReplaying, a YAML file will be loaded from disk and all responses
+// will be served from there. If a request is not found the test will panic.
+//
+// YAML files are (by default) written/read to/from testdata/<test name>.vcr.yaml.
+//
+// In record mode, the recorder hashes the body of every HTTP request and adds a header with the checksum. In replay
+// mode, the recorder looks up the appropriate response to serve using that checksum.
+//
+// All recorded interactions must be deterministic in order for playback mode to work. For tests that use random values,
+// consider setting a constant seed.  For more complicated situations like key generation, consider writing a
+// deterministic implementation of the relevant interfaces. If one or more requests is removed from an interaction, a
+// new recording will not need to be generated. Failures will only occur when unexpected requests occur.
+//
+// Recorder is not a replacement for test assertions. It is a tool that allows Kubernetes tests run quickly within a
+// unittest framework. Test should still make assertions about the end state of a cluster and the healthiness of the
+// services running in it. If a cluster is going to be reused in a test, it is recommended to make assertions about the
+// environment ahead before the test runs. For example, assert that the namespace the test is running does not exist
+// before it is created to ensure no previous data is leaked. Replayed interactions will playback just fine but this
+// will ensure that future recordings don't run on an unclean environment.
+//
+// Most test cases should follow the following template:
+//       var restCfg *rest.Config
+//       if kuberecord.Mode() != kuberecorder.ModeReplaying {
+//               restCfg = LoadOrCreateARealRestConfig()
+//       }
+//       restCfg = Recorder(t, restCfg)
+//       // Make initial  assertions about the environment
+//       AssertNamespaceDoesntExist(t, restCfg)
+//       // Run your tests and assertions
+//       // Cleanup the cluster, ideally back to the initial state.
+func Recorder(t *testing.T, cfg *rest.Config, opts ...Option) *rest.Config {
+	o := &options{
+		name:        t.Name(),
+		mode:        Mode(),
+		cassetteDir: "testdata",
+	}
+
+	for _, opt := range opts {
+		opt.apply(o)
+	}
+
+	// no-op if kuberecord is disabled
+	if o.mode == ModeDisabled {
+		return cfg
+	}
+
+	return wrapConfig(t, cloneConfig(cfg, o.mode), o)
+}
+
+func cloneConfig(cfg *rest.Config, mode recorder.Mode) *rest.Config {
+	if mode == ModeReplaying {
+		// When replaying disable any rate limiting that's built into the rest.Config to ensure tests run as fast as
+		// possible.  Don't inherit any values from the original restCfg as we don't need them and it might be nil or empty.
+		return &rest.Config{QPS: replayQueriesPerSecond, Burst: replayBurst}
+	}
+
+	// Config.Wrap modifies the Config.WrapTransport field, so make a shallow clone.
+	clone := *cfg
+	return &clone
+}
+
+func wrapConfig(t *testing.T, cfg *rest.Config, o *options) *rest.Config {
+	// Share the same mutex and underlying recorder no matter how many times the returned rest.Config instance is used
+	// (e.g. kube.Ctl vs. ClientSet). Each time the rest.Config is used to establish a new K8s connection, Wrap will be
+	// called. All requests should be recorded into a single file, regardless of which of those K8s connections is used.
+	var mut sync.Mutex
+	var rec *recorder.Recorder
+
+	cfg.Wrap(func(rt http.RoundTripper) http.RoundTripper {
+		mut.Lock()
+		defer mut.Unlock()
+
+		// Initialize our recorder if it has not yet been initialized.
+		var err error
+		if rec == nil {
+			rec, err = recorder.NewAsMode(filepath.Join(o.cassetteDir, o.name+".vcr"), o.mode, rt)
+			require.NoError(t, err)
+
+			t.Cleanup(func() { require.NoError(t, rec.Stop()) })
+
+			rec.AddFilter(Filter)
+			rec.SetMatcher(Matcher)
+		}
+
+		// Ensure that all our requests will be stamped with a checksum for match _before_ they make it into the recorder.
+		return &kubeRecorder{mut: &mut, rec: rec, rt: rt}
+	})
+
+	return cfg
+}
+
+type kubeRecorder struct {
+	mut *sync.Mutex
+	rec *recorder.Recorder
+	rt  http.RoundTripper
+}
+
+func (f *kubeRecorder) RoundTrip(r *http.Request) (*http.Response, error) {
+	f.mut.Lock()
+	defer f.mut.Unlock()
+
+	// Swap in the recorder's underlying transport, since different kubeRecorder instances can have different transports,
+	// even though all of them use the same recorder.
+	f.rec.SetTransport(f.rt)
+
+	var body []byte
+	hasher := sha1.New()
+
+	var err error
+	if r.Body != nil {
+		body, err = ioutil.ReadAll(r.Body)
+		if err != nil {
+			return nil, err
+		}
+
+		// Reset the body to something usable
+		r.Body = ioutil.NopCloser(bytes.NewBuffer(body))
+
+		if _, err := hasher.Write(body); err != nil {
+			// "It never returns an error."
+			// - https://golang.org/pkg/hash/#Hash
+			panic(err)
+		}
+	}
+
+	r.Header[fingerPrintHeader] = []string{fmt.Sprintf("%x", hasher.Sum(nil))}
+
+	resp, err := f.rec.RoundTrip(r)
+
+	if errors.Is(err, cassette.ErrInteractionNotFound) {
+		panic(fmt.Sprintf(
+			`Requested interaction not found.\nMethod: %s\nURL: %s\nBody: %s
+Do you need to re-record this interaction?
+Pass -kuberecord='' to your tests and -update if Golden files need to be updated.
+`,
+			r.Method,
+			r.URL,
+			body,
+		))
+	}
+
+	return resp, err
+}

--- a/pkg/kuberecord/recorder_test.go
+++ b/pkg/kuberecord/recorder_test.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2021 The Cockroach Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kuberecord_test
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/cockroachdb/cockroach-operator/pkg/kuberecord"
+	"github.com/cockroachdb/cockroach-operator/pkg/testutil/env"
+	"github.com/stretchr/testify/require"
+	v1 "k8s.io/api/core/v1"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/envtest"
+)
+
+func TestRecorder(t *testing.T) {
+	env := &envtest.Environment{BinaryAssetsDirectory: env.ExpandPath("hack", "bin")}
+
+	cfg, err := env.Start()
+	require.NoError(t, err)
+	defer env.Stop()
+
+	cfg = Recorder(
+		t,
+		cfg,
+		WithName("kuberecord_demo"),
+		WithCassetteDir("testdata/cassettes"),
+	)
+
+	c, err := client.New(cfg, client.Options{})
+	require.NoError(t, err)
+	require.NotNil(t, c)
+
+	ns := &v1.Namespace{ObjectMeta: meta.ObjectMeta{Name: "test-ns"}}
+	require.NoError(t, c.Create(context.TODO(), ns))
+}

--- a/pkg/kuberecord/testdata/cassettes/kuberecord_demo.vcr.yaml
+++ b/pkg/kuberecord/testdata/cassettes/kuberecord_demo.vcr.yaml
@@ -1,0 +1,915 @@
+# Copyright 2021 The Cockroach Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+version: 1
+interactions:
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json, */*
+      User-Agent:
+      - kuberecord.test/v0.0.0 (darwin/amd64) kubernetes/$Format
+      X-Kuberecord-Fingerprint:
+      - da39a3ee5e6b4b0d3255bfef95601890afd80709
+    url: HTTPS://KUBERNETES/api?timeout=32s
+    method: GET
+  response:
+    body: |
+      {"kind":"APIVersions","versions":["v1"],"serverAddressByClientCIDRs":[{"clientCIDR":"0.0.0.0/0","serverAddress":"127.0.0.1:52882"}]}
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Content-Length:
+      - "133"
+      Content-Type:
+      - application/json
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json, */*
+      User-Agent:
+      - kuberecord.test/v0.0.0 (darwin/amd64) kubernetes/$Format
+      X-Kuberecord-Fingerprint:
+      - da39a3ee5e6b4b0d3255bfef95601890afd80709
+    url: HTTPS://KUBERNETES/apis?timeout=32s
+    method: GET
+  response:
+    body: |
+      {"kind":"APIGroupList","apiVersion":"v1","groups":[{"name":"apiregistration.k8s.io","versions":[{"groupVersion":"apiregistration.k8s.io/v1","version":"v1"},{"groupVersion":"apiregistration.k8s.io/v1beta1","version":"v1beta1"}],"preferredVersion":{"groupVersion":"apiregistration.k8s.io/v1","version":"v1"}},{"name":"extensions","versions":[{"groupVersion":"extensions/v1beta1","version":"v1beta1"}],"preferredVersion":{"groupVersion":"extensions/v1beta1","version":"v1beta1"}},{"name":"apps","versions":[{"groupVersion":"apps/v1","version":"v1"}],"preferredVersion":{"groupVersion":"apps/v1","version":"v1"}},{"name":"events.k8s.io","versions":[{"groupVersion":"events.k8s.io/v1beta1","version":"v1beta1"}],"preferredVersion":{"groupVersion":"events.k8s.io/v1beta1","version":"v1beta1"}},{"name":"authentication.k8s.io","versions":[{"groupVersion":"authentication.k8s.io/v1","version":"v1"},{"groupVersion":"authentication.k8s.io/v1beta1","version":"v1beta1"}],"preferredVersion":{"groupVersion":"authentication.k8s.io/v1","version":"v1"}},{"name":"authorization.k8s.io","versions":[{"groupVersion":"authorization.k8s.io/v1","version":"v1"},{"groupVersion":"authorization.k8s.io/v1beta1","version":"v1beta1"}],"preferredVersion":{"groupVersion":"authorization.k8s.io/v1","version":"v1"}},{"name":"autoscaling","versions":[{"groupVersion":"autoscaling/v1","version":"v1"},{"groupVersion":"autoscaling/v2beta1","version":"v2beta1"},{"groupVersion":"autoscaling/v2beta2","version":"v2beta2"}],"preferredVersion":{"groupVersion":"autoscaling/v1","version":"v1"}},{"name":"batch","versions":[{"groupVersion":"batch/v1","version":"v1"},{"groupVersion":"batch/v1beta1","version":"v1beta1"}],"preferredVersion":{"groupVersion":"batch/v1","version":"v1"}},{"name":"certificates.k8s.io","versions":[{"groupVersion":"certificates.k8s.io/v1beta1","version":"v1beta1"}],"preferredVersion":{"groupVersion":"certificates.k8s.io/v1beta1","version":"v1beta1"}},{"name":"networking.k8s.io","versions":[{"groupVersion":"networking.k8s.io/v1","version":"v1"},{"groupVersion":"networking.k8s.io/v1beta1","version":"v1beta1"}],"preferredVersion":{"groupVersion":"networking.k8s.io/v1","version":"v1"}},{"name":"policy","versions":[{"groupVersion":"policy/v1beta1","version":"v1beta1"}],"preferredVersion":{"groupVersion":"policy/v1beta1","version":"v1beta1"}},{"name":"rbac.authorization.k8s.io","versions":[{"groupVersion":"rbac.authorization.k8s.io/v1","version":"v1"},{"groupVersion":"rbac.authorization.k8s.io/v1beta1","version":"v1beta1"}],"preferredVersion":{"groupVersion":"rbac.authorization.k8s.io/v1","version":"v1"}},{"name":"storage.k8s.io","versions":[{"groupVersion":"storage.k8s.io/v1","version":"v1"},{"groupVersion":"storage.k8s.io/v1beta1","version":"v1beta1"}],"preferredVersion":{"groupVersion":"storage.k8s.io/v1","version":"v1"}},{"name":"admissionregistration.k8s.io","versions":[{"groupVersion":"admissionregistration.k8s.io/v1","version":"v1"},{"groupVersion":"admissionregistration.k8s.io/v1beta1","version":"v1beta1"}],"preferredVersion":{"groupVersion":"admissionregistration.k8s.io/v1","version":"v1"}},{"name":"apiextensions.k8s.io","versions":[{"groupVersion":"apiextensions.k8s.io/v1","version":"v1"},{"groupVersion":"apiextensions.k8s.io/v1beta1","version":"v1beta1"}],"preferredVersion":{"groupVersion":"apiextensions.k8s.io/v1","version":"v1"}},{"name":"scheduling.k8s.io","versions":[{"groupVersion":"scheduling.k8s.io/v1","version":"v1"},{"groupVersion":"scheduling.k8s.io/v1beta1","version":"v1beta1"}],"preferredVersion":{"groupVersion":"scheduling.k8s.io/v1","version":"v1"}},{"name":"coordination.k8s.io","versions":[{"groupVersion":"coordination.k8s.io/v1","version":"v1"},{"groupVersion":"coordination.k8s.io/v1beta1","version":"v1beta1"}],"preferredVersion":{"groupVersion":"coordination.k8s.io/v1","version":"v1"}},{"name":"node.k8s.io","versions":[{"groupVersion":"node.k8s.io/v1beta1","version":"v1beta1"}],"preferredVersion":{"groupVersion":"node.k8s.io/v1beta1","version":"v1beta1"}},{"name":"discovery.k8s.io","versions":[{"groupVersion":"discovery.k8s.io/v1beta1","version":"v1beta1"}],"preferredVersion":{"groupVersion":"discovery.k8s.io/v1beta1","version":"v1beta1"}}]}
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Content-Type:
+      - application/json
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json, */*
+      User-Agent:
+      - kuberecord.test/v0.0.0 (darwin/amd64) kubernetes/$Format
+      X-Kuberecord-Fingerprint:
+      - da39a3ee5e6b4b0d3255bfef95601890afd80709
+    url: HTTPS://KUBERNETES/api/v1?timeout=32s
+    method: GET
+  response:
+    body: |
+      {"kind":"APIResourceList","groupVersion":"v1","resources":[{"name":"bindings","singularName":"","namespaced":true,"kind":"Binding","verbs":["create"]},{"name":"componentstatuses","singularName":"","namespaced":false,"kind":"ComponentStatus","verbs":["get","list"],"shortNames":["cs"]},{"name":"configmaps","singularName":"","namespaced":true,"kind":"ConfigMap","verbs":["create","delete","deletecollection","get","list","patch","update","watch"],"shortNames":["cm"],"storageVersionHash":"qFsyl6wFWjQ="},{"name":"endpoints","singularName":"","namespaced":true,"kind":"Endpoints","verbs":["create","delete","deletecollection","get","list","patch","update","watch"],"shortNames":["ep"],"storageVersionHash":"fWeeMqaN/OA="},{"name":"events","singularName":"","namespaced":true,"kind":"Event","verbs":["create","delete","deletecollection","get","list","patch","update","watch"],"shortNames":["ev"],"storageVersionHash":"r2yiGXH7wu8="},{"name":"limitranges","singularName":"","namespaced":true,"kind":"LimitRange","verbs":["create","delete","deletecollection","get","list","patch","update","watch"],"shortNames":["limits"],"storageVersionHash":"EBKMFVe6cwo="},{"name":"namespaces","singularName":"","namespaced":false,"kind":"Namespace","verbs":["create","delete","get","list","patch","update","watch"],"shortNames":["ns"],"storageVersionHash":"Q3oi5N2YM8M="},{"name":"namespaces/finalize","singularName":"","namespaced":false,"kind":"Namespace","verbs":["update"]},{"name":"namespaces/status","singularName":"","namespaced":false,"kind":"Namespace","verbs":["get","patch","update"]},{"name":"nodes","singularName":"","namespaced":false,"kind":"Node","verbs":["create","delete","deletecollection","get","list","patch","update","watch"],"shortNames":["no"],"storageVersionHash":"XwShjMxG9Fs="},{"name":"nodes/proxy","singularName":"","namespaced":false,"kind":"NodeProxyOptions","verbs":["create","delete","get","patch","update"]},{"name":"nodes/status","singularName":"","namespaced":false,"kind":"Node","verbs":["get","patch","update"]},{"name":"persistentvolumeclaims","singularName":"","namespaced":true,"kind":"PersistentVolumeClaim","verbs":["create","delete","deletecollection","get","list","patch","update","watch"],"shortNames":["pvc"],"storageVersionHash":"QWTyNDq0dC4="},{"name":"persistentvolumeclaims/status","singularName":"","namespaced":true,"kind":"PersistentVolumeClaim","verbs":["get","patch","update"]},{"name":"persistentvolumes","singularName":"","namespaced":false,"kind":"PersistentVolume","verbs":["create","delete","deletecollection","get","list","patch","update","watch"],"shortNames":["pv"],"storageVersionHash":"HN/zwEC+JgM="},{"name":"persistentvolumes/status","singularName":"","namespaced":false,"kind":"PersistentVolume","verbs":["get","patch","update"]},{"name":"pods","singularName":"","namespaced":true,"kind":"Pod","verbs":["create","delete","deletecollection","get","list","patch","update","watch"],"shortNames":["po"],"categories":["all"],"storageVersionHash":"xPOwRZ+Yhw8="},{"name":"pods/attach","singularName":"","namespaced":true,"kind":"PodAttachOptions","verbs":["create","get"]},{"name":"pods/binding","singularName":"","namespaced":true,"kind":"Binding","verbs":["create"]},{"name":"pods/eviction","singularName":"","namespaced":true,"group":"policy","version":"v1beta1","kind":"Eviction","verbs":["create"]},{"name":"pods/exec","singularName":"","namespaced":true,"kind":"PodExecOptions","verbs":["create","get"]},{"name":"pods/log","singularName":"","namespaced":true,"kind":"Pod","verbs":["get"]},{"name":"pods/portforward","singularName":"","namespaced":true,"kind":"PodPortForwardOptions","verbs":["create","get"]},{"name":"pods/proxy","singularName":"","namespaced":true,"kind":"PodProxyOptions","verbs":["create","delete","get","patch","update"]},{"name":"pods/status","singularName":"","namespaced":true,"kind":"Pod","verbs":["get","patch","update"]},{"name":"podtemplates","singularName":"","namespaced":true,"kind":"PodTemplate","verbs":["create","delete","deletecollection","get","list","patch","update","watch"],"storageVersionHash":"LIXB2x4IFpk="},{"name":"replicationcontrollers","singularName":"","namespaced":true,"kind":"ReplicationController","verbs":["create","delete","deletecollection","get","list","patch","update","watch"],"shortNames":["rc"],"categories":["all"],"storageVersionHash":"Jond2If31h0="},{"name":"replicationcontrollers/scale","singularName":"","namespaced":true,"group":"autoscaling","version":"v1","kind":"Scale","verbs":["get","patch","update"]},{"name":"replicationcontrollers/status","singularName":"","namespaced":true,"kind":"ReplicationController","verbs":["get","patch","update"]},{"name":"resourcequotas","singularName":"","namespaced":true,"kind":"ResourceQuota","verbs":["create","delete","deletecollection","get","list","patch","update","watch"],"shortNames":["quota"],"storageVersionHash":"8uhSgffRX6w="},{"name":"resourcequotas/status","singularName":"","namespaced":true,"kind":"ResourceQuota","verbs":["get","patch","update"]},{"name":"secrets","singularName":"","namespaced":true,"kind":"Secret","verbs":["create","delete","deletecollection","get","list","patch","update","watch"],"storageVersionHash":"S6u1pOWzb84="},{"name":"serviceaccounts","singularName":"","namespaced":true,"kind":"ServiceAccount","verbs":["create","delete","deletecollection","get","list","patch","update","watch"],"shortNames":["sa"],"storageVersionHash":"pbx9ZvyFpBE="},{"name":"services","singularName":"","namespaced":true,"kind":"Service","verbs":["create","delete","get","list","patch","update","watch"],"shortNames":["svc"],"categories":["all"],"storageVersionHash":"0/CO1lhkEBI="},{"name":"services/proxy","singularName":"","namespaced":true,"kind":"ServiceProxyOptions","verbs":["create","delete","get","patch","update"]},{"name":"services/status","singularName":"","namespaced":true,"kind":"Service","verbs":["get","patch","update"]}]}
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Content-Type:
+      - application/json
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json, */*
+      User-Agent:
+      - kuberecord.test/v0.0.0 (darwin/amd64) kubernetes/$Format
+      X-Kuberecord-Fingerprint:
+      - da39a3ee5e6b4b0d3255bfef95601890afd80709
+    url: HTTPS://KUBERNETES/apis/apiregistration.k8s.io/v1?timeout=32s
+    method: GET
+  response:
+    body: |
+      {"kind":"APIResourceList","apiVersion":"v1","groupVersion":"apiregistration.k8s.io/v1","resources":[{"name":"apiservices","singularName":"","namespaced":false,"kind":"APIService","verbs":["create","delete","deletecollection","get","list","patch","update","watch"],"storageVersionHash":"C+s2HXXP47k="},{"name":"apiservices/status","singularName":"","namespaced":false,"kind":"APIService","verbs":["get","patch","update"]}]}
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Content-Length:
+      - "423"
+      Content-Type:
+      - application/json
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json, */*
+      User-Agent:
+      - kuberecord.test/v0.0.0 (darwin/amd64) kubernetes/$Format
+      X-Kuberecord-Fingerprint:
+      - da39a3ee5e6b4b0d3255bfef95601890afd80709
+    url: HTTPS://KUBERNETES/apis/apiregistration.k8s.io/v1beta1?timeout=32s
+    method: GET
+  response:
+    body: |
+      {"kind":"APIResourceList","apiVersion":"v1","groupVersion":"apiregistration.k8s.io/v1beta1","resources":[{"name":"apiservices","singularName":"","namespaced":false,"kind":"APIService","verbs":["create","delete","deletecollection","get","list","patch","update","watch"],"storageVersionHash":"C+s2HXXP47k="},{"name":"apiservices/status","singularName":"","namespaced":false,"kind":"APIService","verbs":["get","patch","update"]}]}
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Content-Length:
+      - "428"
+      Content-Type:
+      - application/json
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json, */*
+      User-Agent:
+      - kuberecord.test/v0.0.0 (darwin/amd64) kubernetes/$Format
+      X-Kuberecord-Fingerprint:
+      - da39a3ee5e6b4b0d3255bfef95601890afd80709
+    url: HTTPS://KUBERNETES/apis/extensions/v1beta1?timeout=32s
+    method: GET
+  response:
+    body: |
+      {"kind":"APIResourceList","groupVersion":"extensions/v1beta1","resources":[{"name":"ingresses","singularName":"","namespaced":true,"kind":"Ingress","verbs":["create","delete","deletecollection","get","list","patch","update","watch"],"shortNames":["ing"],"storageVersionHash":"ZOAfGflaKd0="},{"name":"ingresses/status","singularName":"","namespaced":true,"kind":"Ingress","verbs":["get","patch","update"]}]}
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Content-Length:
+      - "407"
+      Content-Type:
+      - application/json
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json, */*
+      User-Agent:
+      - kuberecord.test/v0.0.0 (darwin/amd64) kubernetes/$Format
+      X-Kuberecord-Fingerprint:
+      - da39a3ee5e6b4b0d3255bfef95601890afd80709
+    url: HTTPS://KUBERNETES/apis/apps/v1?timeout=32s
+    method: GET
+  response:
+    body: |
+      {"kind":"APIResourceList","apiVersion":"v1","groupVersion":"apps/v1","resources":[{"name":"controllerrevisions","singularName":"","namespaced":true,"kind":"ControllerRevision","verbs":["create","delete","deletecollection","get","list","patch","update","watch"],"storageVersionHash":"85nkx63pcBU="},{"name":"daemonsets","singularName":"","namespaced":true,"kind":"DaemonSet","verbs":["create","delete","deletecollection","get","list","patch","update","watch"],"shortNames":["ds"],"categories":["all"],"storageVersionHash":"dd7pWHUlMKQ="},{"name":"daemonsets/status","singularName":"","namespaced":true,"kind":"DaemonSet","verbs":["get","patch","update"]},{"name":"deployments","singularName":"","namespaced":true,"kind":"Deployment","verbs":["create","delete","deletecollection","get","list","patch","update","watch"],"shortNames":["deploy"],"categories":["all"],"storageVersionHash":"8aSe+NMegvE="},{"name":"deployments/scale","singularName":"","namespaced":true,"group":"autoscaling","version":"v1","kind":"Scale","verbs":["get","patch","update"]},{"name":"deployments/status","singularName":"","namespaced":true,"kind":"Deployment","verbs":["get","patch","update"]},{"name":"replicasets","singularName":"","namespaced":true,"kind":"ReplicaSet","verbs":["create","delete","deletecollection","get","list","patch","update","watch"],"shortNames":["rs"],"categories":["all"],"storageVersionHash":"P1RzHs8/mWQ="},{"name":"replicasets/scale","singularName":"","namespaced":true,"group":"autoscaling","version":"v1","kind":"Scale","verbs":["get","patch","update"]},{"name":"replicasets/status","singularName":"","namespaced":true,"kind":"ReplicaSet","verbs":["get","patch","update"]},{"name":"statefulsets","singularName":"","namespaced":true,"kind":"StatefulSet","verbs":["create","delete","deletecollection","get","list","patch","update","watch"],"shortNames":["sts"],"categories":["all"],"storageVersionHash":"H+vl74LkKdo="},{"name":"statefulsets/scale","singularName":"","namespaced":true,"group":"autoscaling","version":"v1","kind":"Scale","verbs":["get","patch","update"]},{"name":"statefulsets/status","singularName":"","namespaced":true,"kind":"StatefulSet","verbs":["get","patch","update"]}]}
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Content-Type:
+      - application/json
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json, */*
+      User-Agent:
+      - kuberecord.test/v0.0.0 (darwin/amd64) kubernetes/$Format
+      X-Kuberecord-Fingerprint:
+      - da39a3ee5e6b4b0d3255bfef95601890afd80709
+    url: HTTPS://KUBERNETES/apis/events.k8s.io/v1beta1?timeout=32s
+    method: GET
+  response:
+    body: |
+      {"kind":"APIResourceList","apiVersion":"v1","groupVersion":"events.k8s.io/v1beta1","resources":[{"name":"events","singularName":"","namespaced":true,"kind":"Event","verbs":["create","delete","deletecollection","get","list","patch","update","watch"],"shortNames":["ev"],"storageVersionHash":"r2yiGXH7wu8="}]}
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Content-Length:
+      - "308"
+      Content-Type:
+      - application/json
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json, */*
+      User-Agent:
+      - kuberecord.test/v0.0.0 (darwin/amd64) kubernetes/$Format
+      X-Kuberecord-Fingerprint:
+      - da39a3ee5e6b4b0d3255bfef95601890afd80709
+    url: HTTPS://KUBERNETES/apis/authentication.k8s.io/v1?timeout=32s
+    method: GET
+  response:
+    body: |
+      {"kind":"APIResourceList","apiVersion":"v1","groupVersion":"authentication.k8s.io/v1","resources":[{"name":"tokenreviews","singularName":"","namespaced":false,"kind":"TokenReview","verbs":["create"]}]}
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Content-Length:
+      - "202"
+      Content-Type:
+      - application/json
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json, */*
+      User-Agent:
+      - kuberecord.test/v0.0.0 (darwin/amd64) kubernetes/$Format
+      X-Kuberecord-Fingerprint:
+      - da39a3ee5e6b4b0d3255bfef95601890afd80709
+    url: HTTPS://KUBERNETES/apis/authorization.k8s.io/v1?timeout=32s
+    method: GET
+  response:
+    body: |
+      {"kind":"APIResourceList","apiVersion":"v1","groupVersion":"authorization.k8s.io/v1","resources":[{"name":"localsubjectaccessreviews","singularName":"","namespaced":true,"kind":"LocalSubjectAccessReview","verbs":["create"]},{"name":"selfsubjectaccessreviews","singularName":"","namespaced":false,"kind":"SelfSubjectAccessReview","verbs":["create"]},{"name":"selfsubjectrulesreviews","singularName":"","namespaced":false,"kind":"SelfSubjectRulesReview","verbs":["create"]},{"name":"subjectaccessreviews","singularName":"","namespaced":false,"kind":"SubjectAccessReview","verbs":["create"]}]}
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Content-Length:
+      - "591"
+      Content-Type:
+      - application/json
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json, */*
+      User-Agent:
+      - kuberecord.test/v0.0.0 (darwin/amd64) kubernetes/$Format
+      X-Kuberecord-Fingerprint:
+      - da39a3ee5e6b4b0d3255bfef95601890afd80709
+    url: HTTPS://KUBERNETES/apis/authorization.k8s.io/v1beta1?timeout=32s
+    method: GET
+  response:
+    body: |
+      {"kind":"APIResourceList","apiVersion":"v1","groupVersion":"authorization.k8s.io/v1beta1","resources":[{"name":"localsubjectaccessreviews","singularName":"","namespaced":true,"kind":"LocalSubjectAccessReview","verbs":["create"]},{"name":"selfsubjectaccessreviews","singularName":"","namespaced":false,"kind":"SelfSubjectAccessReview","verbs":["create"]},{"name":"selfsubjectrulesreviews","singularName":"","namespaced":false,"kind":"SelfSubjectRulesReview","verbs":["create"]},{"name":"subjectaccessreviews","singularName":"","namespaced":false,"kind":"SubjectAccessReview","verbs":["create"]}]}
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Content-Length:
+      - "596"
+      Content-Type:
+      - application/json
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json, */*
+      User-Agent:
+      - kuberecord.test/v0.0.0 (darwin/amd64) kubernetes/$Format
+      X-Kuberecord-Fingerprint:
+      - da39a3ee5e6b4b0d3255bfef95601890afd80709
+    url: HTTPS://KUBERNETES/apis/authentication.k8s.io/v1beta1?timeout=32s
+    method: GET
+  response:
+    body: |
+      {"kind":"APIResourceList","apiVersion":"v1","groupVersion":"authentication.k8s.io/v1beta1","resources":[{"name":"tokenreviews","singularName":"","namespaced":false,"kind":"TokenReview","verbs":["create"]}]}
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Content-Length:
+      - "207"
+      Content-Type:
+      - application/json
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json, */*
+      User-Agent:
+      - kuberecord.test/v0.0.0 (darwin/amd64) kubernetes/$Format
+      X-Kuberecord-Fingerprint:
+      - da39a3ee5e6b4b0d3255bfef95601890afd80709
+    url: HTTPS://KUBERNETES/apis/autoscaling/v1?timeout=32s
+    method: GET
+  response:
+    body: |
+      {"kind":"APIResourceList","apiVersion":"v1","groupVersion":"autoscaling/v1","resources":[{"name":"horizontalpodautoscalers","singularName":"","namespaced":true,"kind":"HorizontalPodAutoscaler","verbs":["create","delete","deletecollection","get","list","patch","update","watch"],"shortNames":["hpa"],"categories":["all"],"storageVersionHash":"oQlkt7f5j/A="},{"name":"horizontalpodautoscalers/status","singularName":"","namespaced":true,"kind":"HorizontalPodAutoscaler","verbs":["get","patch","update"]}]}
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Content-Length:
+      - "504"
+      Content-Type:
+      - application/json
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json, */*
+      User-Agent:
+      - kuberecord.test/v0.0.0 (darwin/amd64) kubernetes/$Format
+      X-Kuberecord-Fingerprint:
+      - da39a3ee5e6b4b0d3255bfef95601890afd80709
+    url: HTTPS://KUBERNETES/apis/autoscaling/v2beta2?timeout=32s
+    method: GET
+  response:
+    body: |
+      {"kind":"APIResourceList","apiVersion":"v1","groupVersion":"autoscaling/v2beta2","resources":[{"name":"horizontalpodautoscalers","singularName":"","namespaced":true,"kind":"HorizontalPodAutoscaler","verbs":["create","delete","deletecollection","get","list","patch","update","watch"],"shortNames":["hpa"],"categories":["all"],"storageVersionHash":"oQlkt7f5j/A="},{"name":"horizontalpodautoscalers/status","singularName":"","namespaced":true,"kind":"HorizontalPodAutoscaler","verbs":["get","patch","update"]}]}
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Content-Length:
+      - "509"
+      Content-Type:
+      - application/json
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json, */*
+      User-Agent:
+      - kuberecord.test/v0.0.0 (darwin/amd64) kubernetes/$Format
+      X-Kuberecord-Fingerprint:
+      - da39a3ee5e6b4b0d3255bfef95601890afd80709
+    url: HTTPS://KUBERNETES/apis/autoscaling/v2beta1?timeout=32s
+    method: GET
+  response:
+    body: |
+      {"kind":"APIResourceList","apiVersion":"v1","groupVersion":"autoscaling/v2beta1","resources":[{"name":"horizontalpodautoscalers","singularName":"","namespaced":true,"kind":"HorizontalPodAutoscaler","verbs":["create","delete","deletecollection","get","list","patch","update","watch"],"shortNames":["hpa"],"categories":["all"],"storageVersionHash":"oQlkt7f5j/A="},{"name":"horizontalpodautoscalers/status","singularName":"","namespaced":true,"kind":"HorizontalPodAutoscaler","verbs":["get","patch","update"]}]}
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Content-Length:
+      - "509"
+      Content-Type:
+      - application/json
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json, */*
+      User-Agent:
+      - kuberecord.test/v0.0.0 (darwin/amd64) kubernetes/$Format
+      X-Kuberecord-Fingerprint:
+      - da39a3ee5e6b4b0d3255bfef95601890afd80709
+    url: HTTPS://KUBERNETES/apis/batch/v1?timeout=32s
+    method: GET
+  response:
+    body: |
+      {"kind":"APIResourceList","apiVersion":"v1","groupVersion":"batch/v1","resources":[{"name":"jobs","singularName":"","namespaced":true,"kind":"Job","verbs":["create","delete","deletecollection","get","list","patch","update","watch"],"categories":["all"],"storageVersionHash":"mudhfqk/qZY="},{"name":"jobs/status","singularName":"","namespaced":true,"kind":"Job","verbs":["get","patch","update"]}]}
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Content-Length:
+      - "397"
+      Content-Type:
+      - application/json
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json, */*
+      User-Agent:
+      - kuberecord.test/v0.0.0 (darwin/amd64) kubernetes/$Format
+      X-Kuberecord-Fingerprint:
+      - da39a3ee5e6b4b0d3255bfef95601890afd80709
+    url: HTTPS://KUBERNETES/apis/batch/v1beta1?timeout=32s
+    method: GET
+  response:
+    body: |
+      {"kind":"APIResourceList","apiVersion":"v1","groupVersion":"batch/v1beta1","resources":[{"name":"cronjobs","singularName":"","namespaced":true,"kind":"CronJob","verbs":["create","delete","deletecollection","get","list","patch","update","watch"],"shortNames":["cj"],"categories":["all"],"storageVersionHash":"h/JlFAZkyyY="},{"name":"cronjobs/status","singularName":"","namespaced":true,"kind":"CronJob","verbs":["get","patch","update"]}]}
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Content-Length:
+      - "438"
+      Content-Type:
+      - application/json
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json, */*
+      User-Agent:
+      - kuberecord.test/v0.0.0 (darwin/amd64) kubernetes/$Format
+      X-Kuberecord-Fingerprint:
+      - da39a3ee5e6b4b0d3255bfef95601890afd80709
+    url: HTTPS://KUBERNETES/apis/certificates.k8s.io/v1beta1?timeout=32s
+    method: GET
+  response:
+    body: |
+      {"kind":"APIResourceList","apiVersion":"v1","groupVersion":"certificates.k8s.io/v1beta1","resources":[{"name":"certificatesigningrequests","singularName":"","namespaced":false,"kind":"CertificateSigningRequest","verbs":["create","delete","deletecollection","get","list","patch","update","watch"],"shortNames":["csr"],"storageVersionHash":"UQh3YTCDIf0="},{"name":"certificatesigningrequests/approval","singularName":"","namespaced":false,"kind":"CertificateSigningRequest","verbs":["update"]},{"name":"certificatesigningrequests/status","singularName":"","namespaced":false,"kind":"CertificateSigningRequest","verbs":["get","patch","update"]}]}
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Content-Length:
+      - "644"
+      Content-Type:
+      - application/json
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json, */*
+      User-Agent:
+      - kuberecord.test/v0.0.0 (darwin/amd64) kubernetes/$Format
+      X-Kuberecord-Fingerprint:
+      - da39a3ee5e6b4b0d3255bfef95601890afd80709
+    url: HTTPS://KUBERNETES/apis/networking.k8s.io/v1?timeout=32s
+    method: GET
+  response:
+    body: |
+      {"kind":"APIResourceList","apiVersion":"v1","groupVersion":"networking.k8s.io/v1","resources":[{"name":"networkpolicies","singularName":"","namespaced":true,"kind":"NetworkPolicy","verbs":["create","delete","deletecollection","get","list","patch","update","watch"],"shortNames":["netpol"],"storageVersionHash":"YpfwF18m1G8="}]}
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Content-Length:
+      - "328"
+      Content-Type:
+      - application/json
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json, */*
+      User-Agent:
+      - kuberecord.test/v0.0.0 (darwin/amd64) kubernetes/$Format
+      X-Kuberecord-Fingerprint:
+      - da39a3ee5e6b4b0d3255bfef95601890afd80709
+    url: HTTPS://KUBERNETES/apis/networking.k8s.io/v1beta1?timeout=32s
+    method: GET
+  response:
+    body: |
+      {"kind":"APIResourceList","apiVersion":"v1","groupVersion":"networking.k8s.io/v1beta1","resources":[{"name":"ingresses","singularName":"","namespaced":true,"kind":"Ingress","verbs":["create","delete","deletecollection","get","list","patch","update","watch"],"shortNames":["ing"],"storageVersionHash":"ZOAfGflaKd0="},{"name":"ingresses/status","singularName":"","namespaced":true,"kind":"Ingress","verbs":["get","patch","update"]}]}
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Content-Length:
+      - "432"
+      Content-Type:
+      - application/json
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json, */*
+      User-Agent:
+      - kuberecord.test/v0.0.0 (darwin/amd64) kubernetes/$Format
+      X-Kuberecord-Fingerprint:
+      - da39a3ee5e6b4b0d3255bfef95601890afd80709
+    url: HTTPS://KUBERNETES/apis/policy/v1beta1?timeout=32s
+    method: GET
+  response:
+    body: |
+      {"kind":"APIResourceList","apiVersion":"v1","groupVersion":"policy/v1beta1","resources":[{"name":"poddisruptionbudgets","singularName":"","namespaced":true,"kind":"PodDisruptionBudget","verbs":["create","delete","deletecollection","get","list","patch","update","watch"],"shortNames":["pdb"],"storageVersionHash":"6BGBu0kpHtk="},{"name":"poddisruptionbudgets/status","singularName":"","namespaced":true,"kind":"PodDisruptionBudget","verbs":["get","patch","update"]},{"name":"podsecuritypolicies","singularName":"","namespaced":false,"kind":"PodSecurityPolicy","verbs":["create","delete","deletecollection","get","list","patch","update","watch"],"shortNames":["psp"],"storageVersionHash":"khBLobUXkqA="}]}
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Content-Length:
+      - "704"
+      Content-Type:
+      - application/json
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json, */*
+      User-Agent:
+      - kuberecord.test/v0.0.0 (darwin/amd64) kubernetes/$Format
+      X-Kuberecord-Fingerprint:
+      - da39a3ee5e6b4b0d3255bfef95601890afd80709
+    url: HTTPS://KUBERNETES/apis/rbac.authorization.k8s.io/v1?timeout=32s
+    method: GET
+  response:
+    body: |
+      {"kind":"APIResourceList","apiVersion":"v1","groupVersion":"rbac.authorization.k8s.io/v1","resources":[{"name":"clusterrolebindings","singularName":"","namespaced":false,"kind":"ClusterRoleBinding","verbs":["create","delete","deletecollection","get","list","patch","update","watch"],"storageVersionHash":"48tpQ8gZHFc="},{"name":"clusterroles","singularName":"","namespaced":false,"kind":"ClusterRole","verbs":["create","delete","deletecollection","get","list","patch","update","watch"],"storageVersionHash":"bYE5ZWDrJ44="},{"name":"rolebindings","singularName":"","namespaced":true,"kind":"RoleBinding","verbs":["create","delete","deletecollection","get","list","patch","update","watch"],"storageVersionHash":"eGsCzGH6b1g="},{"name":"roles","singularName":"","namespaced":true,"kind":"Role","verbs":["create","delete","deletecollection","get","list","patch","update","watch"],"storageVersionHash":"7FuwZcIIItM="}]}
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Content-Length:
+      - "915"
+      Content-Type:
+      - application/json
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json, */*
+      User-Agent:
+      - kuberecord.test/v0.0.0 (darwin/amd64) kubernetes/$Format
+      X-Kuberecord-Fingerprint:
+      - da39a3ee5e6b4b0d3255bfef95601890afd80709
+    url: HTTPS://KUBERNETES/apis/rbac.authorization.k8s.io/v1beta1?timeout=32s
+    method: GET
+  response:
+    body: |
+      {"kind":"APIResourceList","apiVersion":"v1","groupVersion":"rbac.authorization.k8s.io/v1beta1","resources":[{"name":"clusterrolebindings","singularName":"","namespaced":false,"kind":"ClusterRoleBinding","verbs":["create","delete","deletecollection","get","list","patch","update","watch"],"storageVersionHash":"48tpQ8gZHFc="},{"name":"clusterroles","singularName":"","namespaced":false,"kind":"ClusterRole","verbs":["create","delete","deletecollection","get","list","patch","update","watch"],"storageVersionHash":"bYE5ZWDrJ44="},{"name":"rolebindings","singularName":"","namespaced":true,"kind":"RoleBinding","verbs":["create","delete","deletecollection","get","list","patch","update","watch"],"storageVersionHash":"eGsCzGH6b1g="},{"name":"roles","singularName":"","namespaced":true,"kind":"Role","verbs":["create","delete","deletecollection","get","list","patch","update","watch"],"storageVersionHash":"7FuwZcIIItM="}]}
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Content-Length:
+      - "920"
+      Content-Type:
+      - application/json
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json, */*
+      User-Agent:
+      - kuberecord.test/v0.0.0 (darwin/amd64) kubernetes/$Format
+      X-Kuberecord-Fingerprint:
+      - da39a3ee5e6b4b0d3255bfef95601890afd80709
+    url: HTTPS://KUBERNETES/apis/storage.k8s.io/v1beta1?timeout=32s
+    method: GET
+  response:
+    body: |
+      {"kind":"APIResourceList","apiVersion":"v1","groupVersion":"storage.k8s.io/v1beta1","resources":[{"name":"csidrivers","singularName":"","namespaced":false,"kind":"CSIDriver","verbs":["create","delete","deletecollection","get","list","patch","update","watch"],"storageVersionHash":"Z7aeXSiaYTw="},{"name":"csinodes","singularName":"","namespaced":false,"kind":"CSINode","verbs":["create","delete","deletecollection","get","list","patch","update","watch"],"storageVersionHash":"fnCuCdDgSvE="},{"name":"storageclasses","singularName":"","namespaced":false,"kind":"StorageClass","verbs":["create","delete","deletecollection","get","list","patch","update","watch"],"shortNames":["sc"],"storageVersionHash":"K+m6uJwbjGY="},{"name":"volumeattachments","singularName":"","namespaced":false,"kind":"VolumeAttachment","verbs":["create","delete","deletecollection","get","list","patch","update","watch"],"storageVersionHash":"tJx/ezt6UDU="}]}
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Content-Length:
+      - "932"
+      Content-Type:
+      - application/json
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json, */*
+      User-Agent:
+      - kuberecord.test/v0.0.0 (darwin/amd64) kubernetes/$Format
+      X-Kuberecord-Fingerprint:
+      - da39a3ee5e6b4b0d3255bfef95601890afd80709
+    url: HTTPS://KUBERNETES/apis/storage.k8s.io/v1?timeout=32s
+    method: GET
+  response:
+    body: |
+      {"kind":"APIResourceList","apiVersion":"v1","groupVersion":"storage.k8s.io/v1","resources":[{"name":"csinodes","singularName":"","namespaced":false,"kind":"CSINode","verbs":["create","delete","deletecollection","get","list","patch","update","watch"],"storageVersionHash":"fnCuCdDgSvE="},{"name":"storageclasses","singularName":"","namespaced":false,"kind":"StorageClass","verbs":["create","delete","deletecollection","get","list","patch","update","watch"],"shortNames":["sc"],"storageVersionHash":"K+m6uJwbjGY="},{"name":"volumeattachments","singularName":"","namespaced":false,"kind":"VolumeAttachment","verbs":["create","delete","deletecollection","get","list","patch","update","watch"],"storageVersionHash":"tJx/ezt6UDU="},{"name":"volumeattachments/status","singularName":"","namespaced":false,"kind":"VolumeAttachment","verbs":["get","patch","update"]}]}
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Content-Length:
+      - "860"
+      Content-Type:
+      - application/json
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json, */*
+      User-Agent:
+      - kuberecord.test/v0.0.0 (darwin/amd64) kubernetes/$Format
+      X-Kuberecord-Fingerprint:
+      - da39a3ee5e6b4b0d3255bfef95601890afd80709
+    url: HTTPS://KUBERNETES/apis/admissionregistration.k8s.io/v1?timeout=32s
+    method: GET
+  response:
+    body: |
+      {"kind":"APIResourceList","apiVersion":"v1","groupVersion":"admissionregistration.k8s.io/v1","resources":[{"name":"mutatingwebhookconfigurations","singularName":"","namespaced":false,"kind":"MutatingWebhookConfiguration","verbs":["create","delete","deletecollection","get","list","patch","update","watch"],"storageVersionHash":"yxW1cpLtfp8="},{"name":"validatingwebhookconfigurations","singularName":"","namespaced":false,"kind":"ValidatingWebhookConfiguration","verbs":["create","delete","deletecollection","get","list","patch","update","watch"],"storageVersionHash":"P9NhrezfnWE="}]}
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Content-Length:
+      - "586"
+      Content-Type:
+      - application/json
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json, */*
+      User-Agent:
+      - kuberecord.test/v0.0.0 (darwin/amd64) kubernetes/$Format
+      X-Kuberecord-Fingerprint:
+      - da39a3ee5e6b4b0d3255bfef95601890afd80709
+    url: HTTPS://KUBERNETES/apis/apiextensions.k8s.io/v1?timeout=32s
+    method: GET
+  response:
+    body: |
+      {"kind":"APIResourceList","apiVersion":"v1","groupVersion":"apiextensions.k8s.io/v1","resources":[{"name":"customresourcedefinitions","singularName":"","namespaced":false,"kind":"CustomResourceDefinition","verbs":["create","delete","deletecollection","get","list","patch","update","watch"],"shortNames":["crd","crds"],"storageVersionHash":"jfWCUB31mvA="},{"name":"customresourcedefinitions/status","singularName":"","namespaced":false,"kind":"CustomResourceDefinition","verbs":["get","patch","update"]}]}
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Content-Length:
+      - "505"
+      Content-Type:
+      - application/json
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json, */*
+      User-Agent:
+      - kuberecord.test/v0.0.0 (darwin/amd64) kubernetes/$Format
+      X-Kuberecord-Fingerprint:
+      - da39a3ee5e6b4b0d3255bfef95601890afd80709
+    url: HTTPS://KUBERNETES/apis/apiextensions.k8s.io/v1beta1?timeout=32s
+    method: GET
+  response:
+    body: |
+      {"kind":"APIResourceList","apiVersion":"v1","groupVersion":"apiextensions.k8s.io/v1beta1","resources":[{"name":"customresourcedefinitions","singularName":"","namespaced":false,"kind":"CustomResourceDefinition","verbs":["create","delete","deletecollection","get","list","patch","update","watch"],"shortNames":["crd","crds"],"storageVersionHash":"jfWCUB31mvA="},{"name":"customresourcedefinitions/status","singularName":"","namespaced":false,"kind":"CustomResourceDefinition","verbs":["get","patch","update"]}]}
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Content-Length:
+      - "510"
+      Content-Type:
+      - application/json
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json, */*
+      User-Agent:
+      - kuberecord.test/v0.0.0 (darwin/amd64) kubernetes/$Format
+      X-Kuberecord-Fingerprint:
+      - da39a3ee5e6b4b0d3255bfef95601890afd80709
+    url: HTTPS://KUBERNETES/apis/admissionregistration.k8s.io/v1beta1?timeout=32s
+    method: GET
+  response:
+    body: |
+      {"kind":"APIResourceList","apiVersion":"v1","groupVersion":"admissionregistration.k8s.io/v1beta1","resources":[{"name":"mutatingwebhookconfigurations","singularName":"","namespaced":false,"kind":"MutatingWebhookConfiguration","verbs":["create","delete","deletecollection","get","list","patch","update","watch"],"storageVersionHash":"yxW1cpLtfp8="},{"name":"validatingwebhookconfigurations","singularName":"","namespaced":false,"kind":"ValidatingWebhookConfiguration","verbs":["create","delete","deletecollection","get","list","patch","update","watch"],"storageVersionHash":"P9NhrezfnWE="}]}
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Content-Length:
+      - "591"
+      Content-Type:
+      - application/json
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json, */*
+      User-Agent:
+      - kuberecord.test/v0.0.0 (darwin/amd64) kubernetes/$Format
+      X-Kuberecord-Fingerprint:
+      - da39a3ee5e6b4b0d3255bfef95601890afd80709
+    url: HTTPS://KUBERNETES/apis/scheduling.k8s.io/v1beta1?timeout=32s
+    method: GET
+  response:
+    body: |
+      {"kind":"APIResourceList","apiVersion":"v1","groupVersion":"scheduling.k8s.io/v1beta1","resources":[{"name":"priorityclasses","singularName":"","namespaced":false,"kind":"PriorityClass","verbs":["create","delete","deletecollection","get","list","patch","update","watch"],"shortNames":["pc"],"storageVersionHash":"1QwjyaZjj3Y="}]}
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Content-Length:
+      - "330"
+      Content-Type:
+      - application/json
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json, */*
+      User-Agent:
+      - kuberecord.test/v0.0.0 (darwin/amd64) kubernetes/$Format
+      X-Kuberecord-Fingerprint:
+      - da39a3ee5e6b4b0d3255bfef95601890afd80709
+    url: HTTPS://KUBERNETES/apis/scheduling.k8s.io/v1?timeout=32s
+    method: GET
+  response:
+    body: |
+      {"kind":"APIResourceList","apiVersion":"v1","groupVersion":"scheduling.k8s.io/v1","resources":[{"name":"priorityclasses","singularName":"","namespaced":false,"kind":"PriorityClass","verbs":["create","delete","deletecollection","get","list","patch","update","watch"],"shortNames":["pc"],"storageVersionHash":"1QwjyaZjj3Y="}]}
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Content-Length:
+      - "325"
+      Content-Type:
+      - application/json
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json, */*
+      User-Agent:
+      - kuberecord.test/v0.0.0 (darwin/amd64) kubernetes/$Format
+      X-Kuberecord-Fingerprint:
+      - da39a3ee5e6b4b0d3255bfef95601890afd80709
+    url: HTTPS://KUBERNETES/apis/coordination.k8s.io/v1?timeout=32s
+    method: GET
+  response:
+    body: |
+      {"kind":"APIResourceList","apiVersion":"v1","groupVersion":"coordination.k8s.io/v1","resources":[{"name":"leases","singularName":"","namespaced":true,"kind":"Lease","verbs":["create","delete","deletecollection","get","list","patch","update","watch"],"storageVersionHash":"/sY7hl8ol1U="}]}
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Content-Length:
+      - "289"
+      Content-Type:
+      - application/json
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json, */*
+      User-Agent:
+      - kuberecord.test/v0.0.0 (darwin/amd64) kubernetes/$Format
+      X-Kuberecord-Fingerprint:
+      - da39a3ee5e6b4b0d3255bfef95601890afd80709
+    url: HTTPS://KUBERNETES/apis/coordination.k8s.io/v1beta1?timeout=32s
+    method: GET
+  response:
+    body: |
+      {"kind":"APIResourceList","apiVersion":"v1","groupVersion":"coordination.k8s.io/v1beta1","resources":[{"name":"leases","singularName":"","namespaced":true,"kind":"Lease","verbs":["create","delete","deletecollection","get","list","patch","update","watch"],"storageVersionHash":"/sY7hl8ol1U="}]}
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Content-Length:
+      - "294"
+      Content-Type:
+      - application/json
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json, */*
+      User-Agent:
+      - kuberecord.test/v0.0.0 (darwin/amd64) kubernetes/$Format
+      X-Kuberecord-Fingerprint:
+      - da39a3ee5e6b4b0d3255bfef95601890afd80709
+    url: HTTPS://KUBERNETES/apis/discovery.k8s.io/v1beta1?timeout=32s
+    method: GET
+  response:
+    body: |
+      {"kind":"APIResourceList","apiVersion":"v1","groupVersion":"discovery.k8s.io/v1beta1","resources":[{"name":"endpointslices","singularName":"","namespaced":true,"kind":"EndpointSlice","verbs":["create","delete","deletecollection","get","list","patch","update","watch"],"storageVersionHash":"Nx3SIv6I0mE="}]}
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Content-Length:
+      - "307"
+      Content-Type:
+      - application/json
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: ""
+    form: {}
+    headers:
+      Accept:
+      - application/json, */*
+      User-Agent:
+      - kuberecord.test/v0.0.0 (darwin/amd64) kubernetes/$Format
+      X-Kuberecord-Fingerprint:
+      - da39a3ee5e6b4b0d3255bfef95601890afd80709
+    url: HTTPS://KUBERNETES/apis/node.k8s.io/v1beta1?timeout=32s
+    method: GET
+  response:
+    body: |
+      {"kind":"APIResourceList","apiVersion":"v1","groupVersion":"node.k8s.io/v1beta1","resources":[{"name":"runtimeclasses","singularName":"","namespaced":false,"kind":"RuntimeClass","verbs":["create","delete","deletecollection","get","list","patch","update","watch"],"storageVersionHash":"8nMHWqj34s0="}]}
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Content-Length:
+      - "302"
+      Content-Type:
+      - application/json
+    status: 200 OK
+    code: 200
+    duration: ""
+- request:
+    body: "k8s\0\n\x0F\n\x02v1\x12\tNamespace\x12!\n\x19\n\atest-ns\x12\0\x1A\0\"\0*\02\08\0B\0z\0\x12\0\x1A\x02\n\0\x1A\0\"\0"
+    form: {}
+    headers:
+      Accept:
+      - application/vnd.kubernetes.protobuf, */*
+      Content-Type:
+      - application/vnd.kubernetes.protobuf
+      User-Agent:
+      - kuberecord.test/v0.0.0 (darwin/amd64) kubernetes/$Format
+      X-Kuberecord-Fingerprint:
+      - 52d7714666d9c9af8cb28d035ebf44b19e4234bd
+    url: HTTPS://KUBERNETES/api/v1/namespaces
+    method: POST
+  response:
+    body: !!binary |
+      azhzAAoPCgJ2MRIJTmFtZXNwYWNlEnsKYQoHdGVzdC1ucxIAGgAiGi9hcGkvdjEvbmFtZX
+      NwYWNlcy90ZXN0LW5zKiRiZGU3MzI1Ni1hNmYwLTRjZDgtOGI0Yy03NzZjZDY5MjhiNGIy
+      AjQ0OABCCAjnkPSIBhAAegASDAoKa3ViZXJuZXRlcxoICgZBY3RpdmUaACIA
+    headers:
+      Cache-Control:
+      - no-cache, private
+      Content-Length:
+      - "150"
+      Content-Type:
+      - application/vnd.kubernetes.protobuf
+    status: 201 Created
+    code: 201
+    duration: ""

--- a/pkg/testutil/BUILD.bazel
+++ b/pkg/testutil/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
         "assert.go",
         "builder.go",
         "cmp.go",
+        "env.go",
         "fake.go",
         "helpers.go",
         "require.go",
@@ -72,7 +73,13 @@ go_test(
 
 go_test(
     name = "go_default_test",
-    srcs = ["validate_headers_test.go"],
+    srcs = [
+        "env_test.go",
+        "validate_headers_test.go",
+    ],
     data = glob(["testdata/**"]),
-    embed = [":go_default_library"],
+    deps = [
+        ":go_default_library",
+        "@com_github_stretchr_testify//require:go_default_library",
+    ],
 )

--- a/pkg/testutil/env.go
+++ b/pkg/testutil/env.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2021 The Cockroach Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testutil
+
+import "os"
+
+// WithEnv sets environment variables, runs the supplied function and puts the env back the way it was found.
+func WithEnv(vars map[string]string, fn func()) {
+	toReset := map[string]string{}
+	toClear := make([]string, 0)
+
+	for k, v := range vars {
+		if oldV, ok := os.LookupEnv(k); ok {
+			toReset[k] = oldV
+		} else {
+			toClear = append(toClear, k)
+		}
+
+		os.Setenv(k, v)
+	}
+
+	defer func() {
+		for k, v := range toReset {
+			os.Setenv(k, v)
+		}
+
+		for _, k := range toClear {
+			os.Unsetenv(k)
+		}
+	}()
+
+	fn()
+}

--- a/pkg/testutil/env/BUILD.bazel
+++ b/pkg/testutil/env/BUILD.bazel
@@ -57,6 +57,7 @@ go_test(
     ],
     deps = [
         ":go_default_library",
+        "//pkg/testutil:go_default_library",
         "@com_github_stretchr_testify//require:go_default_library",
     ],
 )

--- a/pkg/testutil/env/path_test.go
+++ b/pkg/testutil/env/path_test.go
@@ -20,6 +20,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/cockroachdb/cockroach-operator/pkg/testutil"
 	. "github.com/cockroachdb/cockroach-operator/pkg/testutil/env"
 	"github.com/stretchr/testify/require"
 )
@@ -31,46 +32,14 @@ func TestExpandPath(t *testing.T) {
 		"BUILD_WORKSPACE_DIRECTORY": "c",
 	}
 
-	withEnv(env, func() {
+	testutil.WithEnv(env, func() {
 		require.Equal(t, "a/b/c/pkg/test/env/path_test.go", ExpandPath("pkg/test/env/path_test.go"))
 	})
 }
 
 func TestPrependToPath(t *testing.T) {
-	withEnv(map[string]string{"PATH": "/usr/local/bin"}, func() {
+	testutil.WithEnv(map[string]string{"PATH": "/usr/local/bin"}, func() {
 		PrependToPath("hack", "bin")
 		require.Equal(t, "hack/bin:/usr/local/bin", os.Getenv("PATH"))
 	})
-}
-
-func withEnv(env map[string]string, fn func()) {
-	toReset := make(map[string]string)
-	toClear := make([]string, 0)
-
-	for k, v := range env {
-		if oldVal, ok := os.LookupEnv(k); ok {
-			toReset[k] = oldVal
-		} else {
-			toClear = append(toClear, k)
-		}
-
-		if v == "__unset__" {
-			os.Unsetenv(k)
-			continue
-		}
-
-		os.Setenv(k, v)
-	}
-
-	defer func() {
-		for k, v := range toReset {
-			os.Setenv(k, v)
-		}
-
-		for _, k := range toClear {
-			os.Unsetenv(k)
-		}
-	}()
-
-	fn()
 }

--- a/pkg/testutil/env_test.go
+++ b/pkg/testutil/env_test.go
@@ -1,0 +1,44 @@
+/*
+Copyright 2021 The Cockroach Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package testutil_test
+
+import (
+	"os"
+	"testing"
+
+	. "github.com/cockroachdb/cockroach-operator/pkg/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWithEnv(t *testing.T) {
+	user := os.Getenv("USER")
+	require.NotEmpty(t, user)
+
+	_, ok := os.LookupEnv("WITH_ENV_TEST")
+	require.False(t, ok)
+
+	// inside function, they should be set appropriately
+	WithEnv(map[string]string{"USER": "testy", "WITH_ENV_TEST": "true"}, func() {
+		require.Equal(t, "testy", os.Getenv("USER"))
+		require.Equal(t, "true", os.Getenv("WITH_ENV_TEST"))
+	})
+
+	// back as it was
+	require.Equal(t, user, os.Getenv("USER"))
+	_, ok = os.LookupEnv("WITH_ENV_TEST")
+	require.False(t, ok)
+}

--- a/pkg/testutil/validate_headers_test.go
+++ b/pkg/testutil/validate_headers_test.go
@@ -14,7 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package testutil
+package testutil_test
 
 import (
 	"io/ioutil"
@@ -22,6 +22,8 @@ import (
 	"path"
 	"path/filepath"
 	"testing"
+
+	. "github.com/cockroachdb/cockroach-operator/pkg/testutil"
 )
 
 const GOOD_MAKEFILE = `# Copyright 2021 The Cockroach Authors


### PR DESCRIPTION
__**NOTE**: I know +1600 looks scary, but over 900 lines are for the YAML fixture__

Adding `kuberecord` which is a package that leverages the [go-vcr](https://github.com/dnaeon/go-vcr) to record interactions with a K8s API server.

This is useful to avoid having to run every command over and over again when running tests. In theory, unless the API version changes, we typically don't expect the behaviour to be any different for things like CreateNamespace, ListPods, etc.

Kuberecord works by wrapping the incoming rest.Config to handle loading prerecorded interactions, scrubbing sensitive/flakey headers, and storing results to disk (`./testdata/<name>.vcr` by default).

This code is largely "borrowed" from an internal repo where it has been in use for a while already. In order to keep the diff here more reasonable, I haven't updated any tests to use it just yet. I'm happy to start addressing that in future PRs once we're happy with the implementation here.

See _record_test.go_ in this PR for an example of how to use it.