### PR TITLE
Add tests for clustersql package

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/cockroachdb/cockroach-operator
 go 1.14
 
 require (
+	github.com/DATA-DOG/go-sqlmock v1.5.0
 	github.com/Masterminds/semver/v3 v3.1.0
 	github.com/banzaicloud/k8s-objectmatcher v1.3.2
 	github.com/cenkalti/backoff v2.2.1+incompatible

--- a/go.sum
+++ b/go.sum
@@ -143,6 +143,8 @@ github.com/CloudyKit/fastprinter v0.0.0-20170127035650-74b38d55f37a h1:3SgJcK9l5
 github.com/CloudyKit/fastprinter v0.0.0-20170127035650-74b38d55f37a/go.mod h1:EFZQ978U7x8IRnstaskI3IysnWY5Ao3QgZUKOXlsAdw=
 github.com/CloudyKit/jet v2.1.3-0.20180809161101-62edd43e4f88+incompatible h1:rZgFj+Gtf3NMi/U5FvCvhzaxzW/TaPYgUYx3bAPz9DE=
 github.com/CloudyKit/jet v2.1.3-0.20180809161101-62edd43e4f88+incompatible/go.mod h1:HPYO+50pSWkPoj9Q/eq0aRGByCL6ScRlUmiEX5Zgm+w=
+github.com/DATA-DOG/go-sqlmock v1.5.0 h1:Shsta01QNfFxHCfpW6YH2STWB0MudeXXEWMr20OEh60=
+github.com/DATA-DOG/go-sqlmock v1.5.0/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
 github.com/DataDog/zstd v1.3.6-0.20190409195224-796139022798/go.mod h1:1jcaCB/ufaK+sKp1NBhlGmpz41jOoPQ35bpF36t7BBo=
 github.com/DataDog/zstd v1.4.1 h1:3oxKN3wbHibqx897utPC2LTQU4J+IHWWJO+glkAkpFM=
 github.com/DataDog/zstd v1.4.1/go.mod h1:1jcaCB/ufaK+sKp1NBhlGmpz41jOoPQ35bpF36t7BBo=

--- a/hack/build/repos.bzl
+++ b/hack/build/repos.bzl
@@ -960,6 +960,15 @@ def _go_dependencies():
         version = "v0.2.2",
     )
     go_repository(
+        name = "com_github_data_dog_go_sqlmock",
+        build_file_generation = "on",
+        build_file_proto_mode = "disable",
+        importpath = "github.com/DATA-DOG/go-sqlmock",
+        sum = "h1:Shsta01QNfFxHCfpW6YH2STWB0MudeXXEWMr20OEh60=",
+        version = "v1.5.0",
+    )
+
+    go_repository(
         name = "com_github_datadog_zstd",
         build_file_generation = "on",
         build_file_proto_mode = "disable",
@@ -1561,6 +1570,9 @@ def _go_dependencies():
         sum = "h1:wDJmvq38kDhkVxi50ni9ykkdUr1PKgqKOoi01fa0Mdk=",
         version = "v0.9.0",
     )
+
+    # end manual updates
+
     go_repository(
         name = "com_github_go_lintpack_lintpack",
         build_file_generation = "on",
@@ -1569,8 +1581,6 @@ def _go_dependencies():
         sum = "h1:DI5mA3+eKdWeJ40nU4d6Wc26qmdG8RCi/btYq0TuRN0=",
         version = "v0.5.2",
     )
-
-    # end manual updates
 
     go_repository(
         name = "com_github_go_logfmt_logfmt",

--- a/pkg/clustersql/BUILD.bazel
+++ b/pkg/clustersql/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "go_default_library",
@@ -27,4 +27,20 @@ filegroup(
     srcs = [":package-srcs"],
     tags = ["automanaged"],
     visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = [
+        "settings_test.go",
+        "zones_test.go",
+    ],
+    deps = [
+        ":go_default_library",
+        "@com_github_cockroachdb_errors//:go_default_library",
+        "@com_github_data_dog_go_sqlmock//:go_default_library",
+        "@com_github_pkg_errors//:go_default_library",
+        "@com_github_stretchr_testify//require:go_default_library",
+        "@in_gopkg_yaml_v2//:go_default_library",
+    ],
 )

--- a/pkg/clustersql/settings_test.go
+++ b/pkg/clustersql/settings_test.go
@@ -1,0 +1,245 @@
+/*
+Copyright 2021 The Cockroach Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clustersql_test
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	. "github.com/cockroachdb/cockroach-operator/pkg/clustersql"
+	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetClusterSetting(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	t.Run("return setting value when found", func(t *testing.T) {
+		rows := sqlmock.NewRows([]string{"name"}).AddRow("bogus_value")
+		mock.ExpectQuery("SHOW CLUSTER SETTING bogus_setting").WillReturnRows(rows)
+
+		v, err := GetClusterSetting(context.Background(), db, "bogus_setting")
+		require.Equal(t, "bogus_value", v)
+		require.NoError(t, err)
+	})
+
+	t.Run("returns error with an invalid setting name", func(t *testing.T) {
+		v, err := GetClusterSetting(context.Background(), db, "!not#valid$")
+		require.Empty(t, v)
+		require.Equal(t, ErrInvalidClusterSettingName, errors.Cause(err))
+	})
+
+	t.Run("returns error when setting not found", func(t *testing.T) {
+		rows := sqlmock.NewRows([]string{"name"})
+		mock.ExpectQuery("SHOW CLUSTER SETTING bogus_setting").WillReturnRows(rows)
+
+		v, err := GetClusterSetting(context.Background(), db, "bogus_setting")
+		require.Empty(t, v)
+		require.Equal(t, sql.ErrNoRows, errors.Cause(err))
+	})
+}
+
+func TestSetClusterSetting(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	t.Run("returns no error when setting value", func(t *testing.T) {
+		mock.
+			ExpectExec("SET CLUSTER SETTING bogus_setting = \\$1").
+			WithArgs("bogus_value").
+			WillReturnResult(sqlmock.NewResult(1, 1))
+
+		require.NoError(t, SetClusterSetting(context.Background(), db, "bogus_setting", "bogus_value"))
+	})
+
+	t.Run("returns error with an invalid setting name", func(t *testing.T) {
+		err := SetClusterSetting(context.Background(), db, "!not#valid$", "nope")
+		require.Equal(t, ErrInvalidClusterSettingName, errors.Cause(err))
+	})
+
+	t.Run("returns error when exec fails", func(t *testing.T) {
+		mock.
+			ExpectExec("SET CLUSTER SETTING bogus_setting = \\$1").
+			WithArgs("nope").
+			WillReturnError(errors.New("boom"))
+
+		err := SetClusterSetting(context.Background(), db, "bogus_setting", "nope")
+		require.EqualError(t, errors.Cause(err), "boom")
+	})
+}
+
+func TestRangeMoveDuration(t *testing.T) {
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	ctx := context.Background()
+
+	stubSettings := func(settings map[string]string) {
+		// map keys are not ordered
+		mock.MatchExpectationsInOrder(false)
+
+		for k, v := range settings {
+			mock.
+				ExpectQuery("SHOW CLUSTER SETTING " + k).
+				WillReturnRows(sqlmock.NewRows([]string{"name"}).AddRow(v))
+		}
+	}
+
+	t.Run("calculates the time it takes for a range to move nodes", func(t *testing.T) {
+		tests := []struct {
+			name             string
+			maxRebalanceRate string
+			maxRecoveryRate  string
+			zones            []Zone
+			exp              time.Duration
+		}{
+			{
+				name:             "rebalance rate faster than recovery",
+				maxRebalanceRate: "10MB",
+				maxRecoveryRate:  "6MB",
+				zones: []Zone{
+					{Target: "zone-1", Config: ZoneConfig{RangeMaxBytes: 10}},
+					{Target: "zone-2", Config: ZoneConfig{RangeMaxBytes: 20}},
+				},
+				exp: time.Duration(10/1000000) * time.Second,
+			},
+			{
+				name:             "recovery rate faster than rebalance",
+				maxRebalanceRate: "1MB",
+				maxRecoveryRate:  "2MB",
+				zones: []Zone{
+					{Target: "zone-1", Config: ZoneConfig{RangeMaxBytes: 10}},
+					{Target: "zone-2", Config: ZoneConfig{RangeMaxBytes: 20}},
+				},
+				exp: time.Duration(20/1000000) * time.Second,
+			},
+			{
+				name:             "min range size is used",
+				maxRebalanceRate: "1MB",
+				maxRecoveryRate:  "2MB",
+				zones: []Zone{
+					{Target: "zone-1", Config: ZoneConfig{RangeMaxBytes: 20}},
+					{Target: "zone-2", Config: ZoneConfig{RangeMaxBytes: 30}},
+				},
+				exp: time.Duration(20/2000000) * time.Second,
+			},
+		}
+
+		for _, tt := range tests {
+			stubSettings(map[string]string{
+				"kv.snapshot_rebalance.max_rate": tt.maxRebalanceRate,
+				"kv.snapshot_recovery.max_rate":  tt.maxRecoveryRate,
+			})
+
+			d, err := RangeMoveDuration(ctx, db, tt.zones...)
+			require.Equal(t, tt.exp, d)
+			require.NoError(t, err)
+		}
+	})
+
+	t.Run("returns error when MaxRangeSize is 0 for all zones", func(t *testing.T) {
+		stubSettings(map[string]string{
+			"kv.snapshot_rebalance.max_rate": "10MB",
+			"kv.snapshot_recovery.max_rate":  "10MB",
+		})
+
+		d, err := RangeMoveDuration(ctx, db, Zone{
+			Target: "us-east1-c",
+			Config: ZoneConfig{RangeMaxBytes: 0},
+		})
+
+		require.Zero(t, d)
+		require.EqualError(t, err, "no maximum range size found")
+	})
+
+	t.Run("return error when fetching ZoneConfigs fails", func(t *testing.T) {
+		stubSettings(map[string]string{
+			"kv.snapshot_rebalance.max_rate": "10MB",
+			"kv.snapshot_recovery.max_rate":  "10MB",
+		})
+
+		// TODO (pseudomuto): this feels a bit dirty reaching into SQL used within zones.go
+		mock.ExpectQuery("SELECT target, full_config_yaml FROM crdb_internal.zones").WillReturnError(errors.New("boom"))
+
+		d, err := RangeMoveDuration(ctx, db)
+		require.Zero(t, d)
+		require.EqualError(t, errors.Cause(err), "boom")
+	})
+
+	t.Run("returns error when setting not found", func(t *testing.T) {
+		// These are order dependent in that they are queried in this exact order in RangeMoveDuration. This is necessary to
+		// make it easier to stub previous values when validating them in a loop.
+		tests := []string{
+			"kv.snapshot_rebalance.max_rate",
+			"kv.snapshot_recovery.max_rate",
+		}
+
+		for i, tt := range tests {
+			for j := 0; j < i; j++ {
+				// all previous values should be valid
+				mock.
+					ExpectQuery("SHOW CLUSTER SETTING " + tests[j]).
+					WillReturnRows(sqlmock.NewRows([]string{"name"}).AddRow("1MB"))
+			}
+
+			// this particular one is not found
+			mock.ExpectQuery("SHOW CLUSTER SETTING " + tt).WillReturnRows(sqlmock.NewRows([]string{"name"}))
+
+			d, err := RangeMoveDuration(ctx, db)
+			require.Zero(t, d)
+			require.Contains(t, err.Error(), "failed to get "+tt)
+		}
+	})
+
+	t.Run("returns error when settings aren't valid", func(t *testing.T) {
+		tests := []struct {
+			badKey   string
+			settings map[string]string
+		}{
+			{
+				badKey: "kv.snapshot_rebalance.max_rate",
+				settings: map[string]string{
+					"kv.snapshot_rebalance.max_rate": "-1Mb",
+					"kv.snapshot_recovery.max_rate":  "1Mb",
+				},
+			},
+			{
+				badKey: "kv.snapshot_recovery.max_rate",
+				settings: map[string]string{
+					"kv.snapshot_rebalance.max_rate": "1Mb",
+					"kv.snapshot_recovery.max_rate":  "-1Mb",
+				},
+			},
+		}
+
+		for _, tt := range tests {
+			stubSettings(tt.settings)
+
+			d, err := RangeMoveDuration(ctx, db)
+			require.Zero(t, d)
+			require.Contains(t, err.Error(), fmt.Sprintf("failed to parse %s as uint64", tt.badKey))
+		}
+	})
+}

--- a/pkg/clustersql/zones.go
+++ b/pkg/clustersql/zones.go
@@ -59,6 +59,8 @@ func ZoneConfigs(ctx context.Context, db *sql.DB) ([]Zone, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to select from crdb_internal.zones")
 	}
+	defer rows.Close()
+
 	var zones []Zone
 	for rows.Next() {
 		var zone Zone

--- a/pkg/clustersql/zones_test.go
+++ b/pkg/clustersql/zones_test.go
@@ -1,0 +1,90 @@
+/*
+Copyright 2021 The Cockroach Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package clustersql_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/DATA-DOG/go-sqlmock"
+	. "github.com/cockroachdb/cockroach-operator/pkg/clustersql"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v2"
+)
+
+func TestZoneConfigs(t *testing.T) {
+	query := "SELECT target, full_config_yaml FROM crdb_internal.zones"
+
+	db, mock, err := sqlmock.New()
+	require.NoError(t, err)
+	defer db.Close()
+
+	t.Run("returns zones from query results", func(t *testing.T) {
+		expectedZones := []Zone{
+			{
+				Target: "us-central1-a",
+				Config: ZoneConfig{
+					RangeMinBytes:     1,
+					RangeMaxBytes:     2,
+					Replicas:          1,
+					GarbageCollection: GarbageCollectionConfig{TTLSeconds: 1},
+				},
+			},
+			{
+				Target: "us-east1-b",
+				Config: ZoneConfig{
+					RangeMinBytes:     10,
+					RangeMaxBytes:     20,
+					Replicas:          3,
+					GarbageCollection: GarbageCollectionConfig{TTLSeconds: 4},
+				},
+			},
+		}
+
+		rows := sqlmock.NewRows([]string{"target", "full_config_yaml"})
+		for _, z := range expectedZones {
+			yml, err := yaml.Marshal(z.Config)
+			require.NoError(t, err)
+			rows.AddRow(z.Target, string(yml))
+		}
+
+		mock.ExpectQuery(query).WillReturnRows(rows).RowsWillBeClosed()
+
+		zones, err := ZoneConfigs(context.Background(), db)
+		require.Equal(t, expectedZones, zones)
+		require.NoError(t, err)
+	})
+
+	t.Run("returns error when query errors out", func(t *testing.T) {
+		mock.ExpectQuery(query).WillReturnError(errors.New("boom"))
+
+		zones, err := ZoneConfigs(context.Background(), db)
+		require.Nil(t, zones)
+		require.EqualError(t, errors.Cause(err), "boom")
+	})
+
+	t.Run("returns error when scanning fails", func(t *testing.T) {
+		// second field was supposed to be YAML
+		rows := sqlmock.NewRows([]string{"target", "full_config_yaml"}).AddRow("us-east1-b", 2)
+		mock.ExpectQuery(query).WillReturnRows(rows)
+
+		zones, err := ZoneConfigs(context.Background(), db)
+		require.Nil(t, zones)
+		require.Contains(t, err.Error(), "sql: Scan error on column index 1")
+	})
+}

--- a/pkg/update/BUILD.bazel
+++ b/pkg/update/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach-operator/pkg/update",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/clustersql:go_default_library",
         "//pkg/healthchecker:go_default_library",
         "//pkg/kube:go_default_library",
         "//pkg/resource:go_default_library",


### PR DESCRIPTION
Adding tests for the `clustersql` package. This involved some very light refactoring and removing some duplicate code in _pkg/update_ which has been updated to use `SetClusterSetting` and `GetClusterSetting` from the `clustersql` package now.