### PR TITLE
Fix confusion between APP_VERSION and VERSION in release script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,15 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-# [Unreleased](https://github.com/cockroachdb/cockroach-operator/compare/2.2.1...master)
+# [Unreleased](https://github.com/cockroachdb/cockroach-operator/compare/v2.2.1...master)
 
-[2.2.1](https://github.com/cockroachdb/cockroach-operator/compare/2.2.0...2.2.1)
+# [v2.2.1](https://github.com/cockroachdb/cockroach-operator/compare/v2.2.0...v2.2.1)
 
 ## Deleted
 
 * References to certificates/v1beta1 preventing the operator from working on K8s 1.22
 
-# [2.2.0](https://github.com/cockroachdb/cockroach-operator/compare/v2.2.0-beta.2...2.2.0)
+# [v2.2.0](https://github.com/cockroachdb/cockroach-operator/compare/v2.2.0-beta.2...v2.2.0)
 
 ## Added
 

--- a/hack/release/steps.go
+++ b/hack/release/steps.go
@@ -132,7 +132,7 @@ func GenerateFiles(fn ExecFn) Step {
 // added appropriately.
 func UpdateChangelog(fn FileFn) Step {
 	const fileName = "CHANGELOG.md"
-	const urlFmt = "https://github.com/cockroachdb/cockroach-operator/compare/%s...%s"
+	const urlFmt = "https://github.com/cockroachdb/cockroach-operator/compare/v%s...%s"
 
 	return StepFn(func(version string) error {
 		data, err := fn(fileName)
@@ -147,8 +147,8 @@ func UpdateChangelog(fn FileFn) Step {
 		newUnreleased := []byte(fmt.Sprintf("[Unreleased](%s)", fmt.Sprintf(urlFmt, version, "master")))
 
 		// fix up the previous unreleased line to reference the new version
-		latestRelease := bytes.Replace(prevUnreleased, []byte("...master"), []byte("..."+version), 1)
-		latestRelease = bytes.Replace(latestRelease, []byte("[Unreleased]"), []byte(fmt.Sprintf("[%s]", version)), 1)
+		latestRelease := bytes.Replace(prevUnreleased, []byte("...master"), []byte("...v"+version), 1)
+		latestRelease = bytes.Replace(latestRelease, []byte("[Unreleased]"), []byte(fmt.Sprintf("# [v%s]", version)), 1)
 
 		// update to include the new and previous versions
 		newUnreleased = append(newUnreleased, append([]byte("\n\n"), latestRelease...)...)

--- a/hack/release/steps_test.go
+++ b/hack/release/steps_test.go
@@ -137,30 +137,30 @@ func TestUpdateChangelog(t *testing.T) {
 	input := `
 # CHANGELOG yada yada yada
 ...
-[Unreleased](https://github.com/cockroachdb/cockroach-operator/compare/v1.0.0...master)
+# [Unreleased](https://github.com/cockroachdb/cockroach-operator/compare/v1.0.0...master)
 
 * Some unreleased content
 
-[v1.0.0](https://github.com/cockroachdb/cockroach-operator/compare/v0.9.0...v1.0.0)
+# [v1.0.0](https://github.com/cockroachdb/cockroach-operator/compare/v0.9.0...v1.0.0)
 ...
-[v0.9.0](https://github.com/cockroachdb/cockroach-operator/compare/v0.8.0...v0.9.0)
+# [v0.9.0](https://github.com/cockroachdb/cockroach-operator/compare/v0.8.0...v0.9.0)
 `
 
 	expected := `
 # CHANGELOG yada yada yada
 ...
-[Unreleased](https://github.com/cockroachdb/cockroach-operator/compare/v1.1.0...master)
+# [Unreleased](https://github.com/cockroachdb/cockroach-operator/compare/v1.1.0...master)
 
-[v1.1.0](https://github.com/cockroachdb/cockroach-operator/compare/v1.0.0...v1.1.0)
+# [v1.1.0](https://github.com/cockroachdb/cockroach-operator/compare/v1.0.0...v1.1.0)
 
 * Some unreleased content
 
-[v1.0.0](https://github.com/cockroachdb/cockroach-operator/compare/v0.9.0...v1.0.0)
+# [v1.0.0](https://github.com/cockroachdb/cockroach-operator/compare/v0.9.0...v1.0.0)
 ...
-[v0.9.0](https://github.com/cockroachdb/cockroach-operator/compare/v0.8.0...v0.9.0)
+# [v0.9.0](https://github.com/cockroachdb/cockroach-operator/compare/v0.8.0...v0.9.0)
 `
 
-	err := UpdateChangelog(func(_ string) ([]byte, error) { return []byte(input), nil }).Apply("v1.1.0")
+	err := UpdateChangelog(func(_ string) ([]byte, error) { return []byte(input), nil }).Apply("1.1.0")
 	require.NoError(t, err)
 
 	data, err := ioutil.ReadFile("CHANGELOG.md")


### PR DESCRIPTION
There were a number of small issues I discovered with //hack/release while releasing v2.2.1.

* Missing v prefix from headings and compare links
* Missing # prefix to make each release a heading

I've addressed those here and ran a quick test to make sure it now works as expected. I also updated CHANGELOG.md to be correctly formatted.

**Checklist**

* [x] I have added these changes to the changelog (or it's not applicable).
