### PR TITLE
Even less resources for smoketests

### DIFF
--- a/config/templates/smoketest.yaml.in
+++ b/config/templates/smoketest.yaml.in
@@ -32,11 +32,11 @@ spec:
   resources:
     requests:
       # This is intentionally low to make it work on local kind clusters.
-      cpu: 500m
-      memory: 500Mi
+      cpu: 300m
+      memory: 300Mi
     limits:
-      cpu: 500m
-      memory: 500Mi
+      cpu: 300m
+      memory: 300Mi
   tlsEnabled: true
   image:
     name: cockroachdb/cockroach:{{ .LatestStableCrdbVersion }}

--- a/examples/smoketest.yaml
+++ b/examples/smoketest.yaml
@@ -32,11 +32,11 @@ spec:
   resources:
     requests:
       # This is intentionally low to make it work on local kind clusters.
-      cpu: 500m
-      memory: 500Mi
+      cpu: 300m
+      memory: 300Mi
     limits:
-      cpu: 500m
-      memory: 500Mi
+      cpu: 300m
+      memory: 300Mi
   tlsEnabled: true
   image:
     name: cockroachdb/cockroach:v21.1.11


### PR DESCRIPTION
Still trying to get the resources low enough to be able to run in GitHub actions. Dropping resources down to 300m cpu and 300Mi memory.