### PR TITLE
Support the mac m1 for development workflows

### DIFF
--- a/hack/bin/BUILD.bazel
+++ b/hack/bin/BUILD.bazel
@@ -5,6 +5,7 @@ load("@io_k8s_repo_infra//defs:run_in_workspace.bzl", "workspace_binary")
 genrule(
     name = "fetch_jq",
     srcs = select({
+        ":m1": ["@jq_osx//file"],
         ":darwin": ["@jq_osx//file"],
         ":k8": ["@jq_linux//file"],
     }),
@@ -16,6 +17,7 @@ genrule(
 genrule(
     name = "fetch_openshift",
     srcs = select({
+        ":m1": ["@openshift_darwin//:file"],
         ":darwin": ["@openshift_darwin//:file"],
         ":k8": ["@openshift_linux//:file"],
     }),
@@ -27,6 +29,7 @@ genrule(
 genrule(
     name = "fetch_oc",
     srcs = select({
+        ":m1": ["@oc_darwin//:file"],
         ":darwin": ["@oc_darwin//:file"],
         ":k8": ["@oc_linux//:file"],
     }),
@@ -38,6 +41,7 @@ genrule(
 genrule(
     name = "fetch_faq",
     srcs = select({
+        ":m1": ["@faq_osx//file"],
         ":darwin": ["@faq_osx//file"],
         ":k8": ["@faq_linux//file"],
     }),
@@ -49,6 +53,7 @@ genrule(
 genrule(
     name = "com_coreos_etcd",
     srcs = select({
+        ":m1": ["@com_coreos_etcd_darwin_amd64//:file"],
         ":darwin": ["@com_coreos_etcd_darwin_amd64//:file"],
         ":k8": ["@com_coreos_etcd_linux_amd64//:file"],
     }),
@@ -60,6 +65,7 @@ genrule(
 genrule(
     name = "io_kubernetes_kube-apiserver",
     srcs = select({
+        ":m1": ["@kube-apiserver_darwin_amd64//file"],
         ":darwin": ["@kube-apiserver_darwin_amd64//file"],
         ":k8": ["@kube-apiserver_linux_amd64//file"],
     }),
@@ -71,6 +77,7 @@ genrule(
 genrule(
     name = "fetch_kubectl",
     srcs = select({
+        ":m1": ["@kubectl_1_18_darwin//file"],
         ":darwin": ["@kubectl_1_18_darwin//file"],
         ":k8": ["@kubectl_1_18_linux//file"],
     }),
@@ -83,6 +90,7 @@ genrule(
 genrule(
     name = "fetch_golangci_lint",
     srcs = select({
+        ":m1": ["@golangci_lint_m1//:file"],
         ":darwin": ["@golangci_lint_darwin//:file"],
         ":k8": ["@golangci_lint_linux//:file"],
     }),
@@ -124,6 +132,7 @@ workspace_binary(
 genrule(
     name = "fetch_kind",
     srcs = select({
+        ":m1": ["@kind_m1//file"],
         ":darwin": ["@kind_darwin//file"],
         ":k8": ["@kind_linux//file"],
     }),
@@ -136,6 +145,7 @@ genrule(
 genrule(
     name = "fetch_kubetest2",
     srcs = select({
+        ":m1": ["@kubetest2_darwin//file"],
         ":darwin": ["@kubetest2_darwin//file"],
         ":k8": ["@kubetest2_linux//file"],
     }),
@@ -148,6 +158,7 @@ genrule(
 genrule(
     name = "fetch_kubetest2_kind",
     srcs = select({
+        ":m1": ["@kubetest2_kind_darwin//file"],
         ":darwin": ["@kubetest2_kind_darwin//file"],
         ":k8": ["@kubetest2_kind_linux//file"],
     }),
@@ -160,6 +171,7 @@ genrule(
 genrule(
     name = "fetch_kubetest2_gke",
     srcs = select({
+        ":m1": ["@kubetest2_gke_darwin//file"],
         ":darwin": ["@kubetest2_gke_darwin//file"],
         ":k8": ["@kubetest2_gke_linux//file"],
     }),
@@ -172,6 +184,7 @@ genrule(
 genrule(
     name = "fetch_kubetest2_exe",
     srcs = select({
+        ":m1": ["@kubetest2_exe_darwin//file"],
         ":darwin": ["@kubetest2_exe_darwin//file"],
         ":k8": ["@kubetest2_exe_linux//file"],
     }),
@@ -192,6 +205,7 @@ genrule(
 genrule(
     name = "fetch_operator-sdk",
     srcs = select({
+        ":m1": ["@operator_sdk_darwin//file"],
         ":darwin": ["@operator_sdk_darwin//file"],
         ":k8": ["@operator_sdk_linux//file"],
     }),
@@ -204,6 +218,7 @@ genrule(
 genrule(
     name = "fetch_opm",
     srcs = select({
+        ":m1": ["@opm_darwin//file"],
         ":darwin": ["@opm_darwin//file"],
         ":k8": ["@opm_linux//file"],
     }),
@@ -216,6 +231,7 @@ genrule(
 genrule(
     name = "fetch_crdb",
     srcs = select({
+        ":m1": ["@crdb_darwin//:file"],
         ":darwin": ["@crdb_darwin//:file"],
         ":k8": ["@crdb_linux//:file"],
     }),
@@ -228,6 +244,7 @@ genrule(
 genrule(
     name = "fetch_kustomize",
     srcs = select({
+        ":m1": ["@kustomize_darwin_arm//:file"],
         ":darwin": ["@kustomize_darwin//:file"],
         ":k8": ["@kustomize_linux//:file"],
     }),
@@ -239,6 +256,7 @@ genrule(
 genrule(
     name = "fetch-aws-k8s-tester",
     srcs = select({
+        ":m1": ["@aws-k8s-tester-m1//file"],
         ":darwin": ["@aws-k8s-tester-darwin//file"],
         ":k8": ["@aws-k8s-tester-linux//file"],
     }),
@@ -256,6 +274,12 @@ config_setting(
 config_setting(
     name = "darwin",
     values = {"host_cpu": "darwin"},
+    visibility = ["//visibility:private"],
+)
+
+config_setting(
+    name = "m1",
+    values = {"host_cpu": "darwin_arm64"},
     visibility = ["//visibility:private"],
 )
 

--- a/hack/bin/deps.bzl
+++ b/hack/bin/deps.bzl
@@ -94,13 +94,13 @@ def install_integration_test_dependencies():
 
     http_archive(
         name = "com_coreos_etcd_darwin_amd64",
-        sha256 = "c8f36adf4f8fb7e974f9bafe6e390a03bc33e6e465719db71d7ed3c6447ce85a",
-        urls = ["https://github.com/etcd-io/etcd/releases/download/v3.3.12/etcd-v3.3.12-darwin-amd64.zip"],
+        sha256 = "27245adea2e0951913276d8c321d79b91caaf904ae3fdaab65194ab41c01db08",
+        urls = ["https://github.com/etcd-io/etcd/releases/download/v3.4.16/etcd-v3.4.16-darwin-amd64.zip"],
         build_file_content = """
 filegroup(
     name = "file",
     srcs = [
-        "etcd-v3.3.12-darwin-amd64/etcd",
+        "etcd-v3.4.16-darwin-amd64/etcd",
     ],
     visibility = ["//visibility:public"],
 )
@@ -109,13 +109,13 @@ filegroup(
 
     http_archive(
         name = "com_coreos_etcd_linux_amd64",
-        sha256 = "dc5d82df095dae0a2970e4d870b6929590689dd707ae3d33e7b86da0f7f211b6",
-        urls = ["https://github.com/etcd-io/etcd/releases/download/v3.3.12/etcd-v3.3.12-linux-amd64.tar.gz"],
+        sha256 = "2e2d5b3572e077e7641193ed07b4929b0eaf0dc2f9463e9b677765528acafb89",
+        urls = ["https://github.com/etcd-io/etcd/releases/download/v3.4.16/etcd-v3.4.16-linux-amd64.tar.gz"],
         build_file_content = """
 filegroup(
     name = "file",
     srcs = [
-        "etcd-v3.3.12-linux-amd64/etcd",
+        "etcd-v3.4.16-linux-amd64/etcd",
     ],
     visibility = ["//visibility:public"],
 )
@@ -152,6 +152,22 @@ filegroup(
         "golangci-lint-1.42.0-darwin-amd64/golangci-lint",
      ],
      visibility = ["//visibility:public"],
+)
+    """,
+    )
+
+    http_archive(
+            name = "golangci_lint_m1",
+            sha256 = "f649893bf2b1d24b2632b5e109884a15f3bf25cfdad46b34fb8fd13a016098fd",
+            urls = ["https://github.com/golangci/golangci-lint/releases/download/v1.42.1/golangci-lint-1.42.1-darwin-arm64.tar.gz"],
+            build_file_content =
+             """
+filegroup(
+    name = "file",
+    srcs = [
+       "golangci-lint-1.42.1-darwin-arm64/golangci-lint",
+    ],
+    visibility = ["//visibility:public"],
 )
     """,
     )
@@ -217,11 +233,19 @@ def install_kind():
     )
 
     http_file(
+            name = "kind_m1",
+            executable = 1,
+            sha256 = "4f019c578600c087908ac59dd0c4ce1791574f153a70608adb372d5abc58cd47",
+            urls = ["https://github.com/kubernetes-sigs/kind/releases/download/v0.11.1/kind-darwin-arm64"],
+    )
+
+    http_file(
         name = "kind_linux",
         executable = 1,
         sha256 = "949f81b3c30ca03a3d4effdecda04f100fa3edc07a28b19400f72ede7c5f0491",
         urls = ["https://github.com/kubernetes-sigs/kind/releases/download/v0.11.1/kind-linux-amd64"],
     )
+
 
 ## Fetch kubetest2 binary used during e2e tests
 def install_kubetest2():
@@ -311,6 +335,21 @@ def install_operator_sdk():
     )
 
 def install_kustomize():
+    http_archive(
+           name = "kustomize_darwin_arm",
+           sha256 = "9556143d01feb9d9fa7706a6b0f60f74617c808f1c8c06130647e36a4e6a8746",
+           urls = ["https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv4.4.0/kustomize_v4.4.0_darwin_arm64.tar.gz"],
+           build_file_content = """
+filegroup(
+    name = "file",
+    srcs = [
+    "kustomize",
+    ],
+    visibility = ["//visibility:public"],
+)
+""",
+    )
+
     http_archive(
        name = "kustomize_darwin",
        sha256 = "77898f8b7c37e3ba0c555b4b7c6d0e3301127fa0de7ade6a36ed767ca1715643",
@@ -428,6 +467,12 @@ def install_kubetest2_aws():
         executable = 1,
         sha256 = "f6a95feef94ab9a96145fff812eeebae14f974edfead98046351f3098808df54",
         urls = ["https://github.com/aws/aws-k8s-tester/releases/download/v1.6.1/aws-k8s-tester-v1.6.1-linux-amd64"],
+    )
+    http_file(
+            name = "aws-k8s-tester-m1",
+            executable = 1,
+            sha256 = "a0c4d6125c0dac4d5333560243975ecc2ef7712b71f5bd29e79c3f450ec7165e",
+            urls = ["https://github.com/aws/aws-k8s-tester/releases/download/v1.6.5/aws-k8s-tester-v1.6.5-darwin-arm64"],
     )
     http_file(
         name = "aws-k8s-tester-darwin",

--- a/hack/dev.sh
+++ b/hack/dev.sh
@@ -40,7 +40,7 @@ nodes:
   image: ${NODE_IMAGE}
 containerdConfigPatches:
 - |-
-  [plugins."io.containerd.grpc.v1.cri".registry.mirrors."localhost:${REGISTRY_PORT}"]
+  [plugins."io.containerd.grpc.v1.cri".registry.mirrors."127.0.0.1:${REGISTRY_PORT}"]
     endpoint = ["http://${REGISTRY_NAME}:${REGISTRY_PORT}"]
 EOF
 }
@@ -56,7 +56,7 @@ metadata:
   namespace: kube-public
 data:
   localRegistryHosting.v1: |
-    host: "localhost:${REGISTRY_PORT}"
+    host: "127.0.0.1:${REGISTRY_PORT}"
     help: "https://kind.sigs.k8s.io/docs/user/local-registry/"
 EOF
 }
@@ -66,7 +66,7 @@ install_operator() {
   # now I've added a defined make variable which can be used for substitution
   # in //config/default/BUILD.bazel.
   K8S_CLUSTER="kind-${CLUSTER_NAME}" \
-    DEV_REGISTRY="localhost:${REGISTRY_PORT}" \
+    DEV_REGISTRY="127.0.0.1:${REGISTRY_PORT}" \
     bazel run \
     --stamp \
     --platforms=@io_bazel_rules_go//go/toolchain:linux_amd64 \


### PR DESCRIPTION
Added support for developer workflow on Mac m1. This PR allows you to run all bazel tests and locally spin up the cockroachdb operator environment on Mac m1 machine.

**Checklist**

* [ ] I have added these changes to the changelog (or it's not applicable).
