### PR TITLE
Decrease memory limit to 500Mi for smoketests

### DIFF
--- a/config/templates/smoketest.yaml.in
+++ b/config/templates/smoketest.yaml.in
@@ -33,10 +33,10 @@ spec:
     requests:
       # This is intentionally low to make it work on local kind clusters.
       cpu: 500m
-      memory: 1Gi
+      memory: 500Mi
     limits:
       cpu: 500m
-      memory: 1Gi
+      memory: 500Mi
   tlsEnabled: true
   image:
     name: cockroachdb/cockroach:{{ .LatestStableCrdbVersion }}

--- a/examples/smoketest.yaml
+++ b/examples/smoketest.yaml
@@ -33,10 +33,10 @@ spec:
     requests:
       # This is intentionally low to make it work on local kind clusters.
       cpu: 500m
-      memory: 1Gi
+      memory: 500Mi
     limits:
       cpu: 500m
-      memory: 1Gi
+      memory: 500Mi
   tlsEnabled: true
   image:
     name: cockroachdb/cockroach:v21.1.11


### PR DESCRIPTION
Decreasing the smoketest resources down to 500Mi of memory. Hopefully this will be low enough to run the tests with GitHub actions.