### PR TITLE
Add sts/scale permissions for operator role

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## Fixed
 
 * Boilerplate test after updating to Go 1.17
+* Permissions for sts/scale subresource
 
 ## Deleted
 

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -58,6 +58,14 @@ rules:
 - apiGroups:
   - apps
   resources:
+  - statefulsets/scale
+  verbs:
+  - get
+  - update
+  - watch
+- apiGroups:
+  - apps
+  resources:
   - statefulsets/status
   verbs:
   - get

--- a/install/operator.yaml
+++ b/install/operator.yaml
@@ -93,6 +93,14 @@ rules:
 - apiGroups:
   - apps
   resources:
+  - statefulsets/scale
+  verbs:
+  - get
+  - update
+  - watch
+- apiGroups:
+  - apps
+  resources:
   - statefulsets/status
   verbs:
   - get

--- a/pkg/controller/cluster_controller.go
+++ b/pkg/controller/cluster_controller.go
@@ -65,6 +65,7 @@ type ClusterReconciler struct {
 // +kubebuilder:rbac:groups=core,resources=pods/log,verbs=get
 // +kubebuilder:rbac:groups=core,resources=nodes,verbs=get;list
 // +kubebuilder:rbac:groups=apps,resources=statefulsets,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups=apps,resources=statefulsets/scale,verbs=get;watch;update
 // +kubebuilder:rbac:groups=apps,resources=statefulsets/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=apps,resources=statefulsets/finalizers,verbs=get;list;watch
 // +kubebuilder:rbac:groups=policy,resources=poddisruptionbudgets,verbs=get;list;watch;create;update;patch;delete


### PR DESCRIPTION
When testing out  an upcomfing change to how we determine which actor to run, we noticed there were some error messages when scaling down (decommissioning) a cluster. The issue is that we aren't able to update the scale subresource for statefulsets.

I've added the permissions and verified that it works locally and in a GKE cluster.

**Checklist**

* [x] I have added these changes to the changelog (or it's not applicable).
