### PR TITLE
Added Custom Annotations support in crdb cluster #696

### DIFF
--- a/apis/v1alpha1/cluster_types.go
+++ b/apis/v1alpha1/cluster_types.go
@@ -109,6 +109,10 @@ type CrdbClusterSpec struct {
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Map of additional custom labels"
 	// +optional
 	AdditionalLabels map[string]string `json:"additionalLabels,omitempty"`
+	// (Optional) Additional custom resource annotations that are added to all resources
+	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Map of additional custom annotations"
+	// +optional
+	AdditionalAnnotations map[string]string `json:"additionalAnnotations,omitempty"`
 	// (Optional) Tolerations for scheduling pods onto some dedicated nodes
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Cockroach Database Tolerations"
 	// +optional

--- a/apis/v1alpha1/cluster_types.go
+++ b/apis/v1alpha1/cluster_types.go
@@ -109,7 +109,8 @@ type CrdbClusterSpec struct {
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Map of additional custom labels"
 	// +optional
 	AdditionalLabels map[string]string `json:"additionalLabels,omitempty"`
-	// (Optional) Additional custom resource annotations that are added to all resources
+	// (Optional) Additional custom resource annotations that are added to all resources.
+	// Changing `AdditionalAnnotations` field will result in cockroachDB cluster restart.
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Map of additional custom annotations"
 	// +optional
 	AdditionalAnnotations map[string]string `json:"additionalAnnotations,omitempty"`

--- a/apis/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/v1alpha1/zz_generated.deepcopy.go
@@ -175,6 +175,13 @@ func (in *CrdbClusterSpec) DeepCopyInto(out *CrdbClusterSpec) {
 			(*out)[key] = val
 		}
 	}
+	if in.AdditionalAnnotations != nil {
+		in, out := &in.AdditionalAnnotations, &out.AdditionalAnnotations
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	if in.Tolerations != nil {
 		in, out := &in.Tolerations, &out.Tolerations
 		*out = make([]v1.Toleration, len(*in))

--- a/config/crd/bases/crdb.cockroachlabs.com_crdbclusters.yaml
+++ b/config/crd/bases/crdb.cockroachlabs.com_crdbclusters.yaml
@@ -59,7 +59,8 @@ spec:
                 additionalProperties:
                   type: string
                 description: (Optional) Additional custom resource annotations that
-                  are added to all resources
+                  are added to all resources. Changing `AdditionalAnnotations` field
+                  will result in cockroachDB cluster restart.
                 type: object
               additionalArgs:
                 description: '(Optional) Additional command line arguments for the

--- a/config/crd/bases/crdb.cockroachlabs.com_crdbclusters.yaml
+++ b/config/crd/bases/crdb.cockroachlabs.com_crdbclusters.yaml
@@ -55,6 +55,12 @@ spec:
             description: CrdbClusterSpec defines the desired state of a CockroachDB
               Cluster that the operator maintains.
             properties:
+              additionalAnnotations:
+                additionalProperties:
+                  type: string
+                description: (Optional) Additional custom resource annotations that
+                  are added to all resources
+                type: object
               additionalArgs:
                 description: '(Optional) Additional command line arguments for the
                   `cockroach` binary Default: ""'

--- a/pkg/kube/helpers.go
+++ b/pkg/kube/helpers.go
@@ -328,3 +328,10 @@ func HandleStsError(err error, l logr.Logger, stsName string, ns string) error {
 	l.Error(err, "error getting statefulset", "stsName", stsName, "namspace", ns)
 	return err
 }
+
+// MergeAnnotations merges the `from` annotations into `to` annotations
+func MergeAnnotations(to, from map[string]string) {
+	for key, value := range from {
+		to[key] = value
+	}
+}

--- a/pkg/resource/discovery_service.go
+++ b/pkg/resource/discovery_service.go
@@ -23,6 +23,8 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/cockroachdb/cockroach-operator/pkg/kube"
 )
 
 // This service only exists to create DNS entries for each pod in
@@ -49,7 +51,13 @@ func (b DiscoveryServiceBuilder) Build(obj client.Object) error {
 		service.ObjectMeta.Labels = map[string]string{}
 	}
 
-	service.ObjectMeta.Annotations = b.monitoringAnnotations()
+	service.Annotations = b.Spec().AdditionalAnnotations
+
+	if service.ObjectMeta.Annotations == nil {
+		service.ObjectMeta.Annotations = map[string]string{}
+	}
+
+	kube.MergeAnnotations(service.ObjectMeta.Annotations, b.monitoringAnnotations())
 
 	service.Spec = corev1.ServiceSpec{
 		ClusterIP:                "None",

--- a/pkg/resource/discovery_service_test.go
+++ b/pkg/resource/discovery_service_test.go
@@ -31,7 +31,8 @@ import (
 )
 
 func TestDiscoveryServiceBuilder(t *testing.T) {
-	cluster := testutil.NewBuilder("test-cluster").Namespaced("test-ns")
+	cluster := testutil.NewBuilder("test-cluster").Namespaced("test-ns").
+		WithAnnotations(map[string]string{"key": "test-discovery-svc"})
 	commonLabels := labels.Common(cluster.Cr())
 
 	tests := []struct {
@@ -52,6 +53,7 @@ func TestDiscoveryServiceBuilder(t *testing.T) {
 						"prometheus.io/scrape": "true",
 						"prometheus.io/path":   "_status/vars",
 						"prometheus.io/port":   "8080",
+						"key":                  "test-discovery-svc",
 					},
 				},
 				Spec: corev1.ServiceSpec{

--- a/pkg/resource/job.go
+++ b/pkg/resource/job.go
@@ -52,6 +52,8 @@ func (b JobBuilder) Build(obj client.Object) error {
 		job.ObjectMeta.Name = b.JobName
 	}
 
+	job.Annotations = b.Spec().AdditionalAnnotations
+
 	// we recreate spec from ground only if we do not find the container job
 	if dbContainer, err := kube.FindContainer(JobContainerName, &job.Spec.Template.Spec); err != nil {
 		job.Spec = kbatch.JobSpec{

--- a/pkg/resource/pod_distruption_budget.go
+++ b/pkg/resource/pod_distruption_budget.go
@@ -49,6 +49,8 @@ func (b PdbBuilder) Build(obj client.Object) error {
 		pdb.ObjectMeta.Labels = map[string]string{}
 	}
 
+	pdb.Annotations = b.Spec().AdditionalAnnotations
+
 	// Using the Common labels that will match
 	// the statefulset
 	commonLabels := labels.Common(b.Cluster.cr)

--- a/pkg/resource/pod_distruption_budget_test.go
+++ b/pkg/resource/pod_distruption_budget_test.go
@@ -33,7 +33,10 @@ import (
 
 func TestPDBBuilder(t *testing.T) {
 	var maxUnavailable int32 = 3
-	cluster := testutil.NewBuilder("test-cluster").Namespaced("test-ns").WithMaxUnavailable(&maxUnavailable)
+	annotations := map[string]string{"key": "test-pdb"}
+
+	cluster := testutil.NewBuilder("test-cluster").Namespaced("test-ns").WithMaxUnavailable(&maxUnavailable).
+		WithAnnotations(annotations)
 	commonLabels := labels.Common(cluster.Cr())
 	selector := commonLabels.Selector(cluster.Cr().Spec.AdditionalLabels)
 
@@ -51,8 +54,9 @@ func TestPDBBuilder(t *testing.T) {
 			selector: commonLabels.Selector(cluster.Cr().Spec.AdditionalLabels),
 			expected: &policy.PodDisruptionBudget{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:   "test-cluster",
-					Labels: map[string]string{},
+					Name:        "test-cluster",
+					Labels:      map[string]string{},
+					Annotations: annotations,
 				},
 				Spec: policy.PodDisruptionBudgetSpec{
 					MaxUnavailable: &maxUnavailableIS,

--- a/pkg/resource/public_service.go
+++ b/pkg/resource/public_service.go
@@ -44,6 +44,8 @@ func (b PublicServiceBuilder) Build(obj client.Object) error {
 		service.ObjectMeta.Labels = map[string]string{}
 	}
 
+	service.Annotations = b.Spec().AdditionalAnnotations
+
 	if service.Spec.Type != corev1.ServiceTypeClusterIP {
 		service.Spec = corev1.ServiceSpec{
 			Type: corev1.ServiceTypeClusterIP,

--- a/pkg/resource/public_service_test.go
+++ b/pkg/resource/public_service_test.go
@@ -31,7 +31,8 @@ import (
 )
 
 func TestPublicServiceBuilder(t *testing.T) {
-	cluster := testutil.NewBuilder("test-cluster").Namespaced("test-ns")
+	annotations := map[string]string{"key": "test-public-svc"}
+	cluster := testutil.NewBuilder("test-cluster").Namespaced("test-ns").WithAnnotations(annotations)
 	commonLabels := labels.Common(cluster.Cr())
 
 	tests := []struct {
@@ -46,8 +47,9 @@ func TestPublicServiceBuilder(t *testing.T) {
 			selector: commonLabels.Selector(cluster.Cr().Spec.AdditionalLabels),
 			expected: &corev1.Service{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:   "test-cluster-public",
-					Labels: map[string]string{},
+					Name:        "test-cluster-public",
+					Labels:      map[string]string{},
+					Annotations: annotations,
 				},
 				Spec: corev1.ServiceSpec{
 					Type: corev1.ServiceTypeClusterIP,

--- a/pkg/resource/statefulset.go
+++ b/pkg/resource/statefulset.go
@@ -193,9 +193,8 @@ func (b StatefulSetBuilder) SetAnnotations(obj client.Object) error {
 func (b StatefulSetBuilder) makePodTemplate() corev1.PodTemplateSpec {
 	pod := corev1.PodTemplateSpec{
 		ObjectMeta: metav1.ObjectMeta{
-			Labels: b.Selector,
-			// TOOO: should we add custom annotations to pod as well ?
-			//Annotations: b.Spec().AdditionalAnnotations,
+			Labels:      b.Selector,
+			Annotations: b.Spec().AdditionalAnnotations,
 		},
 		Spec: corev1.PodSpec{
 			SecurityContext: &corev1.PodSecurityContext{

--- a/pkg/resource/statefulset.go
+++ b/pkg/resource/statefulset.go
@@ -64,6 +64,9 @@ func (b StatefulSetBuilder) Build(obj client.Object) error {
 	if ss.ObjectMeta.Name == "" {
 		ss.ObjectMeta.Name = b.StatefulSetName()
 	}
+
+	ss.Annotations = b.Spec().AdditionalAnnotations
+
 	if ss.Annotations == nil {
 		ss.Annotations = make(map[string]string)
 	}
@@ -191,6 +194,8 @@ func (b StatefulSetBuilder) makePodTemplate() corev1.PodTemplateSpec {
 	pod := corev1.PodTemplateSpec{
 		ObjectMeta: metav1.ObjectMeta{
 			Labels: b.Selector,
+			// TOOO: should we add custom annotations to pod as well ?
+			//Annotations: b.Spec().AdditionalAnnotations,
 		},
 		Spec: corev1.PodSpec{
 			SecurityContext: &corev1.PodSecurityContext{

--- a/pkg/resource/testdata/TestStatefulSetBuilder/insecure_statefulset_cli_args.golden
+++ b/pkg/resource/testdata/TestStatefulSetBuilder/insecure_statefulset_cli_args.golden
@@ -4,6 +4,7 @@ metadata:
   annotations:
     crdb.io/containerimage: ""
     crdb.io/version: ""
+    key: "test-value"
   creationTimestamp: null
   name: test-cluster
 spec:

--- a/pkg/resource/testdata/TestStatefulSetBuilder/insecure_statefulset_cli_args.golden
+++ b/pkg/resource/testdata/TestStatefulSetBuilder/insecure_statefulset_cli_args.golden
@@ -23,6 +23,8 @@ spec:
         app.kubernetes.io/component: database
         app.kubernetes.io/instance: test-cluster
         app.kubernetes.io/name: cockroachdb
+      annotations:
+        key: "test-value"
     spec:
       affinity:
         podAntiAffinity:

--- a/pkg/resource/testdata/TestStatefulSetBuilder/insecure_statefulset_cli_args_in.yaml
+++ b/pkg/resource/testdata/TestStatefulSetBuilder/insecure_statefulset_cli_args_in.yaml
@@ -56,4 +56,6 @@ spec:
     - key: "key"
       operator: "Exists"
       effect: "NoSchedule"
+  additionalAnnotations:
+    key: "test-value"
 status: {}

--- a/pkg/testutil/builder.go
+++ b/pkg/testutil/builder.go
@@ -117,6 +117,11 @@ func (b ClusterBuilder) WithLabels(labels map[string]string) ClusterBuilder {
 	return b
 }
 
+func (b ClusterBuilder) WithAnnotations(annotations map[string]string) ClusterBuilder {
+	b.cluster.Spec.AdditionalAnnotations = annotations
+	return b
+}
+
 func (b ClusterBuilder) WithAffinity(affinity *corev1.Affinity) ClusterBuilder {
 	b.cluster.Spec.Affinity = affinity
 	return b


### PR DESCRIPTION
Closes #696 

* Added Custom Annotations support in crdb cluster
* Added the new API field "additionalAnnotations" for adding user defined annotations to CRDB cluster resources
* Added/Modified existing unit test for this change