### PR TITLE
Make the controller watch Job objects

### DIFF
--- a/pkg/controller/BUILD.bazel
+++ b/pkg/controller/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
         "@com_github_go_logr_logr//:go_default_library",
         "@com_github_lithammer_shortuuid_v3//:go_default_library",
         "@io_k8s_api//apps/v1:go_default_library",
+        "@io_k8s_api//batch/v1:go_default_library",
         "@io_k8s_api//core/v1:go_default_library",
         "@io_k8s_api//policy/v1beta1:go_default_library",
         "@io_k8s_apimachinery//pkg/runtime:go_default_library",

--- a/pkg/controller/cluster_controller.go
+++ b/pkg/controller/cluster_controller.go
@@ -19,6 +19,7 @@ package controller
 import (
 	"context"
 	"fmt"
+	kbatch "k8s.io/api/batch/v1"
 	"time"
 
 	api "github.com/cockroachdb/cockroach-operator/apis/v1alpha1"
@@ -200,6 +201,7 @@ func (r *ClusterReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&corev1.Service{}).
 		Owns(&appsv1.StatefulSet{}).
 		Owns(&policy.PodDisruptionBudget{}).
+		Owns(&kbatch.Job{}).
 		Complete(r)
 }
 

--- a/pkg/controller/cluster_controller.go
+++ b/pkg/controller/cluster_controller.go
@@ -19,7 +19,6 @@ package controller
 import (
 	"context"
 	"fmt"
-	kbatch "k8s.io/api/batch/v1"
 	"time"
 
 	api "github.com/cockroachdb/cockroach-operator/apis/v1alpha1"
@@ -29,6 +28,7 @@ import (
 	"github.com/lithammer/shortuuid/v3"
 	"go.uber.org/zap/zapcore"
 	appsv1 "k8s.io/api/apps/v1"
+	kbatch "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
 	policy "k8s.io/api/policy/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime"


### PR DESCRIPTION
I just ran into another bug in e2e testing where the version checker job started and then...absolutely nothing happened and the test timed out:
```
    logger.go:130: 2021-09-29T19:58:00.059Z	INFO	reconciling CockroachDB cluster	{"CrdbCluster": "crdb-test-m9g4jp/crdb", "ReconcileId": "Hq3Y3Q4sDNRVqepTBWDWYK"}
    logger.go:130: 2021-09-29T19:58:00.059Z	INFO	Running action with name: VersionCheckerAction	{"CrdbCluster": "crdb-test-m9g4jp/crdb", "ReconcileId": "Hq3Y3Q4sDNRVqepTBWDWYK"}
    logger.go:130: 2021-09-29T19:58:00.059Z	WARN	starting to check the crdb version of the container provided	{"CrdbCluster": "crdb-test-m9g4jp/crdb", "ReconcileId": "Hq3Y3Q4sDNRVqepTBWDWYK"}
    logger.go:130: 2021-09-29T19:58:00.059Z	WARN	User set image.name, using that field instead of cockroachDBVersion	{"CrdbCluster": "crdb-test-m9g4jp/crdb", "ReconcileId": "Hq3Y3Q4sDNRVqepTBWDWYK"}
    logger.go:130: 2021-09-29T19:58:00.072Z	WARN	created/updated job, stopping request processing	{"CrdbCluster": "crdb-test-m9g4jp/crdb", "ReconcileId": "Hq3Y3Q4sDNRVqepTBWDWYK"}
    logger.go:130: 2021-09-29T19:58:00.072Z	INFO	request was interrupted	{"CrdbCluster": "crdb-test-m9g4jp/crdb", "ReconcileId": "Hq3Y3Q4sDNRVqepTBWDWYK"}
=== CONT  TestCreateInsecureCluster/creates_3-node_insecure_cluster
    require.go:64: stateful set is not found
    require.go:64: stateful set is not found
    require.go:64: stateful set is not found
    require.go:64: stateful set is not found
    require.go:64: stateful set is not found
    require.go:64: stateful set is not found
    require.go:64: stateful set is not found
...
```

If you look at the code associated with the log "request was interrupted" it says 
```
// Stop processing and wait for Kubernetes scheduler to call us again as the actor
// modified a resource owned by the controller
```
but I believe the issue here is that VersionChecker starts a job and then terminates the request to wait for another call to Reconcile, but the controller does not watch Job objects, so it's possible that no more calls to Reconcile happen.

Hopefully it's as simple a fix as this.