### PR TITLE
Adding kustomize macro so we can use it in bazel

### DIFF
--- a/apis/v1alpha1/BUILD.bazel
+++ b/apis/v1alpha1/BUILD.bazel
@@ -37,12 +37,6 @@ go_test(
         "volume_test.go",
         "webhook_test.go",
     ],
-    data = [
-        "//config/crd/bases:crd_manifest",
-        "//hack/bin:etcd",
-        "//hack/bin:kube-apiserver",
-        "//hack/bin:kubectl",
-    ],
     deps = [
         ":go_default_library",
         "//pkg/client/clientset/versioned:go_default_library",

--- a/apis/v1alpha1/cluster_types_test.go
+++ b/apis/v1alpha1/cluster_types_test.go
@@ -18,7 +18,6 @@ package v1alpha1_test
 
 import (
 	"context"
-	"path/filepath"
 	"testing"
 
 	. "github.com/cockroachdb/cockroach-operator/apis/v1alpha1"
@@ -32,10 +31,7 @@ import (
 )
 
 func TestCrdbCluster(t *testing.T) {
-	env := env.NewEnv(
-		runtime.NewSchemeBuilder(AddToScheme),
-		filepath.Join("..", "..", "config", "crd", "bases"),
-	)
+	env := env.NewEnv(runtime.NewSchemeBuilder(AddToScheme))
 
 	env.Start()
 	defer env.Stop()

--- a/config/crd/BUILD.bazel
+++ b/config/crd/BUILD.bazel
@@ -12,6 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("@k8s_deploy//:defaults.bzl", "k8s_deploy")
+load("//hack/build:kustomize.bzl", "kustomization")
+
+kustomization(
+    name = "manifest",
+    srcs = [":all-srcs"],
+)
+
+k8s_deploy(
+    name = "crd",
+    template = ":manifest",
+    visibility = ["//visibility:public"],
+)
+
 filegroup(
     name = "package-srcs",
     srcs = glob(["**"]),
@@ -21,14 +35,7 @@ filegroup(
 
 filegroup(
     name = "all-srcs",
-    srcs = [
-        ":package-srcs",
-        "//config/crd:all-srcs",
-        "//config/manifests:all-srcs",
-        "//config/samples:all-srcs",
-        "//config/scorecard:all-srcs",
-        "//config/webhook:all-srcs",
-    ],
+    srcs = [":package-srcs"],
     tags = ["automanaged"],
     visibility = ["//visibility:public"],
 )

--- a/config/manifests/BUILD.bazel
+++ b/config/manifests/BUILD.bazel
@@ -12,6 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("//hack/build:kustomize.bzl", "kustomization")
+
+kustomization(
+    name = "manifest",
+    srcs = [
+        ":all-srcs",
+        "//config/crd:manifest.srcs",
+        "//config/samples:manifest.srcs",
+        "//config/scorecard:manifest.srcs",
+        "//config/webhook:manifest.srcs",
+        "//manifests:manifest.srcs",
+    ],
+)
+
 filegroup(
     name = "package-srcs",
     srcs = glob(["**"]),
@@ -21,14 +35,7 @@ filegroup(
 
 filegroup(
     name = "all-srcs",
-    srcs = [
-        ":package-srcs",
-        "//config/crd:all-srcs",
-        "//config/manifests:all-srcs",
-        "//config/samples:all-srcs",
-        "//config/scorecard:all-srcs",
-        "//config/webhook:all-srcs",
-    ],
+    srcs = [":package-srcs"],
     tags = ["automanaged"],
     visibility = ["//visibility:public"],
 )

--- a/config/samples/BUILD.bazel
+++ b/config/samples/BUILD.bazel
@@ -12,18 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-load("@k8s_deploy//:defaults.bzl", "k8s_deploy")
+load("//hack/build:kustomize.bzl", "kustomization")
 
-k8s_deploy(
-    name = "crd",
-    template = ":crdb.cockroachlabs.com_crdbclusters.yaml",
-    visibility = ["//visibility:public"],
-)
-
-filegroup(
-    name = "crd_manifest",
-    srcs = glob(["**"]),
-    visibility = ["//visibility:public"],
+kustomization(
+    name = "manifest",
+    srcs = [":all-srcs"],
+    out = "manifest.yaml",
 )
 
 filegroup(

--- a/config/scorecard/BUILD.bazel
+++ b/config/scorecard/BUILD.bazel
@@ -12,6 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+load("//hack/build:kustomize.bzl", "kustomization")
+
+kustomization(
+    name = "manifest",
+    srcs = [":all-srcs"],
+    out = "manifest.yaml",
+)
+
 filegroup(
     name = "package-srcs",
     srcs = glob(["**"]),
@@ -21,14 +29,7 @@ filegroup(
 
 filegroup(
     name = "all-srcs",
-    srcs = [
-        ":package-srcs",
-        "//config/crd:all-srcs",
-        "//config/manifests:all-srcs",
-        "//config/samples:all-srcs",
-        "//config/scorecard:all-srcs",
-        "//config/webhook:all-srcs",
-    ],
+    srcs = [":package-srcs"],
     tags = ["automanaged"],
     visibility = ["//visibility:public"],
 )

--- a/config/webhook/BUILD.bazel
+++ b/config/webhook/BUILD.bazel
@@ -13,27 +13,17 @@
 # limitations under the License.
 
 load("@k8s_deploy//:defaults.bzl", "k8s_deploy")
-load("@io_bazel_rules_k8s//k8s:objects.bzl", "k8s_objects")
+load("//hack/build:kustomize.bzl", "kustomization")
 
-k8s_objects(
-    name = "webhooks",
-    objects = [
-        ":webhook-config",
-        ":webhook-service",
-    ],
+kustomization(
+    name = "manifest",
+    srcs = [":all-srcs"],
+)
+
+k8s_deploy(
+    name = "webhook",
+    template = ":manifest",
     visibility = ["//visibility:public"],
-)
-
-k8s_deploy(
-    name = "webhook-config",
-    template = ":manifests.yaml",
-    visibility = ["//visibility:private"],
-)
-
-k8s_deploy(
-    name = "webhook-service",
-    template = ":service.yaml",
-    visibility = ["//visibility:private"],
 )
 
 filegroup(

--- a/config/webhook/kustomization.yaml
+++ b/config/webhook/kustomization.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020 The Cockroach Authors
+# Copyright 2021 The Cockroach Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,24 +11,13 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+---
+namespace: default
 
-filegroup(
-    name = "package-srcs",
-    srcs = glob(["**"]),
-    tags = ["automanaged"],
-    visibility = ["//visibility:private"],
-)
+resources:
+  - manifests.yaml
+  - service.yaml
 
-filegroup(
-    name = "all-srcs",
-    srcs = [
-        ":package-srcs",
-        "//config/crd:all-srcs",
-        "//config/manifests:all-srcs",
-        "//config/samples:all-srcs",
-        "//config/scorecard:all-srcs",
-        "//config/webhook:all-srcs",
-    ],
-    tags = ["automanaged"],
-    visibility = ["//visibility:public"],
-)
+replacements:
+  - path: patches/replacements.yaml
+  - path: patches/webhook_config.yaml

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -24,13 +24,10 @@ webhooks:
   clientConfig:
     service:
       name: webhook-service
-      namespace: default
+      namespace: system
       path: /mutate-crdb-cockroachlabs-com-v1alpha1-crdbcluster
   failurePolicy: Fail
   name: mcrdbcluster.kb.io
-  namespaceSelector:
-    matchLabels:
-      cockroach-namespace: default
   rules:
   - apiGroups:
     - crdb.cockroachlabs.com
@@ -55,13 +52,10 @@ webhooks:
   clientConfig:
     service:
       name: webhook-service
-      namespace: default
+      namespace: system
       path: /validate-crdb-cockroachlabs-com-v1alpha1-crdbcluster
   failurePolicy: Fail
   name: vcrdbcluster.kb.io
-  namespaceSelector:
-    matchLabels:
-      cockroach-namespace: default
   rules:
   - apiGroups:
     - crdb.cockroachlabs.com

--- a/config/webhook/patches/replacements.yaml
+++ b/config/webhook/patches/replacements.yaml
@@ -11,15 +11,20 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
----
-apiVersion: v1
-kind: Service
-metadata:
+#
+# This kustomization.yaml is not intended to be run by itself,
+# since it depends on service name and namespace that are out of this kustomize package.
+# It should be run by config/default
+source:
+  kind: Service
   name: webhook-service
-spec:
-  ports:
-    - port: 443
-      targetPort: 9443
-  selector:
-    app: cockroach-operator
+  fieldPath: metadata.namespace
+targets:
+  - select:
+      kind: MutatingWebhookConfiguration
+    fieldPaths:
+      - webhooks.[name=mcrdbcluster.kb.io].clientConfig.service.namespace
+  - select:
+      kind: ValidatingWebhookConfiguration
+    fieldPaths:
+      - webhooks.[name=vcrdbcluster.kb.io].clientConfig.service.namespace

--- a/config/webhook/patches/webhook_config.yaml
+++ b/config/webhook/patches/webhook_config.yaml
@@ -1,4 +1,4 @@
-# Copyright 2020 The Cockroach Authors
+# Copyright 2021 The Cockroach Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -11,24 +11,21 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-filegroup(
-    name = "package-srcs",
-    srcs = glob(["**"]),
-    tags = ["automanaged"],
-    visibility = ["//visibility:private"],
-)
-
-filegroup(
-    name = "all-srcs",
-    srcs = [
-        ":package-srcs",
-        "//config/crd:all-srcs",
-        "//config/manifests:all-srcs",
-        "//config/samples:all-srcs",
-        "//config/scorecard:all-srcs",
-        "//config/webhook:all-srcs",
-    ],
-    tags = ["automanaged"],
-    visibility = ["//visibility:public"],
-)
+---
+source:
+  kind: Service
+  name: webhook-service
+  fieldPath: metadata.namespace
+targets:
+  - select:
+      kind: MutatingWebhookConfiguration
+    fieldPaths:
+      - webhooks.[name=mcrdbcluster.kb.io].namespaceSelector.matchLabels.cockroach-operator
+    options:
+      create: true
+  - select:
+      kind: ValidatingWebhookConfiguration
+    fieldPaths:
+      - webhooks.[name=vcrdbcluster.kb.io].namespaceSelector.matchLabels.cockroach-operator
+    options:
+      create: true

--- a/e2e/create/BUILD.bazel
+++ b/e2e/create/BUILD.bazel
@@ -4,16 +4,6 @@ go_test(
     name = "go_default_test",
     size = "enormous",
     srcs = ["create_test.go"],
-    data = [
-        "//config/crd/bases:crd_manifest",
-        "//hack/bin:cockroach",
-        "//hack/bin:kind",
-        "//hack/bin:etcd",
-        "//hack/bin:kube-apiserver",
-        "//hack/bin:kubectl",
-        "//hack/bin:kubetest2",
-        "//hack/bin:kubetest2-kind",
-    ] + glob(["testdata/**"]),
     deps = [
         "//pkg/actor:go_default_library",
         "//pkg/controller:go_default_library",

--- a/e2e/create/create_test.go
+++ b/e2e/create/create_test.go
@@ -45,14 +45,13 @@ var env *testenv.ActiveEnv
 // TestMain wraps the unit tests. Set TEST_DO_NOT_USE_KIND evnvironment variable to any value
 // if you do not want this test to start a k8s cluster using kind.
 func TestMain(m *testing.M) {
-	e := testenv.CreateActiveEnvForTest([]string{"..", ".."})
+	e := testenv.CreateActiveEnvForTest()
 	env = e.Start()
 	code := testenv.RunCode(m, e)
 	os.Exit(code)
 }
 
 func TestCreateInsecureCluster(t *testing.T) {
-
 	// Test Creating an insecure cluster
 	// No actions on the cluster just create it and
 	// tear it down.

--- a/e2e/decomission/BUILD.bazel
+++ b/e2e/decomission/BUILD.bazel
@@ -4,16 +4,6 @@ go_test(
     name = "go_default_test",
     size = "enormous",
     srcs = ["decomission_test.go"],
-    data = [
-        "//config/crd/bases:crd_manifest",
-        "//hack/bin:cockroach",
-        "//hack/bin:kind",
-        "//hack/bin:etcd",
-        "//hack/bin:kube-apiserver",
-        "//hack/bin:kubectl",
-        "//hack/bin:kubetest2",
-        "//hack/bin:kubetest2-kind",
-    ] + glob(["testdata/**"]),
     deps = [
         "//pkg/actor:go_default_library",
         "//pkg/controller:go_default_library",

--- a/e2e/decomission/decomission_test.go
+++ b/e2e/decomission/decomission_test.go
@@ -44,7 +44,7 @@ var env *testenv.ActiveEnv
 // TestMain wraps the unit tests. Set TEST_DO_NOT_USE_KIND environment variable to any value
 // if you do not want this test to start a k8s cluster using kind.
 func TestMain(m *testing.M) {
-	e := testenv.CreateActiveEnvForTest([]string{"..", ".."})
+	e := testenv.CreateActiveEnvForTest()
 	env = e.Start()
 	code := testenv.RunCode(m, e)
 	os.Exit(code)

--- a/e2e/pvcresize/BUILD.bazel
+++ b/e2e/pvcresize/BUILD.bazel
@@ -4,16 +4,6 @@ go_test(
     name = "go_default_test",
     size = "enormous",
     srcs = ["pvcresize_test.go"],
-    data = [
-        "//config/crd/bases:crd_manifest",
-        "//hack/bin:cockroach",
-        "//hack/bin:kind",
-        "//hack/bin:etcd",
-        "//hack/bin:kube-apiserver",
-        "//hack/bin:kubectl",
-        "//hack/bin:kubetest2",
-        "//hack/bin:kubetest2-kind",
-    ] + glob(["testdata/**"]),
     deps = [
         "//pkg/actor:go_default_library",
         "//pkg/controller:go_default_library",

--- a/e2e/pvcresize/pvcresize_test.go
+++ b/e2e/pvcresize/pvcresize_test.go
@@ -48,7 +48,7 @@ var env *testenv.ActiveEnv
 // TestMain wraps the unit tests. Set TEST_DO_NOT_USE_KIND evnvironment variable to any value
 // if you do not want this test to start a k8s cluster using kind.
 func TestMain(m *testing.M) {
-	e := testenv.CreateActiveEnvForTest([]string{"..", ".."})
+	e := testenv.CreateActiveEnvForTest()
 	env = e.Start()
 	code := testenv.RunCode(m, e)
 	os.Exit(code)

--- a/e2e/upgrades/BUILD.bazel
+++ b/e2e/upgrades/BUILD.bazel
@@ -4,16 +4,6 @@ go_test(
     name = "go_default_test",
     size = "enormous",
     srcs = ["upgrades_test.go"],
-    data = [
-        "//config/crd/bases:crd_manifest",
-        "//hack/bin:cockroach",
-        "//hack/bin:kind",
-        "//hack/bin:etcd",
-        "//hack/bin:kube-apiserver",
-        "//hack/bin:kubectl",
-        "//hack/bin:kubetest2",
-        "//hack/bin:kubetest2-kind",
-    ] + glob(["testdata/**"]),
     deps = [
         "//pkg/actor:go_default_library",
         "//pkg/controller:go_default_library",

--- a/e2e/upgrades/upgrades_test.go
+++ b/e2e/upgrades/upgrades_test.go
@@ -46,7 +46,7 @@ var MajorVersion string = "cockroachdb/cockroach:v21.1.0"
 // TestMain wraps the unit tests. Set TEST_DO_NOT_USE_KIND evnvironment variable to any value
 // if you do not want this test to start a k8s cluster using kind.
 func TestMain(m *testing.M) {
-	e := testenv.CreateActiveEnvForTest([]string{"..", ".."})
+	e := testenv.CreateActiveEnvForTest()
 	env = e.Start()
 	code := testenv.RunCode(m, e)
 	os.Exit(code)

--- a/e2e/upgradessha256/BUILD.bazel
+++ b/e2e/upgradessha256/BUILD.bazel
@@ -4,16 +4,6 @@ go_test(
     name = "go_default_test",
     size = "enormous",
     srcs = ["upgradessha256_test.go"],
-    data = [
-        "//config/crd/bases:crd_manifest",
-        "//hack/bin:cockroach",
-        "//hack/bin:kind",
-        "//hack/bin:etcd",
-        "//hack/bin:kube-apiserver",
-        "//hack/bin:kubectl",
-        "//hack/bin:kubetest2",
-        "//hack/bin:kubetest2-kind",
-    ] + glob(["testdata/**"]),
     deps = [
         "//pkg/actor:go_default_library",
         "//pkg/controller:go_default_library",

--- a/e2e/upgradessha256/upgradessha256_test.go
+++ b/e2e/upgradessha256/upgradessha256_test.go
@@ -42,7 +42,7 @@ var env *testenv.ActiveEnv
 // TestMain wraps the unit tests. Set TEST_DO_NOT_USE_KIND evnvironment variable to any value
 // if you do not want this test to start a k8s cluster using kind.
 func TestMain(m *testing.M) {
-	e := testenv.CreateActiveEnvForTest([]string{"..", ".."})
+	e := testenv.CreateActiveEnvForTest()
 	env = e.Start()
 	code := testenv.RunCode(m, e)
 	os.Exit(code)

--- a/e2e/versionchecker/BUILD.bazel
+++ b/e2e/versionchecker/BUILD.bazel
@@ -4,16 +4,6 @@ go_test(
     name = "go_default_test",
     size = "enormous",
     srcs = ["versionchecker_test.go"],
-    data = [
-        "//config/crd/bases:crd_manifest",
-        "//hack/bin:cockroach",
-        "//hack/bin:kind",
-        "//hack/bin:etcd",
-        "//hack/bin:kube-apiserver",
-        "//hack/bin:kubectl",
-        "//hack/bin:kubetest2",
-        "//hack/bin:kubetest2-kind",
-    ] + glob(["testdata/**"]),
     deps = [
         "//pkg/actor:go_default_library",
         "//pkg/controller:go_default_library",

--- a/e2e/versionchecker/versionchecker_test.go
+++ b/e2e/versionchecker/versionchecker_test.go
@@ -18,11 +18,12 @@ package versionchecker_test
 
 import (
 	"flag"
-	corev1 "k8s.io/api/core/v1"
-	apiresource "k8s.io/apimachinery/pkg/api/resource"
 	"os"
 	"testing"
 	"time"
+
+	corev1 "k8s.io/api/core/v1"
+	apiresource "k8s.io/apimachinery/pkg/api/resource"
 
 	"github.com/cockroachdb/cockroach-operator/pkg/actor"
 	"github.com/cockroachdb/cockroach-operator/pkg/controller"
@@ -44,7 +45,7 @@ var env *testenv.ActiveEnv
 // TestMain wraps the unit tests. Set TEST_DO_NOT_USE_KIND environment variable to any value
 // if you do not want this test to start a k8s cluster using kind.
 func TestMain(m *testing.M) {
-	e := testenv.CreateActiveEnvForTest([]string{"..", ".."})
+	e := testenv.CreateActiveEnvForTest()
 	env = e.Start()
 	code := testenv.RunCode(m, e)
 	os.Exit(code)

--- a/hack/bin/BUILD.bazel
+++ b/hack/bin/BUILD.bazel
@@ -228,8 +228,8 @@ genrule(
 genrule(
     name = "fetch_kustomize",
     srcs = select({
-        ":darwin": ["@kustomize_darwin//file"],
-        ":k8": ["@kustomize_linux//file"],
+        ":darwin": ["@kustomize_darwin//:file"],
+        ":k8": ["@kustomize_linux//:file"],
     }),
     outs = ["kustomize"],
     cmd = "cp $(SRCS) $@",

--- a/hack/bin/deps.bzl
+++ b/hack/bin/deps.bzl
@@ -365,18 +365,34 @@ def install_operator_sdk():
 
      ## Fetch opm used on generating csv
 def install_kustomize():
-    http_file(
+    http_archive(
        name = "kustomize_darwin",
-       executable = 1,
-       sha256 = "4b8bd021578f90295dbf1145a2ef66e3e25b4d13a9256923e38ce5f85eba1d7d",
-       urls = ["https://storage.googleapis.com/crdb-bazel-artifacts/macos/kustomize"],
+       sha256 = "77898f8b7c37e3ba0c555b4b7c6d0e3301127fa0de7ade6a36ed767ca1715643",
+       urls = ["https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv4.3.0/kustomize_v4.3.0_darwin_amd64.tar.gz"],
+       build_file_content = """
+filegroup(
+    name = "file",
+    srcs = [
+	"kustomize",
+    ],
+    visibility = ["//visibility:public"],
+)
+""",
     )
 
-    http_file(
+    http_archive(
         name = "kustomize_linux",
-        executable = 1,
-        sha256 = "e52e8c194b5084301338d8762bf36b81b5254f525b164ba8b010de123110247f",
-        urls = ["https://storage.googleapis.com/crdb-bazel-artifacts/linux/kustomize"],
+        sha256 = "d34818d2b5d52c2688bce0e10f7965aea1a362611c4f1ddafd95c4d90cb63319",
+        urls = ["https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv4.3.0/kustomize_v4.3.0_linux_amd64.tar.gz"],
+        build_file_content = """
+filegroup(
+    name = "file",
+    srcs = [
+	"kustomize",
+    ],
+    visibility = ["//visibility:public"],
+)
+""",
     )
 
 ## Fetch opm used on generating csv

--- a/hack/build/kustomize.bzl
+++ b/hack/build/kustomize.bzl
@@ -1,0 +1,73 @@
+# Copyright 2020 The Cockroach Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# The kustomization rule generates rules to kustomize the current target.
+#
+# Targets:
+#   <name> - generates the base to a single file at <out>
+#   <name>.preview - generate the base and print to stdout
+#
+# The main goal of this rule is to make it easy to use kustomize to build manifests that can be used as
+# k8s_deploy/k8s_object(s) dependencies.
+#
+# Example:
+#
+#     load("@k8s_deploy//:defaults.bzl", "k8s_deploy")
+#     load("//hack/build:kustomize.bzl", "kustomization")
+#
+#     kustomization(
+#         name = "manifest",
+#         srcs = [":all-srcs"],
+#     )
+#
+#     k8s_deploy(
+#         name = "crd",
+#         template = ":manifest",
+#         visibility = ["//visibility:public"],
+#     )
+def kustomization(
+    name,
+    srcs,
+    out = "manifest.yaml",
+    tools = ["//hack/boilerplate:all-srcs", "//hack/bin:kustomize"],
+    visibility = ["//visibility:public"]):
+  rule_srcs = "{}.srcs".format(name)
+  rule_main = "{}.main".format(name)
+
+  native.filegroup(name = rule_srcs, srcs = srcs, visibility = ["//visibility:public"])
+  native.filegroup(name = rule_main, srcs = ["kustomization.yaml"], visibility = ["//visibility:private"])
+
+  build_cmd = " ".join([
+      "$(location //hack/bin:kustomize)",
+      "build",
+      "--load-restrictor=LoadRestrictionsNone", # allow symlinks because bazel
+      "$$(dirname $(location :{}))".format(rule_main)])
+
+  # bazel build <name> to generate manifest.yaml
+  native.genrule(
+      name = name,
+      exec_tools = tools,
+      srcs = [":{}".format(rule_srcs), ":{}".format(rule_main)],
+      outs = [out],
+      visibility = visibility,
+      cmd = "cat hack/boilerplate/boilerplate.yaml.txt > \"$@\" && {} >> \"$@\"".format(build_cmd))
+
+  # bazel run <name>.preview to view generated manifest
+  native.genrule(
+      name = "{}.preview".format(name),
+      srcs = [":"+ name],
+      outs = ["output"],
+      visibility = visibility,
+      cmd = "echo 'cat $(location :{})' > \"$@\"".format(name),
+      executable = True)

--- a/hack/update-crds.sh
+++ b/hack/update-crds.sh
@@ -54,18 +54,11 @@ do
 done
 
 fix_webhook_manifest() {
-  local selector='namespaceSelector:\n    matchLabels:\n      cockroach-namespace: default'
-
   for file in config/webhook/manifests.yaml; do
     local manifest="${REPO_ROOT}/${file}"
-    # we don't use the "system" namespace here
-    sed 's/namespace: system/namespace: default/g' "${manifest}" > "${manifest}.mod"
     # strip out null creationTimestamp
-    sed '/creationTimestamp: null/d' "${manifest}.mod" > "${manifest}"
-    # add a namespaceSelector to the webhooks (not available via kubebuilder markers)
-    sed "s/name: mcrdbcluster.kb.io/name: mcrdbcluster.kb.io\n  ${selector}/" "${manifest}" > "${manifest}.mod"
-    sed "s/name: vcrdbcluster.kb.io/name: vcrdbcluster.kb.io\n  ${selector}/" "${manifest}.mod" > "${manifest}"
-    rm "${manifest}.mod"
+    sed '/creationTimestamp: null/d' "${manifest}" > "${manifest}.mod"
+    mv "${manifest}.mod" "${manifest}"
   done
 }
 

--- a/manifests/BUILD.bazel
+++ b/manifests/BUILD.bazel
@@ -1,5 +1,11 @@
 load("@k8s_deploy//:defaults.bzl", "k8s_deploy")
 load("@io_bazel_rules_k8s//k8s:objects.bzl", "k8s_objects")
+load("//hack/build:kustomize.bzl", "kustomization")
+
+kustomization(
+    name = "manifest",
+    srcs = [":all-srcs"],
+)
 
 k8s_deploy(
     name = "operator",
@@ -23,8 +29,8 @@ genrule(
 k8s_objects(
     name = "install_operator",
     objects = [
-        "//config/crd/bases:crd",
-        "//config/webhook:webhooks",
+        "//config/crd:crd",
+        "//config/webhook:webhook",
         ":operator",
     ],
 )

--- a/manifests/kustomization.yaml
+++ b/manifests/kustomization.yaml
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+namespace: default
+
 resources:
 - operator.yaml
 

--- a/pkg/testutil/env/BUILD.bazel
+++ b/pkg/testutil/env/BUILD.bazel
@@ -7,7 +7,17 @@ go_library(
         "path.go",
         "sandbox.go",
     ],
-    data = ["//config/crd/bases:crd_manifest"],
+    data = [
+        "//config/crd:manifest",
+        "//config/webhook:manifest",
+        "//hack/bin:cockroach",
+        "//hack/bin:etcd",
+        "//hack/bin:kind",
+        "//hack/bin:kube-apiserver",
+        "//hack/bin:kubectl",
+        "//hack/bin:kubetest2",
+        "//hack/bin:kubetest2-kind",
+    ],
     importpath = "github.com/cockroachdb/cockroach-operator/pkg/testutil/env",
     visibility = ["//visibility:public"],
     deps = [
@@ -44,16 +54,6 @@ go_test(
     srcs = [
         "env_test.go",
         "path_test.go",
-    ],
-    data = [
-        "//config/crd/bases:crd_manifest",
-        "//hack/bin:cockroach",
-        "//hack/bin:etcd",
-        "//hack/bin:kind",
-        "//hack/bin:kube-apiserver",
-        "//hack/bin:kubectl",
-        "//hack/bin:kubetest2",
-        "//hack/bin:kubetest2-kind",
     ],
     deps = [
         ":go_default_library",

--- a/pkg/testutil/env/env_test.go
+++ b/pkg/testutil/env/env_test.go
@@ -23,8 +23,7 @@ import (
 )
 
 func TestCreateEnv(t *testing.T) {
-	env := CreateActiveEnvForTest([]string{"..", "..", ".."})
-	if env == nil {
+	if env := CreateActiveEnvForTest(); env == nil {
 		t.Log("env is nil")
 		t.Fail()
 	}


### PR DESCRIPTION
We've currently got some things using kustomize, but others referencing yaml manifests directly. I think we can leverage kustomize to make things like changing the namespace we deploy to for example much simpler.

I've added the `kustomization` macro, which can be used to generate K8s manifests. These in turn can be used by `k8s_deploy`, `k8s_object(s)`, etc. as inputs.

To do this, I've updated kustomize to the latest version (4.3.0) in order to take advantage of
[replacements](https://kubectl.docs.kubernetes.io/references/kustomize/kustomization/replacements/). These are used to set the namespaceSelector for the webhooks for example, by referencing the namespace from the service. This allows us to set the namespace once in kustomization.yaml and have it used for all resources (unless otherwise specified).

Finally, I've updated the testenv to use these new resources. This ensures that both the crds, and the webhooks are running in the testenv.

**Example**

```bazel
load("@k8s_deploy//:defaults.bzl", "k8s_deploy")
load("//hack/build:kustomize.bzl", "kustomization")

// generates manifest.yaml at runtime by processing kustomization.yaml
kustomization(
    name = "manifest",
    srcs = [":all-srcs"],
)

// deploys the result from :manifest
k8s_deploy(
    name = "my-resource",
    template = ":manifest",
    visibility = ["//visibility:public"],
)
...
...
```
If you'd like to verify the results, you can run `bazel run //<path>:manifest.preview. The resulting manifest will be printed to stdout.