### PR TITLE
Update smoke tests to be aware of new namespace

### DIFF
--- a/hack/smoketest/main.go
+++ b/hack/smoketest/main.go
@@ -63,8 +63,8 @@ func main() {
 		StartKindCluster(clusterName, version),
 		ApplyManifest(filepath.Join("install", "crds.yaml")),
 		ApplyManifest(filepath.Join("install", "operator.yaml")),
-		WaitForDeploymentAvailable("cockroach-operator"),
-		WaitForSecret("cockroach-operator-webhook-ca"),
+		WaitForDeploymentAvailable("cockroach-operator-manager", "cockroach-operator-system"),
+		WaitForSecret("cockroach-operator-webhook-ca", "cockroach-operator-system"),
 		sleep(10 * time.Second), // just give the manager time to write the TLS certs to disk
 		ApplyManifest(filepath.Join("examples", "smoketest.yaml")),
 		WaitForStatefulSetRollout("cockroachdb"),

--- a/hack/smoketest/steps.go
+++ b/hack/smoketest/steps.go
@@ -93,25 +93,25 @@ func ApplyManifest(file string) Step {
 }
 
 // WaitForDeploymentAvailable waits until the specified deployment is available. It will timeout after 2m.
-func WaitForDeploymentAvailable(name string) Step {
+func WaitForDeploymentAvailable(name, namespace string) Step {
 	return StepFn(func(fn ExecFn) error {
 		fmt.Println("Waiting for deployment to be available")
 		return fn(
 			"kubectl",
-			[]string{"wait", "--for", "condition=Available", "deploy/" + name, "--timeout", "2m"},
+			[]string{"wait", "--for", "condition=Available", "deploy/" + name, "-n", namespace, "--timeout", "2m"},
 			os.Environ(),
 		)
 	})
 }
 
 // WaitForSecret waits for a Kuebernetes secret to be available
-func WaitForSecret(name string) Step {
+func WaitForSecret(name, namespace string) Step {
 	return StepFn(func(fn ExecFn) error {
 		fmt.Println("Waiting for secret to be created")
 		return retry(5, 10*time.Second, func() error {
 			return fn(
 				"kubectl",
-				[]string{"get", "secret", name},
+				[]string{"get", "secret", name, "-n", namespace},
 				os.Environ(),
 			)
 		})

--- a/hack/smoketest/steps_test.go
+++ b/hack/smoketest/steps_test.go
@@ -86,13 +86,15 @@ func TestApplyManifest(t *testing.T) {
 
 func TestWaitForDeploymentAvailable(t *testing.T) {
 	fn := new(mockExecFn)
-	require.NoError(t, WaitForDeploymentAvailable("deploy-name").Apply(fn.exec))
+	require.NoError(t, WaitForDeploymentAvailable("deploy-name", "some-ns").Apply(fn.exec))
 
 	expArgs := []string{
 		"wait",
 		"--for",
 		"condition=Available",
 		"deploy/deploy-name",
+		"-n",
+		"some-ns",
 		"--timeout",
 		"2m",
 	}
@@ -103,10 +105,10 @@ func TestWaitForDeploymentAvailable(t *testing.T) {
 
 func TestWaitForSecret(t *testing.T) {
 	fn := new(mockExecFn)
-	require.NoError(t, WaitForSecret("my-secret").Apply(fn.exec))
+	require.NoError(t, WaitForSecret("my-secret", "my-ns").Apply(fn.exec))
 
 	require.Equal(t, "kubectl", fn.cmd)
-	require.Equal(t, []string{"get", "secret", "my-secret"}, fn.args)
+	require.Equal(t, []string{"get", "secret", "my-secret", "-n", "my-ns"}, fn.args)
 }
 
 func TestWaitForStatefulSetRollout(t *testing.T) {


### PR DESCRIPTION
Since updating the default namespace to `cockroach-operator-system` the nightly smoke tests have been failing. This is because there is a check to wait for a deployment (that doesn't exist) to be available.

This patch adds the namespace to the appropriate calls and makes the tests work again. I've verified this by running the following command locally: `make test/smoketest NODE_VERSION=1.22.1`

**Checklist**

* [x] I have added these changes to the changelog (or it's not applicable).
