### PR TITLE
make upgradessha256 actually run upgradessha256

### DIFF
--- a/.github/workflows/e2e-kind-upgradessha256.yaml
+++ b/.github/workflows/e2e-kind-upgradessha256.yaml
@@ -17,12 +17,12 @@ name: e2e-kind-upgradessha256
 on:
   # Triggers the workflow on push or pull request events but only for the master branch
   push:
-    branches: [master]
+    branches: [ master ]
     paths-ignore:
       - "**.md"
       - "docs/**"
   pull_request:
-    branches: [master]
+    branches: [ master ]
     paths-ignore:
       - "**.md"
       - "docs/**"
@@ -31,12 +31,12 @@ on:
   workflow_dispatch:
 
 jobs:
-  e2e-kind-upgrades:
+  e2e-kind-upgradessha256:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        bazel: ["4.0.0"]
+        bazel: [ "4.0.0" ]
     steps:
       - uses: actions/checkout@v2
 


### PR DESCRIPTION
The e2e upgradessha256 job had the same name as the e2e upgrades job in CI, and because of that I think they ended up running the exact same tests which is a little pointless. I think this fixes it to what was intended.