### PR TITLE
Always run required checks

### DIFF
--- a/.github/workflows/e2e-kind-create.yaml
+++ b/.github/workflows/e2e-kind-create.yaml
@@ -18,14 +18,8 @@ on:
   # Triggers the workflow on push or pull request events but only for the master branch
   push:
     branches: [ master ]
-    paths-ignore:
-      - "**.md"
-      - "docs/**"
   pull_request:
     branches: [ master ]
-    paths-ignore:
-      - "**.md"
-      - "docs/**"
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/e2e-kind-decommission.yaml
+++ b/.github/workflows/e2e-kind-decommission.yaml
@@ -18,14 +18,8 @@ on:
   # Triggers the workflow on push or pull request events but only for the master branch
   push:
     branches: [ master ]
-    paths-ignore:
-      - "**.md"
-      - "docs/**"
   pull_request:
     branches: [ master ]
-    paths-ignore:
-      - "**.md"
-      - "docs/**"
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/e2e-kind-upgrades.yaml
+++ b/.github/workflows/e2e-kind-upgrades.yaml
@@ -18,14 +18,8 @@ on:
   # Triggers the workflow on push or pull request events but only for the master branch
   push:
     branches: [ master ]
-    paths-ignore:
-      - "**.md"
-      - "docs/**"
   pull_request:
     branches: [ master ]
-    paths-ignore:
-      - "**.md"
-      - "docs/**"
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/e2e-kind-upgradessha256.yaml
+++ b/.github/workflows/e2e-kind-upgradessha256.yaml
@@ -18,14 +18,8 @@ on:
   # Triggers the workflow on push or pull request events but only for the master branch
   push:
     branches: [ master ]
-    paths-ignore:
-      - "**.md"
-      - "docs/**"
   pull_request:
     branches: [ master ]
-    paths-ignore:
-      - "**.md"
-      - "docs/**"
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/e2e-kind-versionchecker.yaml
+++ b/.github/workflows/e2e-kind-versionchecker.yaml
@@ -18,14 +18,8 @@ on:
   # Triggers the workflow on push or pull request events but only for the master branch
   push:
     branches: [ master ]
-    paths-ignore:
-      - "**.md"
-      - "docs/**"
   pull_request:
     branches: [ master ]
-    paths-ignore:
-      - "**.md"
-      - "docs/**"
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/templates.yaml
+++ b/.github/workflows/templates.yaml
@@ -18,14 +18,8 @@ on:
   # Triggers the workflow on push or pull request events but only for the master branch
   push:
     branches: [ master ]
-    paths-ignore:
-      - "**.md"
-      - "docs/**"
   pull_request:
     branches: [ master ]
-    paths-ignore:
-      - "**.md"
-      - "docs/**"
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -18,14 +18,8 @@ on:
   # Triggers the workflow on push or pull request events but only for the master branch
   push:
     branches: [ master ]
-    paths-ignore:
-      - "**.md"
-      - "docs/**"
   pull_request:
     branches: [ master ]
-    paths-ignore:
-      - "**.md"
-      - "docs/**"
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:


### PR DESCRIPTION
We recently ran into an issue where an update to README wouldn't run the required checks. It would make sense to skip the checks for docs changes, but the checks are required for merging. Leading us to change .gitignore simply to trigger them.

We can look into a better long-term solution, but for now I've altered the workflows to run on every push/pr to master.

**Checklist**

* [x] I have added these changes to the changelog (or it's not applicable).
