### PR TITLE
Tear down test env with each test

### DIFF
--- a/e2e/create/create_test.go
+++ b/e2e/create/create_test.go
@@ -18,7 +18,6 @@ package e2e
 
 import (
 	"flag"
-	"os"
 	"testing"
 	"time"
 
@@ -39,18 +38,6 @@ var parallel = *flag.Bool("parallel", false, "run tests in parallel")
 // run the pvc test
 var pvc = flag.Bool("pvc", false, "run pvc test")
 
-// TODO should we make this an atomic that is created by evn pkg?
-var env *testenv.ActiveEnv
-
-// TestMain wraps the unit tests. Set TEST_DO_NOT_USE_KIND evnvironment variable to any value
-// if you do not want this test to start a k8s cluster using kind.
-func TestMain(m *testing.M) {
-	e := testenv.CreateActiveEnvForTest()
-	env = e.Start()
-	code := testenv.RunCode(m, e)
-	os.Exit(code)
-}
-
 func TestCreateInsecureCluster(t *testing.T) {
 	// Test Creating an insecure cluster
 	// No actions on the cluster just create it and
@@ -66,6 +53,10 @@ func TestCreateInsecureCluster(t *testing.T) {
 	testLog := zapr.NewLogger(zaptest.NewLogger(t))
 
 	actor.Log = testLog
+
+	e := testenv.CreateActiveEnvForTest()
+	env := e.Start()
+	defer e.Stop()
 
 	sb := testenv.NewDiffingSandbox(t, env)
 	sb.StartManager(t, controller.InitClusterReconcilerWithLogger(testLog))
@@ -106,6 +97,10 @@ func TestCreatesSecureCluster(t *testing.T) {
 	testLog := zapr.NewLogger(zaptest.NewLogger(t))
 
 	actor.Log = testLog
+
+	e := testenv.CreateActiveEnvForTest()
+	env := e.Start()
+	defer e.Stop()
 
 	sb := testenv.NewDiffingSandbox(t, env)
 	sb.StartManager(t, controller.InitClusterReconcilerWithLogger(testLog))

--- a/e2e/upgrades/upgrades_test.go
+++ b/e2e/upgrades/upgrades_test.go
@@ -18,7 +18,6 @@ package upgrades
 
 import (
 	"flag"
-	"os"
 	"testing"
 	"time"
 
@@ -35,22 +34,10 @@ import (
 // for openshift.  We need to create those only once.
 var parallel = *flag.Bool("parallel", false, "run tests in parallel")
 
-// TODO should we make this an atomic that is created by evn pkg?
-var env *testenv.ActiveEnv
-
 // TODO move these into a common file
 var MinorVersion1 string = "cockroachdb/cockroach:v20.2.8"
 var MinorVersion2 string = "cockroachdb/cockroach:v20.2.9"
 var MajorVersion string = "cockroachdb/cockroach:v21.1.0"
-
-// TestMain wraps the unit tests. Set TEST_DO_NOT_USE_KIND evnvironment variable to any value
-// if you do not want this test to start a k8s cluster using kind.
-func TestMain(m *testing.M) {
-	e := testenv.CreateActiveEnvForTest()
-	env = e.Start()
-	code := testenv.RunCode(m, e)
-	os.Exit(code)
-}
 
 // TestUpgradesMinorVersion tests a minor version bump
 func TestUpgradesMinorVersion(t *testing.T) {
@@ -69,6 +56,10 @@ func TestUpgradesMinorVersion(t *testing.T) {
 	testLog := zapr.NewLogger(zaptest.NewLogger(t))
 
 	actor.Log = testLog
+
+	e := testenv.CreateActiveEnvForTest()
+	env := e.Start()
+	defer e.Stop()
 
 	sb := testenv.NewDiffingSandbox(t, env)
 	sb.StartManager(t, controller.InitClusterReconcilerWithLogger(testLog))
@@ -121,6 +112,10 @@ func TestUpgradesMajorVersion20to21(t *testing.T) {
 
 	actor.Log = testLog
 
+	e := testenv.CreateActiveEnvForTest()
+	env := e.Start()
+	defer e.Stop()
+
 	sb := testenv.NewDiffingSandbox(t, env)
 	sb.StartManager(t, controller.InitClusterReconcilerWithLogger(testLog))
 
@@ -169,6 +164,10 @@ func TestUpgradesMajorVersion20_1To20_2(t *testing.T) {
 	testLog := zapr.NewLogger(zaptest.NewLogger(t))
 
 	actor.Log = testLog
+
+	e := testenv.CreateActiveEnvForTest()
+	env := e.Start()
+	defer e.Stop()
 
 	sb := testenv.NewDiffingSandbox(t, env)
 	sb.StartManager(t, controller.InitClusterReconcilerWithLogger(testLog))
@@ -224,6 +223,10 @@ func TestUpgradesMinorVersionThenRollback(t *testing.T) {
 	testLog := zapr.NewLogger(zaptest.NewLogger(t))
 
 	actor.Log = testLog
+
+	e := testenv.CreateActiveEnvForTest()
+	env := e.Start()
+	defer e.Stop()
 
 	sb := testenv.NewDiffingSandbox(t, env)
 	sb.StartManager(t, controller.InitClusterReconcilerWithLogger(testLog))

--- a/e2e/upgradessha256/upgradessha256_test.go
+++ b/e2e/upgradessha256/upgradessha256_test.go
@@ -36,18 +36,6 @@ import (
 // We may have a threadsafe problem where one test starts messing with another test
 var parallel = *flag.Bool("parallel", false, "run tests in parallel")
 
-// TODO should we make this an atomic that is created by evn pkg?
-var env *testenv.ActiveEnv
-
-// TestMain wraps the unit tests. Set TEST_DO_NOT_USE_KIND evnvironment variable to any value
-// if you do not want this test to start a k8s cluster using kind.
-func TestMain(m *testing.M) {
-	e := testenv.CreateActiveEnvForTest()
-	env = e.Start()
-	code := testenv.RunCode(m, e)
-	os.Exit(code)
-}
-
 // TestUpgradesMinorVersion tests a minor version bump
 func TestUpgradesMinorVersion(t *testing.T) {
 
@@ -65,6 +53,10 @@ func TestUpgradesMinorVersion(t *testing.T) {
 	testLog := zapr.NewLogger(zaptest.NewLogger(t))
 
 	actor.Log = testLog
+
+	e := testenv.CreateActiveEnvForTest()
+	env := e.Start()
+	defer e.Stop()
 
 	sb := testenv.NewDiffingSandbox(t, env)
 	sb.StartManager(t, controller.InitClusterReconcilerWithLogger(testLog))
@@ -125,6 +117,10 @@ func TestUpgradesMajorVersion20to21(t *testing.T) {
 
 	actor.Log = testLog
 
+	e := testenv.CreateActiveEnvForTest()
+	env := e.Start()
+	defer e.Stop()
+
 	sb := testenv.NewDiffingSandbox(t, env)
 	sb.StartManager(t, controller.InitClusterReconcilerWithLogger(testLog))
 	//related images must be in sha256 format
@@ -177,6 +173,10 @@ func TestUpgradesMajorVersion20_1To20_2(t *testing.T) {
 	testLog := zapr.NewLogger(zaptest.NewLogger(t))
 
 	actor.Log = testLog
+
+	e := testenv.CreateActiveEnvForTest()
+	env := e.Start()
+	defer e.Stop()
 
 	sb := testenv.NewDiffingSandbox(t, env)
 	sb.StartManager(t, controller.InitClusterReconcilerWithLogger(testLog))

--- a/pkg/testutil/env/env.go
+++ b/pkg/testutil/env/env.go
@@ -19,9 +19,6 @@ package env
 import (
 	"flag"
 	"fmt"
-	"os"
-	"testing"
-
 	api "github.com/cockroachdb/cockroach-operator/apis/v1alpha1"
 	customClient "github.com/cockroachdb/cockroach-operator/pkg/client/clientset/versioned"
 	"github.com/cockroachdb/errors"
@@ -33,6 +30,7 @@ import (
 	kscheme "k8s.io/client-go/kubernetes/scheme"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp" // GCP auth support
 	"k8s.io/client-go/rest"
+	"os"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 )
@@ -137,13 +135,6 @@ type ActiveEnv struct {
 func CreateActiveEnvForTest() *Env {
 	os.Setenv("USE_EXISTING_CLUSTER", "true")
 	return NewEnv(runtime.NewSchemeBuilder(api.AddToScheme))
-}
-
-func RunCode(m *testing.M, e *Env) int {
-	e.Start()
-	code := m.Run()
-	e.Stop()
-	return code
 }
 
 func loadResources(k *k8s) ([]schema.GroupVersionResource, error) {


### PR DESCRIPTION
There's an issue with the existing test structure where the controller may log something in between when a test finishes and when the test env is torn down, causing a panic. I'm working on a separate PR that adds some more logging to the controller and this race condition became really apparent.

Fix by starting and stopping the test env tightly around each test.