### PR TITLE
Update build steps to avoid removing yum

### DIFF
--- a/cmd/cockroach-operator/BUILD.bazel
+++ b/cmd/cockroach-operator/BUILD.bazel
@@ -48,7 +48,7 @@ container_run_and_commit_layer(
     commands = [
         "microdnf install yum",
         "yum -v -y update --all",
-        "microdnf remove yum && microdnf clean all",
+        "microdnf clean all && rm -rf /var/cache/yum",
     ],
     image = "@redhat_ubi_minimal//image",
 )


### PR DESCRIPTION
Our publish step for the docker image was failing since yum is now a
protected package in the ubi base image.

I've updated the script to leave yum, but clear its cache. The
resulting image results in a slightly smaller (184MB vs 193MB) image.

From the output logs:

```
error: Could not depsolve transaction; 1 problem detected: Problem: The
operation would result in removing the following protected packages: yum
```

I tested this locally, before and after the fix with:

```
bazel run //cmd/cockroach-operator:ubi_base_image -- --norun
```