### PR TITLE
Add RELEASE_IMAGE_COCKROACH_<version> to manager env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## Fixed
 
 * Bundle generation for updated OpenShift marketplace requirements
+* Related images added to manager env for supporting cockroachDBVersion in the spec
 
 # [v2.5.0](https://github.com/cockroachdb/cockroach-operator/compare/v2.4.0...v2.5.0)
 

--- a/config/manager/patches/image.yaml
+++ b/config/manager/patches/image.yaml
@@ -25,3 +25,94 @@ spec:
       containers:
         - name: cockroach-operator
           image: cockroachdb/cockroach-operator:v2.5.0
+          env:
+            - name: RELATED_IMAGE_COCKROACH_v20_1_4
+              value: cockroachdb/cockroach:v20.1.4
+            - name: RELATED_IMAGE_COCKROACH_v20_1_5
+              value: cockroachdb/cockroach:v20.1.5
+            - name: RELATED_IMAGE_COCKROACH_v20_1_8
+              value: cockroachdb/cockroach:v20.1.8
+            - name: RELATED_IMAGE_COCKROACH_v20_1_11
+              value: cockroachdb/cockroach:v20.1.11
+            - name: RELATED_IMAGE_COCKROACH_v20_1_12
+              value: cockroachdb/cockroach:v20.1.12
+            - name: RELATED_IMAGE_COCKROACH_v20_1_13
+              value: cockroachdb/cockroach:v20.1.13
+            - name: RELATED_IMAGE_COCKROACH_v20_1_15
+              value: cockroachdb/cockroach:v20.1.15
+            - name: RELATED_IMAGE_COCKROACH_v20_1_16
+              value: cockroachdb/cockroach:v20.1.16
+            - name: RELATED_IMAGE_COCKROACH_v20_1_17
+              value: cockroachdb/cockroach:v20.1.17
+            - name: RELATED_IMAGE_COCKROACH_v20_2_0
+              value: cockroachdb/cockroach:v20.2.0
+            - name: RELATED_IMAGE_COCKROACH_v20_2_1
+              value: cockroachdb/cockroach:v20.2.1
+            - name: RELATED_IMAGE_COCKROACH_v20_2_2
+              value: cockroachdb/cockroach:v20.2.2
+            - name: RELATED_IMAGE_COCKROACH_v20_2_3
+              value: cockroachdb/cockroach:v20.2.3
+            - name: RELATED_IMAGE_COCKROACH_v20_2_4
+              value: cockroachdb/cockroach:v20.2.4
+            - name: RELATED_IMAGE_COCKROACH_v20_2_5
+              value: cockroachdb/cockroach:v20.2.5
+            - name: RELATED_IMAGE_COCKROACH_v20_2_6
+              value: cockroachdb/cockroach:v20.2.6
+            - name: RELATED_IMAGE_COCKROACH_v20_2_8
+              value: cockroachdb/cockroach:v20.2.8
+            - name: RELATED_IMAGE_COCKROACH_v20_2_9
+              value: cockroachdb/cockroach:v20.2.9
+            - name: RELATED_IMAGE_COCKROACH_v20_2_10
+              value: cockroachdb/cockroach:v20.2.10
+            - name: RELATED_IMAGE_COCKROACH_v20_2_11
+              value: cockroachdb/cockroach:v20.2.11
+            - name: RELATED_IMAGE_COCKROACH_v20_2_12
+              value: cockroachdb/cockroach:v20.2.12
+            - name: RELATED_IMAGE_COCKROACH_v20_2_13
+              value: cockroachdb/cockroach:v20.2.13
+            - name: RELATED_IMAGE_COCKROACH_v20_2_14
+              value: cockroachdb/cockroach:v20.2.14
+            - name: RELATED_IMAGE_COCKROACH_v20_2_15
+              value: cockroachdb/cockroach:v20.2.15
+            - name: RELATED_IMAGE_COCKROACH_v20_2_16
+              value: cockroachdb/cockroach:v20.2.16
+            - name: RELATED_IMAGE_COCKROACH_v20_2_17
+              value: cockroachdb/cockroach:v20.2.17
+            - name: RELATED_IMAGE_COCKROACH_v20_2_18
+              value: cockroachdb/cockroach:v20.2.18
+            - name: RELATED_IMAGE_COCKROACH_v21_1_0
+              value: cockroachdb/cockroach:v21.1.0
+            - name: RELATED_IMAGE_COCKROACH_v21_1_1
+              value: cockroachdb/cockroach:v21.1.1
+            - name: RELATED_IMAGE_COCKROACH_v21_1_2
+              value: cockroachdb/cockroach:v21.1.2
+            - name: RELATED_IMAGE_COCKROACH_v21_1_3
+              value: cockroachdb/cockroach:v21.1.3
+            - name: RELATED_IMAGE_COCKROACH_v21_1_4
+              value: cockroachdb/cockroach:v21.1.4
+            - name: RELATED_IMAGE_COCKROACH_v21_1_5
+              value: cockroachdb/cockroach:v21.1.5
+            - name: RELATED_IMAGE_COCKROACH_v21_1_6
+              value: cockroachdb/cockroach:v21.1.6
+            - name: RELATED_IMAGE_COCKROACH_v21_1_7
+              value: cockroachdb/cockroach:v21.1.7
+            - name: RELATED_IMAGE_COCKROACH_v21_1_9
+              value: cockroachdb/cockroach:v21.1.9
+            - name: RELATED_IMAGE_COCKROACH_v21_1_10
+              value: cockroachdb/cockroach:v21.1.10
+            - name: RELATED_IMAGE_COCKROACH_v21_1_11
+              value: cockroachdb/cockroach:v21.1.11
+            - name: RELATED_IMAGE_COCKROACH_v21_1_12
+              value: cockroachdb/cockroach:v21.1.12
+            - name: RELATED_IMAGE_COCKROACH_v21_1_13
+              value: cockroachdb/cockroach:v21.1.13
+            - name: RELATED_IMAGE_COCKROACH_v21_2_0
+              value: cockroachdb/cockroach:v21.2.0
+            - name: RELATED_IMAGE_COCKROACH_v21_2_1
+              value: cockroachdb/cockroach:v21.2.1
+            - name: RELATED_IMAGE_COCKROACH_v21_2_2
+              value: cockroachdb/cockroach:v21.2.2
+            - name: RELATED_IMAGE_COCKROACH_v21_2_3
+              value: cockroachdb/cockroach:v21.2.3
+            - name: RELATED_IMAGE_COCKROACH_v21_2_4
+              value: cockroachdb/cockroach:v21.2.4

--- a/config/templates/deployment_image.yaml.in
+++ b/config/templates/deployment_image.yaml.in
@@ -25,3 +25,18 @@ spec:
       containers:
         - name: cockroach-operator
           image: cockroachdb/cockroach-operator:{{.OperatorVersion}}
+          env:
+{{- range .CrdbVersions}}{{if stable . }}
+            {{- /*
+                .CrdbVersions: a slice of CockroachDB versions. Every item uses
+                semver.Version as its type. See https://github.com/Masterminds/semver for
+                available methods. We use the `Original()` method, which preserves the
+                leading "v" in the output.
+                The `stable` template function is used to determine if the
+                version is stable or alpha/beta/rc. We publish only stable
+                versions to RedHat Connect.
+                The `underscore` template function replaces all dots with underscores.
+            */}}
+            - name: RELATED_IMAGE_COCKROACH_{{ underscore .Original }}
+              value: cockroachdb/cockroach:{{ .Original }}
+{{- end }}{{ end }}

--- a/install/operator.yaml
+++ b/install/operator.yaml
@@ -373,6 +373,96 @@ spec:
         - -zap-log-level
         - info
         env:
+        - name: RELATED_IMAGE_COCKROACH_v20_1_4
+          value: cockroachdb/cockroach:v20.1.4
+        - name: RELATED_IMAGE_COCKROACH_v20_1_5
+          value: cockroachdb/cockroach:v20.1.5
+        - name: RELATED_IMAGE_COCKROACH_v20_1_8
+          value: cockroachdb/cockroach:v20.1.8
+        - name: RELATED_IMAGE_COCKROACH_v20_1_11
+          value: cockroachdb/cockroach:v20.1.11
+        - name: RELATED_IMAGE_COCKROACH_v20_1_12
+          value: cockroachdb/cockroach:v20.1.12
+        - name: RELATED_IMAGE_COCKROACH_v20_1_13
+          value: cockroachdb/cockroach:v20.1.13
+        - name: RELATED_IMAGE_COCKROACH_v20_1_15
+          value: cockroachdb/cockroach:v20.1.15
+        - name: RELATED_IMAGE_COCKROACH_v20_1_16
+          value: cockroachdb/cockroach:v20.1.16
+        - name: RELATED_IMAGE_COCKROACH_v20_1_17
+          value: cockroachdb/cockroach:v20.1.17
+        - name: RELATED_IMAGE_COCKROACH_v20_2_0
+          value: cockroachdb/cockroach:v20.2.0
+        - name: RELATED_IMAGE_COCKROACH_v20_2_1
+          value: cockroachdb/cockroach:v20.2.1
+        - name: RELATED_IMAGE_COCKROACH_v20_2_2
+          value: cockroachdb/cockroach:v20.2.2
+        - name: RELATED_IMAGE_COCKROACH_v20_2_3
+          value: cockroachdb/cockroach:v20.2.3
+        - name: RELATED_IMAGE_COCKROACH_v20_2_4
+          value: cockroachdb/cockroach:v20.2.4
+        - name: RELATED_IMAGE_COCKROACH_v20_2_5
+          value: cockroachdb/cockroach:v20.2.5
+        - name: RELATED_IMAGE_COCKROACH_v20_2_6
+          value: cockroachdb/cockroach:v20.2.6
+        - name: RELATED_IMAGE_COCKROACH_v20_2_8
+          value: cockroachdb/cockroach:v20.2.8
+        - name: RELATED_IMAGE_COCKROACH_v20_2_9
+          value: cockroachdb/cockroach:v20.2.9
+        - name: RELATED_IMAGE_COCKROACH_v20_2_10
+          value: cockroachdb/cockroach:v20.2.10
+        - name: RELATED_IMAGE_COCKROACH_v20_2_11
+          value: cockroachdb/cockroach:v20.2.11
+        - name: RELATED_IMAGE_COCKROACH_v20_2_12
+          value: cockroachdb/cockroach:v20.2.12
+        - name: RELATED_IMAGE_COCKROACH_v20_2_13
+          value: cockroachdb/cockroach:v20.2.13
+        - name: RELATED_IMAGE_COCKROACH_v20_2_14
+          value: cockroachdb/cockroach:v20.2.14
+        - name: RELATED_IMAGE_COCKROACH_v20_2_15
+          value: cockroachdb/cockroach:v20.2.15
+        - name: RELATED_IMAGE_COCKROACH_v20_2_16
+          value: cockroachdb/cockroach:v20.2.16
+        - name: RELATED_IMAGE_COCKROACH_v20_2_17
+          value: cockroachdb/cockroach:v20.2.17
+        - name: RELATED_IMAGE_COCKROACH_v20_2_18
+          value: cockroachdb/cockroach:v20.2.18
+        - name: RELATED_IMAGE_COCKROACH_v21_1_0
+          value: cockroachdb/cockroach:v21.1.0
+        - name: RELATED_IMAGE_COCKROACH_v21_1_1
+          value: cockroachdb/cockroach:v21.1.1
+        - name: RELATED_IMAGE_COCKROACH_v21_1_2
+          value: cockroachdb/cockroach:v21.1.2
+        - name: RELATED_IMAGE_COCKROACH_v21_1_3
+          value: cockroachdb/cockroach:v21.1.3
+        - name: RELATED_IMAGE_COCKROACH_v21_1_4
+          value: cockroachdb/cockroach:v21.1.4
+        - name: RELATED_IMAGE_COCKROACH_v21_1_5
+          value: cockroachdb/cockroach:v21.1.5
+        - name: RELATED_IMAGE_COCKROACH_v21_1_6
+          value: cockroachdb/cockroach:v21.1.6
+        - name: RELATED_IMAGE_COCKROACH_v21_1_7
+          value: cockroachdb/cockroach:v21.1.7
+        - name: RELATED_IMAGE_COCKROACH_v21_1_9
+          value: cockroachdb/cockroach:v21.1.9
+        - name: RELATED_IMAGE_COCKROACH_v21_1_10
+          value: cockroachdb/cockroach:v21.1.10
+        - name: RELATED_IMAGE_COCKROACH_v21_1_11
+          value: cockroachdb/cockroach:v21.1.11
+        - name: RELATED_IMAGE_COCKROACH_v21_1_12
+          value: cockroachdb/cockroach:v21.1.12
+        - name: RELATED_IMAGE_COCKROACH_v21_1_13
+          value: cockroachdb/cockroach:v21.1.13
+        - name: RELATED_IMAGE_COCKROACH_v21_2_0
+          value: cockroachdb/cockroach:v21.2.0
+        - name: RELATED_IMAGE_COCKROACH_v21_2_1
+          value: cockroachdb/cockroach:v21.2.1
+        - name: RELATED_IMAGE_COCKROACH_v21_2_2
+          value: cockroachdb/cockroach:v21.2.2
+        - name: RELATED_IMAGE_COCKROACH_v21_2_3
+          value: cockroachdb/cockroach:v21.2.3
+        - name: RELATED_IMAGE_COCKROACH_v21_2_4
+          value: cockroachdb/cockroach:v21.2.4
         - name: OPERATOR_NAME
           value: cockroachdb
         - name: POD_NAME


### PR DESCRIPTION
When supplying `cockroachDBVersion` in the spec rather than a specific
image, we check for the image in the manager's env. However, at the
moment that env doesn't include the related images.

This PR addresses that by adding them to the generated deployment
manifest, which in turn is used to create the operator.yaml file in
_/install_.

I've verified that everything still works as expected when generating
the bundle by running `make release/generate-bundle` and ensuring the
image values are what we expect.

**Checklist**

* [x] I have added these changes to the changelog (or it's not applicable).
