### PR TITLE
Validate pvc.volumeMode to circumvent potential reconcilation loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * Removed unused beta channel
 * Dynamically create instance specific service account, role, and role binding
 * OpenShift deployment now allows the operator to run for all namespaces
+* Now validates if `pvc.Volumemode` set correctly to `Filesystem`
 
 ## Fixed
 


### PR DESCRIPTION
This is an attempt to fix the issue reported
in https://github.com/cockroachdb/cockroach-operator/issues/850
and https://github.com/cockroachdb/cockroach-operator/issues/845.

Currently, there seems to be a bug in
[k8s-objectmaker](https://github.com/banzaicloud/k8s-objectmatcher/pull/49),
which causes the operator to think that the sts
has changed since creation and get stuck in the reconcilation loop.

To mitigate, we check whether `volumeMode` is set,
and set correctly upon cluster creation.

