### PR TITLE
don't requeue permanent errors

### DIFF
--- a/pkg/controller/cluster_controller.go
+++ b/pkg/controller/cluster_controller.go
@@ -144,7 +144,7 @@ func (r *ClusterReconciler) Reconcile(ctx context.Context, req reconcile.Request
 			// Long pause
 			if cantRecoverErr, ok := err.(actor.PermanentErr); ok {
 				log.Error(cantRecoverErr, "can't proceed with reconcile", "Action", a.GetActionType())
-				return requeueAfter(5*time.Minute, err)
+				return noRequeue()
 			}
 
 			// No requeue until the user makes changes

--- a/pkg/controller/result.go
+++ b/pkg/controller/result.go
@@ -27,7 +27,7 @@ func requeueIfError(err error) (ctrl.Result, error) {
 }
 
 func noRequeue() (ctrl.Result, error) {
-	return requeueIfError(nil)
+	return ctrl.Result{}, nil
 }
 
 func requeueAfter(interval time.Duration, err error) (ctrl.Result, error) {


### PR DESCRIPTION
I'm doing an audit of the way the actors handle errors, and as part of that, looked into how reconciliation handles the errors. It doesn't really make sense that a "permanent" error should get ever get requeued, so let's make them not requeue.

The two existing uses of PermanentErr are indeed pretty permanent: both occur when the `cockroach version` command doesn't run successfully.