### PR TITLE
Drop Nodes() check and loop through builders in deploy action

### DIFF
--- a/pkg/resource/discovery_service.go
+++ b/pkg/resource/discovery_service.go
@@ -37,6 +37,10 @@ type DiscoveryServiceBuilder struct {
 	Selector map[string]string
 }
 
+func (b DiscoveryServiceBuilder) ResourceName() string {
+	return b.DiscoveryServiceName()
+}
+
 func (b DiscoveryServiceBuilder) Build(obj client.Object) error {
 	service, ok := obj.(*corev1.Service)
 	if !ok {
@@ -44,7 +48,7 @@ func (b DiscoveryServiceBuilder) Build(obj client.Object) error {
 	}
 
 	if service.ObjectMeta.Name == "" {
-		service.ObjectMeta.Name = b.DiscoveryServiceName()
+		service.ObjectMeta.Name = b.ResourceName()
 	}
 
 	if service.ObjectMeta.Labels == nil {
@@ -76,7 +80,7 @@ func (b DiscoveryServiceBuilder) Build(obj client.Object) error {
 func (b DiscoveryServiceBuilder) Placeholder() client.Object {
 	return &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: b.DiscoveryServiceName(),
+			Name: b.ResourceName(),
 		},
 	}
 }

--- a/pkg/resource/job.go
+++ b/pkg/resource/job.go
@@ -42,6 +42,10 @@ type JobBuilder struct {
 	JobName  string
 }
 
+func (b JobBuilder) ResourceName() string {
+	return b.JobName
+}
+
 func (b JobBuilder) Build(obj client.Object) error {
 	job, ok := obj.(*kbatch.Job)
 	if !ok {

--- a/pkg/resource/pod_distruption_budget.go
+++ b/pkg/resource/pod_distruption_budget.go
@@ -33,6 +33,10 @@ type PdbBuilder struct {
 	Selector map[string]string
 }
 
+func (b PdbBuilder) ResourceName() string {
+	return b.DiscoveryServiceName()
+}
+
 // Build creates a policy.PodDisruptionBudget for the
 // StatefulSet.
 func (b PdbBuilder) Build(obj client.Object) error {
@@ -42,7 +46,7 @@ func (b PdbBuilder) Build(obj client.Object) error {
 	}
 
 	if pdb.ObjectMeta.Name == "" {
-		pdb.ObjectMeta.Name = b.DiscoveryServiceName()
+		pdb.ObjectMeta.Name = b.ResourceName()
 	}
 
 	if pdb.ObjectMeta.Labels == nil {
@@ -85,7 +89,7 @@ func (b PdbBuilder) Build(obj client.Object) error {
 func (b PdbBuilder) Placeholder() client.Object {
 	return &policy.PodDisruptionBudget{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: b.DiscoveryServiceName(),
+			Name: b.ResourceName(),
 		},
 	}
 }

--- a/pkg/resource/public_service.go
+++ b/pkg/resource/public_service.go
@@ -30,6 +30,10 @@ type PublicServiceBuilder struct {
 	Selector map[string]string
 }
 
+func (b PublicServiceBuilder) ResourceName() string {
+	return b.PublicServiceName()
+}
+
 func (b PublicServiceBuilder) Build(obj client.Object) error {
 	service, ok := obj.(*corev1.Service)
 	if !ok {

--- a/pkg/resource/resource.go
+++ b/pkg/resource/resource.go
@@ -32,6 +32,7 @@ import (
 
 // Builder populates a given Kubernetes resource or creates its default instance (placeholder)
 type Builder interface {
+	ResourceName() string
 	Build(client.Object) error
 	Placeholder() client.Object
 }

--- a/pkg/resource/statefulset.go
+++ b/pkg/resource/statefulset.go
@@ -166,10 +166,14 @@ func (b StatefulSetBuilder) Build(obj client.Object) error {
 	return nil
 }
 
+func (b StatefulSetBuilder) ResourceName() string {
+	return b.StatefulSetName()
+}
+
 func (b StatefulSetBuilder) Placeholder() client.Object {
 	return &appsv1.StatefulSet{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: b.StatefulSetName(),
+			Name: b.Name(),
 		},
 	}
 }


### PR DESCRIPTION
Related to https://github.com/cockroachdb/cockroach-operator/pull/714#discussion_r712474193

There's an unnecessary check for the node counts here in the deploy action. This is handled automatically by the admission controller since we've got a validation on the minimum node count (3).

While I was here, I also updated the action to loop through all the builders (in order) to avoid duplicating all of the reconciler and error checking code.