### PR TITLE
Add nightly tests for supported K8s versions

### DIFF
--- a/.github/workflows/nightly-smoketest.yaml
+++ b/.github/workflows/nightly-smoketest.yaml
@@ -1,0 +1,46 @@
+# Copyright 2021 The Cockroach Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# This workflow tests that we can stand up a CRDB cluster with the operator and execute SQL in the cluster. It uses the
+# steps that are outlined in our public docs to ensure that the flow we're recommending always works.
+name: Nightly Smoketest
+
+on:
+  schedule:
+    # runs at 3am UTC Mon-Fri
+    # ref: <min> <hr> <month-day> <month> <weekday>
+    - cron: '0 3 * * 1-5'
+
+  # allows running from the actions tab in GitHub
+  workflow_dispatch: ~
+
+jobs:
+  smoketest:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        # supported Kubenetes versions
+        NODE_VERSION: [1.18.19, 1.19.11, 1.20.7, 1.21.2, 1.22.1]
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup Bazel
+        uses: abhinavsingh/setup-bazel@v3
+        with:
+          version: 4.2.1
+
+      - name: Bank Workload
+        env:
+          NODE_VERSION: ${{ matrix.NODE_VERSION }}
+        run: make test/smoketest

--- a/Makefile
+++ b/Makefile
@@ -64,6 +64,11 @@ test/verify:
 test/lint:
 	bazel run //hack:verify-gofmt
 
+# NODE_VERSION refers the to version of the kindest/node image. E.g. 1.22.1
+.PHONY: test/smoketest
+test/smoketest:
+	@bazel run //hack/smoketest -- -dir $(PWD) -version $(NODE_VERSION)
+
 # Run only e2e stort tests
 # We can use this to only run one specific test
 .PHONY: test/e2e-short

--- a/hack/BUILD.bazel
+++ b/hack/BUILD.bazel
@@ -178,6 +178,7 @@ filegroup(
         "//hack/gke:all-srcs",
         "//hack/k8s:all-srcs",
         "//hack/release:all-srcs",
+        "//hack/smoketest:all-srcs",
     ],
     tags = ["automanaged"],
     visibility = ["//visibility:public"],

--- a/hack/smoketest/BUILD.bazel
+++ b/hack/smoketest/BUILD.bazel
@@ -1,0 +1,45 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library", "go_test")
+
+go_library(
+    name = "go_default_library",
+    srcs = [
+        "main.go",
+        "steps.go",
+    ],
+    importpath = "github.com/cockroachdb/cockroach-operator/hack/smoketest",
+    visibility = ["//visibility:public"],
+    deps = ["@io_k8s_sigs_kubetest2//pkg/process:go_default_library"],
+)
+
+go_binary(
+    name = "smoketest",
+    data = [
+        "//hack/bin:kind",
+        "//hack/bin:kubectl",
+    ],
+    embed = [":go_default_library"],
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)
+
+go_test(
+    name = "go_default_test",
+    srcs = ["steps_test.go"],
+    deps = [
+        ":go_default_library",
+        "@com_github_stretchr_testify//require:go_default_library",
+    ],
+)

--- a/hack/smoketest/main.go
+++ b/hack/smoketest/main.go
@@ -1,0 +1,89 @@
+/*
+Copyright 2021 The Cockroach Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"sigs.k8s.io/kubetest2/pkg/process"
+)
+
+var (
+	clusterName string
+	dir         string
+	version     string
+)
+
+// main runs a simple smoke test that ensures that the operator brings up the database and that it's all functioning as
+// expected.
+//
+// It roughly follows the steps we provide in our docs:
+// https://www.cockroachlabs.com/docs/stable/deploy-cockroachdb-with-kubernetes.html#step-2-start-cockroachdb
+//
+// It will:
+// * Start a kind cluster
+// * Install the CRDs and the operator from the install dir
+// * Apply the example cluster
+// * Add the client-secure-operator
+// * Run the bank workload
+func main() {
+	flag.StringVar(&clusterName, "cluster", "smoketest", "the name of the kind cluster")
+	flag.StringVar(&dir, "dir", ".", "the directory run in")
+	flag.StringVar(&version, "version", "1.22.1", "the version of kubernetes (kindest node)")
+	flag.Parse()
+
+	// ensure kind, kubectl, etc. are on the path
+	path := os.Getenv("PATH")
+	os.Setenv("PATH", fmt.Sprintf("%s:%s", filepath.Join(os.Getenv("PWD"), "hack", "bin"), path))
+
+	// change to the desired dir (typically $BUILD_WORKSPACE_DIRECTORY)
+	if err := os.Chdir(dir); err != nil {
+		bail(err)
+	}
+
+	steps := []Step{
+		StartKindCluster(clusterName, version),
+		ApplyManifest(filepath.Join("install", "crds.yaml")),
+		ApplyManifest(filepath.Join("install", "operator.yaml")),
+		WaitForDeploymentAvailable("cockroach-operator"),
+		WaitForSecret("cockroach-operator-webhook-tls"),
+		ApplyManifest(filepath.Join("examples", "example.yaml")),
+		WaitForStatefulSetRollout("cockroachdb"),
+		ApplyManifest(filepath.Join("examples", "client-secure-operator.yaml")),
+		WaitForPodReady("cockroachdb-client-secure"),
+		InitBankWorkload(),
+		RunBankWorkload(10 * time.Second),
+	}
+
+	defer StopKindCluster(clusterName).Apply(process.ExecJUnit)
+
+	for _, step := range steps {
+		if err := step.Apply(process.ExecJUnit); err != nil {
+			bail(err)
+		}
+	}
+}
+
+func bail(err error) {
+	fmt.Fprintf(os.Stderr, "OOPS! An error occurred: %s\n", err)
+	StopKindCluster(clusterName).Apply(process.ExecJUnit)
+	os.Exit(1)
+}

--- a/hack/smoketest/steps.go
+++ b/hack/smoketest/steps.go
@@ -1,0 +1,190 @@
+/*
+Copyright 2021 The Cockroach Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"time"
+)
+
+var (
+	// certsDir is where the certs are store on disk in the cockroachdb-client-secure pod
+	certsDir = "%2Fcockroach%2Fcockroach-certs%2F"
+
+	// pURL is the connection string for use inside the cockroachdb-client-secure pod
+	pURL = strings.Join(
+		[]string{
+			"postgresql://root@cockroachdb-public:26257",
+			fmt.Sprintf("?sslcert=%sclient.root.crt", certsDir),
+			fmt.Sprintf("&sslkey=%sclient.root.key", certsDir),
+			"&sslmode=verify-full",
+			fmt.Sprintf("&sslrootcert=%sca.crt", certsDir),
+		},
+		"",
+	)
+)
+
+// Step defines an action to be taken during the release process
+type Step interface {
+	Apply(ExecFn) error
+}
+
+// StepFn is a function that implements Step.
+type StepFn func(ExecFn) error
+
+// Apply applies the function.
+func (fn StepFn) Apply(ex ExecFn) error {
+	return fn(ex)
+}
+
+// ExecFn describes a function that executes shell commands.
+type ExecFn func(cmd string, args, env []string) error
+
+// StartKindCluster starts a kind cluster named `kind-<name>` using the specified image
+func StartKindCluster(name string, version string) Step {
+	return StepFn(func(fn ExecFn) error {
+		fmt.Println("Creating kind cluster...")
+		return fn(
+			"kind",
+			[]string{"create", "cluster", "--name", name, "--image", "kindest/node:v" + version},
+			os.Environ(),
+		)
+	})
+}
+
+// StopKindCluster stops the cluster named `kind-<name>`.
+func StopKindCluster(name string) Step {
+	fmt.Println("Deleting kind cluster...")
+	return StepFn(func(fn ExecFn) error {
+		return fn(
+			"kind",
+			[]string{"delete", "cluster", "--name", name},
+			os.Environ(),
+		)
+	})
+}
+
+// ApplyManifest performs a kubectl apply -f for the specified file.
+func ApplyManifest(file string) Step {
+	return StepFn(func(fn ExecFn) error {
+		fmt.Println("Applying " + file)
+		return fn(
+			"kubectl",
+			[]string{"apply", "-f", file},
+			os.Environ(),
+		)
+	})
+}
+
+// WaitForDeploymentAvailable waits until the specified deployment is available. It will timeout after 2m.
+func WaitForDeploymentAvailable(name string) Step {
+	return StepFn(func(fn ExecFn) error {
+		fmt.Println("Waiting for deployment to be available")
+		return fn(
+			"kubectl",
+			[]string{"wait", "--for", "condition=Available", "deploy/" + name, "--timeout", "2m"},
+			os.Environ(),
+		)
+	})
+}
+
+// WaitForSecret waits for a Kuebernetes secret to be available
+func WaitForSecret(name string) Step {
+	return StepFn(func(fn ExecFn) error {
+		fmt.Println("Waiting for secret to be created")
+		return retry(5, 10*time.Second, func() error {
+			return fn(
+				"kubectl",
+				[]string{"get", "secret", name},
+				os.Environ(),
+			)
+		})
+	})
+}
+
+// WaitForStatefulSetRollout waits until the specified deployment is available. It will timeout after 2m.
+func WaitForStatefulSetRollout(name string) Step {
+	return StepFn(func(fn ExecFn) error {
+		fmt.Println("Waiting for statefulset to be ready")
+		return retry(20, 10*time.Second, func() error {
+			return fn(
+				"kubectl",
+				[]string{"rollout", "status", "-w", "sts/" + name},
+				os.Environ(),
+			)
+		})
+	})
+}
+
+// WaitForPodReady waits until the named pod is in a ready state.
+func WaitForPodReady(name string) Step {
+	return StepFn(func(fn ExecFn) error {
+		fmt.Println("Waiting for pod to be ready")
+		return fn(
+			"kubectl",
+			[]string{"wait", "--for", "condition=Ready", "pod/" + name, "--timeout", "2m"},
+			os.Environ(),
+		)
+	})
+}
+
+// InitBankWorkload initializes the bank workload
+func InitBankWorkload() Step {
+	return StepFn(func(fn ExecFn) error {
+		return runWithClient(fn, "workload", "init", "bank")
+	})
+}
+
+// RunBankWorkload runs the bank workload for the specified duration
+func RunBankWorkload(d time.Duration) Step {
+	return StepFn(func(fn ExecFn) error {
+		return runWithClient(fn, "workload", "run", "bank", "--duration", d.String())
+	})
+}
+
+func runWithClient(fn ExecFn, cmd ...string) error {
+	args := append([]string{
+		"exec",
+		"-it",
+		"cockroachdb-client-secure",
+		"--",
+		"cockroach",
+	}, cmd...)
+
+	args = append(args, pURL)
+	return fn("kubectl", args, os.Environ())
+}
+
+func retry(maxAttempts int, durBetweenTries time.Duration, fn func() error) error {
+	attempts := 0
+
+	for {
+		err := fn()
+		if err == nil {
+			return nil
+		}
+
+		attempts++
+		if attempts == maxAttempts {
+			return err
+		}
+
+		time.Sleep(durBetweenTries)
+	}
+}

--- a/hack/smoketest/steps_test.go
+++ b/hack/smoketest/steps_test.go
@@ -1,0 +1,172 @@
+/*
+Copyright 2021 The Cockroach Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package main_test
+
+import (
+	"testing"
+	"time"
+
+	. "github.com/cockroachdb/cockroach-operator/hack/smoketest"
+	"github.com/stretchr/testify/require"
+)
+
+type mockExecFn struct {
+	cmd  string
+	args []string
+	env  []string
+	err  error
+}
+
+func (m *mockExecFn) exec(cmd string, args, env []string) error {
+	m.cmd = cmd
+	m.args = args
+	m.env = env
+	return m.err
+}
+
+func TestStartKindCluster(t *testing.T) {
+	tests := []struct {
+		name    string
+		version string
+	}{
+		{name: "cluster1", version: "1.18.2"},
+		{name: "cluster2", version: "1.22.1"},
+	}
+
+	for _, tt := range tests {
+		fn := new(mockExecFn)
+		require.NoError(t, StartKindCluster(tt.name, tt.version).Apply(fn.exec))
+
+		expArgs := []string{
+			"create",
+			"cluster",
+			"--name",
+			tt.name,
+			"--image",
+			"kindest/node:v" + tt.version,
+		}
+
+		require.Equal(t, "kind", fn.cmd)
+		require.Equal(t, expArgs, fn.args)
+	}
+}
+
+func TestStopKindCluster(t *testing.T) {
+	fn := new(mockExecFn)
+	require.NoError(t, StopKindCluster("test-cluster").Apply(fn.exec))
+
+	require.Equal(t, "kind", fn.cmd)
+	require.Equal(t, []string{"delete", "cluster", "--name", "test-cluster"}, fn.args)
+}
+
+func TestApplyManifest(t *testing.T) {
+	fn := new(mockExecFn)
+	require.NoError(t, ApplyManifest("some/path.yaml").Apply(fn.exec))
+
+	require.Equal(t, "kubectl", fn.cmd)
+	require.Equal(t, []string{"apply", "-f", "some/path.yaml"}, fn.args)
+}
+
+func TestWaitForDeploymentAvailable(t *testing.T) {
+	fn := new(mockExecFn)
+	require.NoError(t, WaitForDeploymentAvailable("deploy-name").Apply(fn.exec))
+
+	expArgs := []string{
+		"wait",
+		"--for",
+		"condition=Available",
+		"deploy/deploy-name",
+		"--timeout",
+		"2m",
+	}
+
+	require.Equal(t, "kubectl", fn.cmd)
+	require.Equal(t, expArgs, fn.args)
+}
+
+func TestWaitForSecret(t *testing.T) {
+	fn := new(mockExecFn)
+	require.NoError(t, WaitForSecret("my-secret").Apply(fn.exec))
+
+	require.Equal(t, "kubectl", fn.cmd)
+	require.Equal(t, []string{"get", "secret", "my-secret"}, fn.args)
+}
+
+func TestWaitForStatefulSetRollout(t *testing.T) {
+	fn := new(mockExecFn)
+	require.NoError(t, WaitForStatefulSetRollout("my-sts").Apply(fn.exec))
+
+	require.Equal(t, "kubectl", fn.cmd)
+	require.Equal(t, []string{"rollout", "status", "-w", "sts/my-sts"}, fn.args)
+}
+
+func TestWaitForPodReady(t *testing.T) {
+	fn := new(mockExecFn)
+	require.NoError(t, WaitForPodReady("my-pod").Apply(fn.exec))
+
+	expArgs := []string{
+		"wait",
+		"--for",
+		"condition=Ready",
+		"pod/my-pod",
+		"--timeout",
+		"2m",
+	}
+
+	require.Equal(t, "kubectl", fn.cmd)
+	require.Equal(t, expArgs, fn.args)
+}
+
+func TestInitBankWorkload(t *testing.T) {
+	fn := new(mockExecFn)
+	require.NoError(t, InitBankWorkload().Apply(fn.exec))
+
+	expArgs := []string{
+		"exec",
+		"-it",
+		"cockroachdb-client-secure",
+		"--",
+		"cockroach",
+		"workload",
+		"init",
+		"bank",
+	}
+
+	require.Equal(t, "kubectl", fn.cmd)
+	require.Equal(t, expArgs, fn.args[:len(fn.args)-1])
+}
+
+func TestRunBankWorkload(t *testing.T) {
+	fn := new(mockExecFn)
+	require.NoError(t, RunBankWorkload(5*time.Second).Apply(fn.exec))
+
+	expArgs := []string{
+		"exec",
+		"-it",
+		"cockroachdb-client-secure",
+		"--",
+		"cockroach",
+		"workload",
+		"run",
+		"bank",
+		"--duration",
+		"5s",
+	}
+
+	require.Equal(t, "kubectl", fn.cmd)
+	require.Equal(t, expArgs, fn.args[:len(fn.args)-1])
+}


### PR DESCRIPTION
We need to ensure that we're testing all of the supported versions of Kubernetes. As APIs are upgraded/removed we should not rely on manually verifying which APIs are being used and which are still valid.

I've added a smoke test here which stands up a kind cluster (for each supported version), deploys the operator, and runs the bank workload for a few seconds just to ensure things are working.

You might be thinking, "why not just run (one of) our e2e tests?" The answer is that I wanted to ensure we had a test in place that does what our [docs] tell users to do. Which is to install the crds from _install/crds.yaml_, the operator from _install/operator.yaml_, and the example from _examples/example.yaml_. These files are updated whenever we do a release or run `make release/gen-templates`.

To make sure the cluster is functional, the test also adds the secure client pod and executes the [bank workload] for 10s.

Finally, I've added a new GitHub workflow to run these tests nightly. I chose 3am rather arbitrarily since I figured almost everyone else chooses midnight :smile:

[docs]:
https://www.cockroachlabs.com/docs/stable/deploy-cockroachdb-with-kubernetes.html#step-2-start-cockroachdb
[bank workload]:
https://www.cockroachlabs.com/docs/stable/cockroach-workload.html#run-the-bank-workload

**Checklist**

* [x] I have added these changes to the changelog (or it's not applicable).
