### PR TITLE
Properly mark nodes as decommissioned

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 # [Unreleased](https://github.com/cockroachdb/cockroach-operator/compare/v2.4.0...master)
 
+## Fixed
+
+* Mark nodes as decommissioned after draining the node
+
 # [v2.4.0](https://github.com/cockroachdb/cockroach-operator/compare/v2.3.0...v2.4.0)
 
 ## Added

--- a/e2e/decommission/decommission_test.go
+++ b/e2e/decommission/decommission_test.go
@@ -19,7 +19,6 @@ package decommission
 import (
 	"context"
 	"flag"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"testing"
 	"time"
 
@@ -30,6 +29,7 @@ import (
 	"github.com/go-logr/zapr"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zaptest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // TODO parallel seems to be buggy.  Not certain why, but we need to figure out if running with the operator
@@ -65,10 +65,15 @@ func TestDecommissionFunctionalityWithPrune(t *testing.T) {
 
 	sb := testenv.NewDiffingSandbox(t, env)
 	sb.StartManager(t, controller.InitClusterReconcilerWithLogger(testLog))
-	builder := testutil.NewBuilder("crdb").Namespaced(sb.Namespace).WithNodeCount(4).WithTLS().
+
+	builder := testutil.NewBuilder("crdb").
+		Namespaced(sb.Namespace).
+		WithNodeCount(4).
+		WithTLS().
 		WithImage("cockroachdb/cockroach:v20.2.5").
 		WithPVDataStore("1Gi", "standard" /* default storage class in KIND */)
-	steps := testutil.Steps{
+
+	testutil.Steps{
 		{
 			Name: "creates a 4-node secure cluster and tests db",
 			Test: func(t *testing.T) {
@@ -94,8 +99,7 @@ func TestDecommissionFunctionalityWithPrune(t *testing.T) {
 				testutil.RequireNumberOfPVCs(t, context.TODO(), sb, builder, 3)
 			},
 		},
-	}
-	steps.Run(t)
+	}.Run(t)
 }
 
 // TestDecommissionFunctionality creates a cluster of 4 nodes and then decommissions on of the CRDB nodes.
@@ -123,10 +127,15 @@ func TestDecommissionFunctionality(t *testing.T) {
 
 	sb := testenv.NewDiffingSandbox(t, env)
 	sb.StartManager(t, controller.InitClusterReconcilerWithLogger(testLog))
-	builder := testutil.NewBuilder("crdb").Namespaced(sb.Namespace).WithNodeCount(4).WithTLS().
+
+	builder := testutil.NewBuilder("crdb").
+		Namespaced(sb.Namespace).
+		WithNodeCount(4).
+		WithTLS().
 		WithImage("cockroachdb/cockroach:v20.2.5").
 		WithPVDataStore("1Gi", "standard" /* default storage class in KIND */)
-	steps := testutil.Steps{
+
+	testutil.Steps{
 		{
 			Name: "creates a 4-node secure cluster and tests db",
 			Test: func(t *testing.T) {
@@ -153,6 +162,5 @@ func TestDecommissionFunctionality(t *testing.T) {
 				testutil.RequireNumberOfPVCs(t, context.TODO(), sb, builder, 4)
 			},
 		},
-	}
-	steps.Run(t)
+	}.Run(t)
 }

--- a/pkg/testutil/require.go
+++ b/pkg/testutil/require.go
@@ -285,6 +285,7 @@ func RequireDecommissionNode(t *testing.T, sb testenv.DiffingSandbox, b ClusterB
 		}
 		return true, nil
 	})
+
 	require.NoError(t, err)
 	t.Log("Done decommissioning node")
 }
@@ -339,9 +340,7 @@ func makeDrainStatusChecker(t *testing.T, sb testenv.DiffingSandbox, b ClusterBu
 		t.Logf("replicas=%s\n", replicasStr)
 		t.Logf("isDecommissioning=%v\n", isDecommissioning)
 
-		// we are not checking isLive != "true"  on tests because the operator exits with islive=true
-		// and when the checks for the test run the node is already decommissioned so isLive can be false
-		if isDecommissioning != "true" {
+		if isLive != "false" {
 			return errors.New("unexpected node status")
 		}
 


### PR DESCRIPTION
Currently, nodes are decommissioned by executing `cockroach node
decommission --wait=none` and then waiting for `replicas` to hit zero by
polling `cockroach node status --decommission`.

This leaves nodes in the _decommissioning_ state and never "finalizes"
the decommission by setting their state to decommissioned.

This PR adds a call to `cockroach node decommission` (without the `--wait` flag) once the replicas have
gone down to 0, which will mark the node as decommissioned
appropriately.

**Checklist**

* [x] I have added these changes to the changelog (or it's not applicable).
