### PR TITLE
Use OpenAPI validation for node count

### DIFF
--- a/apis/v1alpha1/cluster_types.go
+++ b/apis/v1alpha1/cluster_types.go
@@ -32,6 +32,7 @@ import (
 type CrdbClusterSpec struct {
 	// Number of nodes (pods) in the cluster
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Number of nodes",xDescriptors="urn:alm:descriptor:com.tectonic.ui:podCount"
+	// +kubebuilder:validation:Minimum=3
 	// +required
 	Nodes int32 `json:"nodes"`
 	// Container image information

--- a/apis/v1alpha1/cluster_types_test.go
+++ b/apis/v1alpha1/cluster_types_test.go
@@ -50,7 +50,7 @@ func TestCrdbCluster(t *testing.T) {
 			Name:      key.Name,
 			Namespace: key.Namespace,
 		},
-		Spec: CrdbClusterSpec{},
+		Spec: CrdbClusterSpec{Nodes: 3},
 	}
 
 	ctx := context.TODO()

--- a/config/crd/bases/crdb.cockroachlabs.com_crdbclusters.yaml
+++ b/config/crd/bases/crdb.cockroachlabs.com_crdbclusters.yaml
@@ -892,6 +892,7 @@ spec:
               nodes:
                 description: Number of nodes (pods) in the cluster
                 format: int32
+                minimum: 3
                 type: integer
               podEnvVariables:
                 description: '(Optional) PodEnvVariables is a slice of environment

--- a/pkg/actor/decommission.go
+++ b/pkg/actor/decommission.go
@@ -85,13 +85,6 @@ func (d decommission) Act(ctx context.Context, cluster *resource.Cluster) error 
 	}
 
 	nodes := uint(cluster.Spec().Nodes)
-	//We do not scale down if the nodes field is less than 3
-	//TODO @alina add validation webhook (see https://github.com/cockroachdb/cockroach-operator/issues/245)
-	if nodes < 3 {
-		err := errors.New("decommission with less than 3 nodes is not supported")
-		log.Error(err, "We cannot decommission if there are less than 3 nodes", "nodes", nodes)
-		return err
-	}
 	log.Info("replicas decommissioning", "status.CurrentReplicas", status.CurrentReplicas, "expected", cluster.Spec().Nodes)
 	if status.CurrentReplicas <= cluster.Spec().Nodes {
 		return nil


### PR DESCRIPTION
We currently check for the node count to be >=3 in the decommissioner. There's actually a `TODO` comment in there about adding a validation hook to avoid this. However, since the admission controller will always run the OpenAPI validation when resources are submitted to the API server, we don't actually need a hook for this.

I've added a minimum=3 marker to the spec, which will be enforced automatically, negating the need for this check.

**Proof:**

To try this out, you can update the `nodes` property in `examples/example.yaml` to be `2`. The run the following:

```
make dev/up && make dev/up-wait # start a local kind cluster
kubectl apply -f examples/example.yaml
=> The CrdbCluster "cockroachdb" is invalid: spec.nodes: Invalid value: 2: spec.nodes in body should be greater than or equal to 3

make dev/down
```