### PR TITLE
Address issues with running on OpenShift

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,4 +62,4 @@ bazel-testlogs
 faq
 
 _artifacts
-
+tmp

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,11 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 * Cleanup of initialization and structure of Actor and Director
 
+## Fixed
+
+* Error on startup in OpenShift related to webhook configuration
+* Finalizer permissions to address `cannot set blockOwnerDeletion if an ownerReference refers to a resource you can’t set finalizers on` issue
+
 # [v2.2.1](https://github.com/cockroachdb/cockroach-operator/compare/v2.2.0...v2.2.1)
 
 ## Changed

--- a/config/manifests/bases/cockroach-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/cockroach-operator.clusterserviceversion.yaml
@@ -89,6 +89,9 @@ spec:
       - description: Container image information
         displayName: Cockroach Database Image
         path: image
+      - description: (Optional) If specified, the pod's nodeSelector
+        displayName: Map of nodeSelectors to match when scheduling pods on nodes
+        path: nodeSelector
       - description: Number of nodes (pods) in the cluster
         displayName: Number of nodes
         path: nodes

--- a/config/manifests/kustomization.yaml
+++ b/config/manifests/kustomization.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 ---
-namespace: default
+namespace: placeholder
 
 resources:
   - ../default

--- a/config/manifests/patches/deployment_patch.yaml
+++ b/config/manifests/patches/deployment_patch.yaml
@@ -24,12 +24,12 @@ spec:
       containers:
         - name: cockroach-operator
           args:
-            - feature-gates
-            - Upgrade=false,ResizePVC=true
+            - -skip-webhook-config
+            # - -feature-gates
+            # - TolerationRules=true,AffinityRules=true
             # the below log level accepts "info" "debug" "warn" or "error"
             - -zap-log-level
             - info
-            # - debug
           env:
             - name: RELATED_IMAGE_COCKROACH_v20_1_4
               value: RH_COCKROACH_DB_IMAGE_PLACEHOLDER_v20_1_4

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -78,6 +78,14 @@ rules:
 - apiGroups:
   - batch
   resources:
+  - jobs/finalizers
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - batch
+  resources:
   - jobs/status
   verbs:
   - get
@@ -195,6 +203,12 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - crdb.cockroachlabs.com
+  resources:
+  - crdbclusters/finalizers
+  verbs:
+  - update
 - apiGroups:
   - crdb.cockroachlabs.com
   resources:

--- a/config/templates/deployment_patch.yaml.in
+++ b/config/templates/deployment_patch.yaml.in
@@ -24,12 +24,12 @@ spec:
       containers:
         - name: cockroach-operator
           args:
-            - feature-gates
-            - Upgrade=false,ResizePVC=true
+            - -skip-webhook-config
+            # - -feature-gates
+            # - TolerationRules=true,AffinityRules=true
             # the below log level accepts "info" "debug" "warn" or "error"
             - -zap-log-level
             - info
-            # - debug
           env:
 {{- range .CrdbVersions}}{{if stable . }}
             {{- /*

--- a/hack/update-pkg-manifest.sh
+++ b/hack/update-pkg-manifest.sh
@@ -96,7 +96,7 @@ combine_files() {
   sed '/replaces: .*/d' "${csv}" > tmp-csv && mv tmp-csv "${csv}"
 
   # delete all except the csv and crd files
-  rm -v !("cockroach-operator.v${2}.clusterserviceversion.yaml"|"crdb.cockroachlabs.com_crdbclusters.yaml")
+  rm -v !("${csv}"|"crdb.cockroachlabs.com_crdbclusters.yaml")
   popd >/dev/null
 }
 

--- a/install/operator.yaml
+++ b/install/operator.yaml
@@ -113,6 +113,14 @@ rules:
 - apiGroups:
   - batch
   resources:
+  - jobs/finalizers
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - batch
+  resources:
   - jobs/status
   verbs:
   - get
@@ -230,6 +238,12 @@ rules:
   - patch
   - update
   - watch
+- apiGroups:
+  - crdb.cockroachlabs.com
+  resources:
+  - crdbclusters/finalizers
+  verbs:
+  - update
 - apiGroups:
   - crdb.cockroachlabs.com
   resources:

--- a/pkg/controller/cluster_controller.go
+++ b/pkg/controller/cluster_controller.go
@@ -19,7 +19,6 @@ package controller
 import (
 	"context"
 	"fmt"
-	"k8s.io/client-go/kubernetes"
 	"time"
 
 	api "github.com/cockroachdb/cockroach-operator/apis/v1alpha1"
@@ -33,6 +32,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	policy "k8s.io/api/policy/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -50,6 +50,7 @@ type ClusterReconciler struct {
 
 // +kubebuilder:rbac:groups=crdb.cockroachlabs.com,resources=crdbclusters,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=crdb.cockroachlabs.com,resources=crdbclusters/status,verbs=get;update;patch
+// +kubebuilder:rbac:groups=crdb.cockroachlabs.com,resources=crdbclusters/finalizers,verbs=update
 // +kubebuilder:rbac:groups=certificates.k8s.io,resources=certificatesigningrequests,verbs=get;list;watch;create;patch;delete
 // +kubebuilder:rbac:groups=certificates.k8s.io,resources=certificatesigningrequests/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=certificates.k8s.io,resources=certificatesigningrequests/approval,verbs=update
@@ -71,6 +72,7 @@ type ClusterReconciler struct {
 // +kubebuilder:rbac:groups=policy,resources=poddisruptionbudgets/finalizers,verbs=get;list;watch
 // +kubebuilder:rbac:groups=batch,resources=jobs,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=batch,resources=jobs/status,verbs=get
+// +kubebuilder:rbac:groups=batch,resources=jobs/finalizers,verbs=get;list;watch
 // +kubebuilder:rbac:groups=admissionregistration.k8s.io,resources=mutatingwebhookconfigurations,verbs=get;update;patch;
 // +kubebuilder:rbac:groups=admissionregistration.k8s.io,resources=validatingwebhookconfigurations,verbs=get;update;patch;
 


### PR DESCRIPTION
Fixes #779
Fixes #780 
Fixes #784 

We have a couple of issues that prevent the operator from running properly on OpenShift.

**Issue 1: Webhooks**

The first has to do with webhook configuration. On startup, we generate a CA and associates TLS certificates for the webhook-service. The CA is patched into the webhook config's CABundle and the certs are placed on disk for the webhook service to use.

The trouble is that openShift doesn't name the webhook configurations the same (for the better IMO). So at startup we can't find the hook and bail on startup (CrashLoopBackoff).

OpenShift will setup the service and patch the CA bundle automatically, so I've added the `-skip-webhook-config` flag and ensured that it's set in the manifests for OpenShift by default.

**Issue 2: Jobs**

When we deploy a CrdbCluster, we queue a version checker job. There are currently permission issues with this since we don't have update permissions on crdbclusters/finalizers. More details can be found here:
https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#ownerreferencespermissionenforcement

I've added the appropriate permissions here.

## Testing

Start by creating a script we can use to package and publish the operator, bundle, and index images. (I put mine in tmp/publish). Don't forget to `chmod +x <your-path>` to make it executable.

> NOTE: Replace `<YOUR_REGISTRY>` with the docker registry you want to publish to. Remember this will need to accessible from your cluster.

```bash
#!/usr/bin/env bash
set -euo pipefail

BUNDLE_PATH="deploy/certified-metadata-bundle/cockroach-operator"

export VERSION="2.2.1"
export RH_BUNDLE_REGISTRY="<YOUR_REGISTRY>" # e.g. gcr.io/your-gcp-project
export RH_BUNDLE_IMAGE_REPOSITORY="cockroachdb/operator-bundle"
export RH_OPERATOR_IMAGE="${RH_BUNDLE_REGISTRY}/cockroachdb/cockroach-operator:v${VERSION}"

main() {
  local bundle_tag="${RH_BUNDLE_REGISTRY}/cockroachdb/operator-bundle:v${VERSION}"
  local index_tag="${RH_BUNDLE_REGISTRY}/cockroachdb/operator-index:v${VERSION}"

  publish_image
  build_bundle
  publish_bundle "${bundle_tag}"
  publish_index "${bundle_tag}" "${index_tag}"
}

publish_image() {
  DOCKER_REGISTRY="${RH_BUNDLE_REGISTRY}" \
    DOCKER_IMAGE_REPOSITORY="cockroachdb/cockroach-operator" \
    make release/image
}

build_bundle() {
  rm -rf "${BUNDLE_PATH}/${VERSION}" "${BUNDLE_PATH}/bundle-${VERSION}.Dockerfile"
  make release/opm-build-bundle

  local csv="${BUNDLE_PATH}/${VERSION}/manifests/cockroach-operator.v${VERSION}.clusterserviceversion.yaml"
  sed -i '' -e 's/IfNotPresent/Always/g' "${csv}"
}

publish_bundle() {
  docker build \
    -f "${BUNDLE_PATH}/bundle-${VERSION}.Dockerfile" \
    -t "${1}" \
    "${BUNDLE_PATH}"

  docker push "${1}"
}

publish_index() {
  opm index add --bundles "${1}" --tag "${2}" --container-tool docker
  docker push "${2}"
}

main "$@"
```

* Publish the images (e.g. `tmp/publish)
* Revert local changes `git restore deploy/*`

<details>
  <summary><strong>Testing with OpenShift</strong></summary>

You'll need a running OpenShift cluster for this. You can use the instructions in operator.md or OKD to get setup.

```yaml
# Create tmp/opm-catalog-source.yaml
apiVersion: operators.coreos.com/v1alpha1
kind: CatalogSource
metadata:
  name: crdb-dev-catalog
  namespace: openshift-marketplace
spec:
  sourceType: grpc
  image: <YOUR_REGISTRY>/cockroachdb/operator-index:v2.2.1
  displayName: CRDB Development
  publisher: The CRDB Authors
  updateStrategy:
    registryPoll:
      interval: 1m
```

* Apply the resource: `kubectl apply -f tmp/opm-catalog-source.yaml`
* From OperatorHub (in your cluster), select the "CRDB Development" source on the left
* Install the operator into a new namespace
* Deploy the example `kubectl apply -f examples/example.yaml -n <your_ns>`
* Verify it all comes up as expected
</details>

<details>
<summary><strong>Testing on GKE</strong></summary>
Assuming you've got an accessible GKE cluster

* `kubectl apply -f install/crds.yaml`
* `sed -e 's+image: +image: <YOUR_REGISTRY>/+g' install/operator.yaml | k apply -f -`
* `kubectl apply -f examples/example.yaml`
</details>

<details>
  <summary><strong>Testing locally with Kind</strong></summary>
* `make dev/up` - stand up a local cluster with the operator pre-installed
* `kubectl apply -f examples/example.yaml`
* Make sure the deployment succeeds and all pods come up properly
* `make dev/down`
</details>

**Checklist**

* [x] I have added these changes to the changelog (or it's not applicable).
