### PR TITLE
Fix reconcile annotations init when it's nil

### DIFF
--- a/pkg/resource/resource.go
+++ b/pkg/resource/resource.go
@@ -161,6 +161,7 @@ func (r Reconciler) reconcileAnnotations(current, desired runtime.Object) error 
 	aa := daccessor.GetAnnotations()
 	if aa == nil {
 		aa = make(map[string]string)
+		daccessor.SetAnnotations(aa)
 	}
 
 	for k, v := range caccessor.GetAnnotations() {


### PR DESCRIPTION
_Add a description of the problem this PR addresses and an overview of how this PR works_.

during learning code of `reconcileAnnotations`, I think it should `SetAnnotations` when init desired object's annotations.

otherwise following put aa should be useless?

**Checklist**

* [x] it's not applicable to the changelog.
