### PR TITLE
actually update cluster conditions in initialize actor

### DIFF
--- a/apis/v1alpha1/condition_types.go
+++ b/apis/v1alpha1/condition_types.go
@@ -26,8 +26,8 @@ const (
 	CrdbVersionChecked ClusterConditionType = "CrdbVersionChecked"
 	//DecommissionCondition string
 	DecommissionCondition ClusterConditionType = "Decommission"
-	//InitializedCondition string
-	InitializedCondition ClusterConditionType = "Initialized"
+	//CrdbInitializedCondition string
+	CrdbInitializedCondition ClusterConditionType = "Initialized"
 	//ClusterRestartCondition string
 	ClusterRestartCondition ClusterConditionType = "RestartedCluster"
 )

--- a/pkg/actor/actor.go
+++ b/pkg/actor/actor.go
@@ -110,8 +110,8 @@ func (cd *clusterDirector) GetActorsToExecute(cluster *resource.Cluster) []Actor
 	featureDecommissionEnabled := utilfeature.DefaultMutableFeatureGate.Enabled(features.Decommission)
 	featureResizePVCEnabled := utilfeature.DefaultMutableFeatureGate.Enabled(features.ResizePVC)
 	featureClusterRestartEnabled := utilfeature.DefaultMutableFeatureGate.Enabled(features.ClusterRestart)
-	conditionInitializedTrue := condition.True(api.InitializedCondition, conditions)
-	conditionInitializedFalse := condition.False(api.InitializedCondition, conditions)
+	conditionInitializedTrue := condition.True(api.CrdbInitializedCondition, conditions)
+	conditionInitializedFalse := condition.False(api.CrdbInitializedCondition, conditions)
 	conditionVersionCheckedTrue := condition.True(api.CrdbVersionChecked, conditions)
 	conditionVersionCheckedFalse := condition.False(api.CrdbVersionChecked, conditions)
 

--- a/pkg/actor/actor_test.go
+++ b/pkg/actor/actor_test.go
@@ -52,7 +52,7 @@ func createTestDirectorAndCluster(t *testing.T) (*resource.Cluster, actor.Direct
 func TestDecommissionFeatureGate(t *testing.T) {
 	cluster, director := createTestDirectorAndCluster(t)
 
-	cluster.SetTrue(api.InitializedCondition)
+	cluster.SetTrue(api.CrdbInitializedCondition)
 
 	utilfeature.DefaultMutableFeatureGate.Set("UseDecommission=true")
 	actors := director.GetActorsToExecute(cluster)
@@ -66,7 +66,7 @@ func TestDecommissionFeatureGate(t *testing.T) {
 func TestVersionValidatorFeatureGate(t *testing.T) {
 	cluster, director := createTestDirectorAndCluster(t)
 
-	cluster.SetTrue(api.InitializedCondition)
+	cluster.SetTrue(api.CrdbInitializedCondition)
 
 	utilfeature.DefaultMutableFeatureGate.Set("CrdbVersionValidator=true")
 	actors := director.GetActorsToExecute(cluster)
@@ -80,7 +80,7 @@ func TestVersionValidatorFeatureGate(t *testing.T) {
 func TestResizePVCFeatureGate(t *testing.T) {
 	cluster, director := createTestDirectorAndCluster(t)
 
-	cluster.SetTrue(api.InitializedCondition)
+	cluster.SetTrue(api.CrdbInitializedCondition)
 
 	utilfeature.DefaultMutableFeatureGate.Set("ResizePVC=true")
 	actors := director.GetActorsToExecute(cluster)
@@ -94,7 +94,7 @@ func TestResizePVCFeatureGate(t *testing.T) {
 func TestClusterRestartFeatureGate(t *testing.T) {
 	cluster, director := createTestDirectorAndCluster(t)
 
-	cluster.SetTrue(api.InitializedCondition)
+	cluster.SetTrue(api.CrdbInitializedCondition)
 	cluster.SetTrue(api.CrdbVersionChecked)
 
 	utilfeature.DefaultMutableFeatureGate.Set("ClusterRestart=true")
@@ -141,7 +141,7 @@ func TestInitializedButNotVersionChecked(t *testing.T) {
 	cluster, director := createTestDirectorAndCluster(t)
 
 	utilfeature.DefaultMutableFeatureGate.Set("UseDecommission=true,CrdbVersionValidator=true,ResizePVC=true,ClusterRestart=true")
-	cluster.SetTrue(api.InitializedCondition)
+	cluster.SetTrue(api.CrdbInitializedCondition)
 
 	actors := director.GetActorsToExecute(cluster)
 	require.True(t, actorsHaveTypes(actors, []api.ActionType{api.DecommissionAction, api.VersionCheckerAction, api.ResizePVCAction}))
@@ -151,7 +151,7 @@ func TestVersionCheckedAndInitialized(t *testing.T) {
 	cluster, director := createTestDirectorAndCluster(t)
 
 	utilfeature.DefaultMutableFeatureGate.Set("UseDecommission=true,CrdbVersionValidator=true,ResizePVC=true,ClusterRestart=true")
-	cluster.SetTrue(api.InitializedCondition)
+	cluster.SetTrue(api.CrdbInitializedCondition)
 	cluster.SetTrue(api.CrdbVersionChecked)
 
 	actors := director.GetActorsToExecute(cluster)

--- a/pkg/actor/initialize.go
+++ b/pkg/actor/initialize.go
@@ -137,7 +137,7 @@ func (init initialize) Act(ctx context.Context, cluster *resource.Cluster) error
 			return errors.Wrap(err, msg)
 		}
 		refreshedCluster := resource.NewCluster(newcr)
-		refreshedCluster.SetTrue(api.InitializedCondition)
+		refreshedCluster.SetTrue(api.CrdbInitializedCondition)
 
 		err = init.client.Status().Update(ctx, refreshedCluster.Unwrap())
 		if err != nil {

--- a/pkg/actor/initialize.go
+++ b/pkg/actor/initialize.go
@@ -128,17 +128,23 @@ func (init initialize) Act(ctx context.Context, cluster *resource.Cluster) error
 		return errors.Wrap(err, msg)
 	}
 
+	// If we got here, we need to update the CrdbClusterStatus object with an updated CrdbInitialized condition.
 	fetcher := resource.NewKubeFetcher(ctx, cluster.Namespace(), init.client)
 	err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		// Fetch the latest CrdbClusterStatus
 		newcr := resource.ClusterPlaceholder(cluster.Name())
 		if err := fetcher.Fetch(newcr); err != nil {
 			msg := "failed to retrieve CrdbCluster resource"
 			log.Error(err, msg)
 			return errors.Wrap(err, msg)
 		}
+
+		// Set the CrdbInitialized condition in the cluster status to true
 		refreshedCluster := resource.NewCluster(newcr)
 		refreshedCluster.SetTrue(api.CrdbInitializedCondition)
 
+		// Actually attempt to update the CrdbClusterStatus object. If the update runs into a conflict for any reason
+		// (say, the client adds a label to the CrdbCluster object), we will retry.
 		err = init.client.Status().Update(ctx, refreshedCluster.Unwrap())
 		if err != nil {
 			msg := "failed to update initialized annotation; will try again"

--- a/pkg/actor/initialize.go
+++ b/pkg/actor/initialize.go
@@ -19,6 +19,7 @@ package actor
 import (
 	"context"
 	"fmt"
+	"k8s.io/client-go/util/retry"
 	"strconv"
 	"strings"
 
@@ -127,9 +128,32 @@ func (init initialize) Act(ctx context.Context, cluster *resource.Cluster) error
 		return errors.Wrap(err, msg)
 	}
 
-	cluster.SetTrue(api.InitializedCondition)
+	fetcher := resource.NewKubeFetcher(ctx, cluster.Namespace(), init.client)
+	err = retry.RetryOnConflict(retry.DefaultRetry, func() error {
+		newcr := resource.ClusterPlaceholder(cluster.Name())
+		if err := fetcher.Fetch(newcr); err != nil {
+			msg := "failed to retrieve CrdbCluster resource"
+			log.Error(err, msg)
+			return errors.Wrap(err, msg)
+		}
+		refreshedCluster := resource.NewCluster(newcr)
+		refreshedCluster.SetTrue(api.InitializedCondition)
 
-	log.V(DEBUGLEVEL).Info("completed intializing database")
+		err = init.client.Status().Update(ctx, refreshedCluster.Unwrap())
+		if err != nil {
+			msg := "failed to update initialized annotation; will try again"
+			log.Error(err, msg)
+			return errors.Wrap(err, msg)
+		}
+		return err
+	})
+	if err != nil {
+		msg := "failed to update initialized annotation"
+		log.Error(err, msg)
+		return errors.Wrap(err, msg)
+	}
+
+	log.V(DEBUGLEVEL).Info("completed initializing database")
 	return nil
 }
 

--- a/pkg/actor/initialize.go
+++ b/pkg/actor/initialize.go
@@ -144,7 +144,7 @@ func (init initialize) Act(ctx context.Context, cluster *resource.Cluster) error
 		refreshedCluster.SetTrue(api.CrdbInitializedCondition)
 
 		// Actually attempt to update the CrdbClusterStatus object. If the update runs into a conflict for any reason
-		// (say, the client adds a label to the CrdbCluster object), we will retry.
+		// (say, someone adds a label to the CrdbCluster object after we just retrieved it), we will retry.
 		err = init.client.Status().Update(ctx, refreshedCluster.Unwrap())
 		if err != nil {
 			msg := "failed to update initialized annotation; will try again"

--- a/pkg/condition/condition.go
+++ b/pkg/condition/condition.go
@@ -27,7 +27,7 @@ func InitConditionsIfNeeded(status *api.CrdbClusterStatus, now metav1.Time) {
 	}
 
 	if len(status.Conditions) == 0 {
-		SetFalse(api.InitializedCondition, status, now)
+		SetFalse(api.CrdbInitializedCondition, status, now)
 		//we make sure we will use version validator on first run
 		SetFalse(api.CrdbVersionChecked, status, now)
 	}


### PR DESCRIPTION
It looks like the intent of this one existing line in Initialize is to actually set the cluster initialized condition to true, but currently it's only working by coincidence when the updated cluster gets written way downstream for something unrelated. The bit of refactoring I've done so far has surfaced this bug.

Make it so we actually update the cluster initialized condition within the initialize actor.