### PR TITLE
Give nightly tests a bit longer to be ready

### DIFF
--- a/hack/k8s/verify_k8s_running.go
+++ b/hack/k8s/verify_k8s_running.go
@@ -215,7 +215,6 @@ var KindPodLabels = []string{"kindnet", "kube-proxy"}
 var KindComponentLabels = []string{"etcd", "kube-apiserver", "kube-controller-manager", "kube-scheduler"}
 
 func main() {
-
 	// -type is the flag we use to determine if we are checking kind or gke
 	k8sTypeFlag := flag.String("type", "", "gke or kind")
 	flag.Parse()
@@ -238,6 +237,9 @@ func main() {
 			klog.Error(err)
 			panic("unable to find gke pods")
 		}
+		// TODO(pseudomuto): This clearly isn't the right solution. Rather than sleeping and hoping for the best, we should
+		// figure out what exactly is requiring this period of time and wait on that directly.
+		time.Sleep(1 * time.Minute)
 		fmt.Println("gke is running")
 	case *k8sTypeFlag == "kind":
 		p := createK8sPodLabel(&Component, &KindComponentLabels)

--- a/pkg/testutil/env/env.go
+++ b/pkg/testutil/env/env.go
@@ -19,6 +19,8 @@ package env
 import (
 	"flag"
 	"fmt"
+	"os"
+
 	api "github.com/cockroachdb/cockroach-operator/apis/v1alpha1"
 	customClient "github.com/cockroachdb/cockroach-operator/pkg/client/clientset/versioned"
 	"github.com/cockroachdb/errors"
@@ -30,7 +32,6 @@ import (
 	kscheme "k8s.io/client-go/kubernetes/scheme"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp" // GCP auth support
 	"k8s.io/client-go/rest"
-	"os"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 )


### PR DESCRIPTION
Our nightly tests have been failing. At first, we thought it might just
be flakiness, but the issue appears to be consistent.

After running the tests from my local machine, I was able to reproduce
the issue and found that by adding a pause before saying K8s is ready, I
can reliably get the tests to pass.

Clearly, adding a sleep call is not ideal/desirable. I'm hoping to get
this in so we can stop the bleeding so to speak and then figure out what
the actual issue is.
