### PR TITLE
Add labels to PVCs

### DIFF
--- a/apis/v1alpha1/volume.go
+++ b/apis/v1alpha1/volume.go
@@ -48,9 +48,6 @@ func (v *Volume) Apply(name string, container string, path string,
 		pvc := corev1.PersistentVolumeClaim{
 			ObjectMeta: metaMutator(v.VolumeClaim.PersistentVolumeSource.ClaimName),
 			Spec:       v.VolumeClaim.PersistentVolumeClaimSpec,
-			//Status: corev1.PersistentVolumeClaimStatus{`
-			//	Phase: corev1.ClaimPending,
-			//},
 		}
 
 		spec.VolumeClaimTemplates = append(spec.VolumeClaimTemplates, pvc)

--- a/pkg/resource/statefulset.go
+++ b/pkg/resource/statefulset.go
@@ -39,14 +39,15 @@ const (
 	grpcPortName = "grpc"
 	sqlPortName  = "sql"
 
-	DataDirName      = "datadir"
-	DataDirMountPath = "/cockroach/cockroach-data/"
+	dataDirName      = "datadir"
+	dataDirMountPath = "/cockroach/cockroach-data/"
 
 	certsDirName = "certs"
+	certCpCmd    = ">- cp -p /cockroach/cockroach-certs-prestage/..data/* /cockroach/cockroach-certs/ && chmod 700 /cockroach/cockroach-certs/*.key && chown 1000581000:1000581000 /cockroach/cockroach-certs/*.key"
 	emptyDirName = "emptydir"
 
+	// DbContainerName is the name of the container definition in the pod spec
 	DbContainerName = "db"
-	certCpCmd       = ">- cp -p /cockroach/cockroach-certs-prestage/..data/* /cockroach/cockroach-certs/ && chmod 700 /cockroach/cockroach-certs/*.key && chown 1000581000:1000581000 /cockroach/cockroach-certs/*.key"
 )
 
 type StatefulSetBuilder struct {
@@ -85,10 +86,11 @@ func (b StatefulSetBuilder) Build(obj client.Object) error {
 		Template: b.makePodTemplate(),
 	}
 
-	if err := b.Spec().DataStore.Apply(DataDirName, DbContainerName, DataDirMountPath, &ss.Spec,
+	if err := b.Spec().DataStore.Apply(dataDirName, DbContainerName, dataDirMountPath, &ss.Spec,
 		func(name string) metav1.ObjectMeta {
 			return metav1.ObjectMeta{
-				Name: DataDirName,
+				Name:   dataDirName,
+				Labels: b.Selector,
 			}
 		}); err != nil {
 		return err

--- a/pkg/resource/testdata/TestStatefulSetBuilder/default_insecure_statefulset.golden
+++ b/pkg/resource/testdata/TestStatefulSetBuilder/default_insecure_statefulset.golden
@@ -93,6 +93,10 @@ spec:
   - metadata:
       creationTimestamp: null
       name: datadir
+      labels:
+        app.kubernetes.io/component: database
+        app.kubernetes.io/instance: test-cluster
+        app.kubernetes.io/name: cockroachdb
     spec:
       accessModes:
       - ReadWriteOnce

--- a/pkg/resource/testdata/TestStatefulSetBuilder/default_secure.golden
+++ b/pkg/resource/testdata/TestStatefulSetBuilder/default_secure.golden
@@ -141,6 +141,11 @@ spec:
   - metadata:
       creationTimestamp: null
       name: datadir
+      labels:
+        app.kubernetes.io/component: database
+        app.kubernetes.io/instance: test-cluster
+        app.kubernetes.io/name: cockroachdb
+        car: koenigsegg
     spec:
       accessModes:
       - ReadWriteOnce

--- a/pkg/resource/testdata/TestStatefulSetBuilder/insecure_statefulset_cli_args.golden
+++ b/pkg/resource/testdata/TestStatefulSetBuilder/insecure_statefulset_cli_args.golden
@@ -112,6 +112,10 @@ spec:
   - metadata:
       creationTimestamp: null
       name: datadir
+      labels:
+        app.kubernetes.io/component: database
+        app.kubernetes.io/instance: test-cluster
+        app.kubernetes.io/name: cockroachdb
     spec:
       accessModes:
       - ReadWriteOnce

--- a/pkg/resource/testdata/TestStatefulSetBuilder/insecure_statefulset_with_resources.golden
+++ b/pkg/resource/testdata/TestStatefulSetBuilder/insecure_statefulset_with_resources.golden
@@ -97,6 +97,10 @@ spec:
   - metadata:
       creationTimestamp: null
       name: datadir
+      labels:
+        app.kubernetes.io/component: database
+        app.kubernetes.io/instance: test-cluster
+        app.kubernetes.io/name: cockroachdb
     spec:
       accessModes:
       - ReadWriteOnce


### PR DESCRIPTION
Our intention with `AdditionalLabels` is to add them to all resources created by CrdbCluster. Currently, the PVCs are missing these. So I've updated the StatefulSet resource appropriately to add the labels.

How to verify this works:

```shell
$ make dev/up
$ kubectl apply -f examples/example.yaml
$ kubectl get pods -w # wait until at least one of the db pods is running and ready
$ k get pvc datadir-cockroachdb-0 -oyaml
# verify that `crdb: is-cool` is in the labels
$ make dev/down
```