### PR TITLE
Fix kubectl apply link for operator manifest

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ kubectl apply -f https://raw.githubusercontent.com/cockroachdb/cockroach-operato
 Apply the Operator manifest. By default, the Operator is configured to install in the `default` namespace. To use the Operator in a custom namespace, download the Operator manifest and edit all instances of `namespace: default` to specify your custom namespace. Then apply this version of the manifest to the cluster with `kubectl apply -f {local-file-path}` instead of using the command below.
 
 ```
-kubectl apply -f https://raw.githubusercontent.com/cockroachdb/cockroach-operator/master/manifests/operator.yaml
+kubectl apply -f https://raw.githubusercontent.com/cockroachdb/cockroach-operator/master/install/operator.yaml
 ```
 
 > **Note:** The Operator can only install CockroachDB into its own namespace. 


### PR DESCRIPTION
The `operator.yaml` link in the readme seems to be broken. This fixes the `kubectl apply` command.

**Checklist**

* [x] I have added these changes to the changlog (or it's not applicable).
