### PR TITLE
Adding CHANGELOG.md for tracking changes between releases

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,5 @@
+_Add a description of the problem this PR addresses and an overview of how this PR works_.
+
+**Checklist**
+
+* [ ] I have added these changes to the changlog (or it's not applicable).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,69 @@
+# CHANGELOG
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+# [Unreleased](https://github.com/cockroachdb/cockroach-operator/compare/v2.2.0-beta.2...master)
+
+## Added
+
+* Added CHANGELOG.md to track changes across releases
+
+# [v2.2.0-beta.2](https://github.com/cockroachdb/cockroach-operator/compare/v2.2.0-beta.1...v2.2.0-beta.2)
+
+## Added
+
+* More information to operator logs (e.g. reconcilerID)
+
+## Changed
+
+* Refactor templates to leverage kustomize bases/overlays in //config
+
+## Fixed
+
+* Propagate affinity and tolerations for version checker job
+* Ensure the controller watches owned job objects
+* CertificateGenerated conditional correctly set during deploys
+
+# [v2.2.0-beta.1](https://github.com/cockroachdb/cockroach-operator/compare/v2.1.0...v2.2.0-beta.1)
+
+## Added
+
+* Support for taints and tolerations
+* Support for custom annotations
+* Mutating and validating webhooks and associated TLS configuration
+* Several enhancements for local development (e.g. `make dev/up`)
+
+## Changed
+
+* Updated validation markers for the CRD (required, minimum, etc.)
+* Introduced Director to consolidate the handles logic from the actors
+* Standardized on cockroachdb/errors for wrapping errors
+
+## Fixed
+
+* No longer requeueing permanent errors
+* PVCs no longer missing `AdditionalLabels`
+* Some flakiness in e2e tests
+* Version checker jobs no longer pile up when pods take >2m to come up
+
+# [v2.1.0](https://github.com/cockroachdb/cockroach-operator/compare/v2.0.1...v2.1.0)
+
+## Added
+
+* `AdditionalLabels` which are added to all managed resources
+* Examples for new features (addition labels, affinity rules, etc)
+* e2e tests for EKS, OpenShift, and downgrading
+
+## Changed
+
+* Skip the initContainer when running an insecure cluster
+* Can now pass additional parameters to OpenShift
+* Updating of crdbversions.yaml now automated via GitHub actions
+
+## Deleted
+
+* Dead code from multiple packages
+* Dependency on ginko and gomega

--- a/hack/release/main.go
+++ b/hack/release/main.go
@@ -18,6 +18,7 @@ package main
 import (
 	"flag"
 	"fmt"
+	"io/ioutil"
 	"os"
 	"os/exec"
 
@@ -39,6 +40,7 @@ func main() {
 		EnsureUniqueVersion(func(cmd *exec.Cmd) error { return cmd.Run() }),
 		CreateReleaseBranch(process.ExecJUnit),
 		UpdateVersion(),
+		UpdateChangelog(ioutil.ReadFile),
 		GenerateFiles(process.ExecJUnit),
 	}
 

--- a/hack/release/steps_test.go
+++ b/hack/release/steps_test.go
@@ -132,3 +132,38 @@ func TestGenerateFiles(t *testing.T) {
 		require.Equal(t, os.Environ(), fn.env)
 	}
 }
+
+func TestUpdateChangelog(t *testing.T) {
+	input := `
+# CHANGELOG yada yada yada
+...
+[Unreleased](https://github.com/cockroachdb/cockroach-operator/compare/v1.0.0...master)
+
+* Some unreleased content
+
+[v1.0.0](https://github.com/cockroachdb/cockroach-operator/compare/v0.9.0...v1.0.0)
+...
+[v0.9.0](https://github.com/cockroachdb/cockroach-operator/compare/v0.8.0...v0.9.0)
+`
+
+	expected := `
+# CHANGELOG yada yada yada
+...
+[Unreleased](https://github.com/cockroachdb/cockroach-operator/compare/v1.1.0...master)
+
+[v1.1.0](https://github.com/cockroachdb/cockroach-operator/compare/v1.0.0...v1.1.0)
+
+* Some unreleased content
+
+[v1.0.0](https://github.com/cockroachdb/cockroach-operator/compare/v0.9.0...v1.0.0)
+...
+[v0.9.0](https://github.com/cockroachdb/cockroach-operator/compare/v0.8.0...v0.9.0)
+`
+
+	err := UpdateChangelog(func(_ string) ([]byte, error) { return []byte(input), nil }).Apply("v1.1.0")
+	require.NoError(t, err)
+
+	data, err := ioutil.ReadFile("CHANGELOG.md")
+	require.NoError(t, err)
+	require.Equal(t, string(data), expected)
+}


### PR DESCRIPTION
The title says it all really. The format follows a known standard, and includes links to the diffs for every released version.

I've also updated hack/release to automatically convert the previous `[Unreleased]` section to the new release and add a new unlreleased heading to point to the diff between the latest release and master.

Finally, I went through the changes from v2.1.0 to now and backfilled the details here.

> NOTE: If we've got a previous beta, as we do right now, we'll need to copy the details (Added/Changed/etc) from those to the new release before pushing the new release branch.

New PRs will have a checklist that will remind us to update the changelog regularly.

**Testing**

To test this out, you need to comment out the `origin/master` argument in hack/release/steps.go since the CHANGELOG file doesn't yet exist on master.

```
# hack/release/steps.go
old: []string{"checkout", "-b", fmt.Sprintf("release-%s", version), "origin/master"}
new: []string{"checkout", "-b", fmt.Sprintf("release-%s", version)}
```

* `git commit -am "temp commit for testing"`
* `make release/new VERSION=2.2.0`

You'll now be on a new release branch with a clean git index. The updated CHANGELOG.md file can be inspected for correctness.