### PR TITLE
Add sidecar support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * Bundle generation for updated OpenShift marketplace requirements
 * Related images added to manager env for supporting cockroachDBVersion in the spec
 * Fixed operator crash loop when cockroachDBVersion is used.
-
+* Fix issue when sidecar container is injected to job pod
+ 
 ## Changed
 
 * Now validates if `pvc.Volumemode` set correctly to `Filesystem`

--- a/pkg/actor/validate_version.go
+++ b/pkg/actor/validate_version.go
@@ -182,7 +182,9 @@ func (v *versionChecker) Act(ctx context.Context, cluster *resource.Cluster, log
 			}
 			return errors.Wrapf(err, "failed to check the version of the crdb")
 		}
-		podLogOpts := corev1.PodLogOptions{}
+		podLogOpts := corev1.PodLogOptions{
+			Container: resource.JobContainerName,
+		}
 		//get pod for the job we created
 
 		pods, err := v.clientset.CoreV1().Pods(job.Namespace).List(ctx, metav1.ListOptions{


### PR DESCRIPTION
if the cluster contains security tools working as sidecar,
the GetLogs function requires to read "crdb" container only

Example of cockroach-operator error log, when a sidecar container is injected to the vcheck pod:

Error:
```
runtime.goexit
  | src/runtime/asm_amd64.s:1581
Wraps: (2) error in opening stream
Wraps: (3) a container name must be specified for pod cockroachdb-vcheck-27429886-hqfnm, choose one of:
 [XXXXXXXXXX-init-container XXXXXXXXXX-container crdb]
Error types: (1) *withstack.withStack (2) *errutil.withPrefix (3) *errors.StatusError
```

StackTrace: 
```
github.com/cockroachdb/cockroach-operator/pkg/actor.(*versionChecker).Act
  | \tpkg/actor/validate_version.go:219
  | github.com/cockroachdb/cockroach-operator/pkg/controller.(*ClusterReconciler).Reconcile
  | \tpkg/controller/cluster_controller.go:146
  | sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler
  | \texternal/io_k8s_sigs_controller_runtime/pkg/internal/controller/controller.go:297
  | sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem
  | \texternal/io_k8s_sigs_controller_runtime/pkg/internal/controller/controller.go:252
  | sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func1.2
  | \texternal/io_k8s_sigs_controller_runtime/pkg/internal/controller/controller.go:215
  | k8s.io/apimachinery/pkg/util/wait.JitterUntilWithContext.func1
  | \texternal/io_k8s_apimachinery/pkg/util/wait/wait.go:185
  | k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1
  | \texternal/io_k8s_apimachinery/pkg/util/wait/wait.go:155
  | k8s.io/apimachinery/pkg/util/wait.BackoffUntil
  | \texternal/io_k8s_apimachinery/pkg/util/wait/wait.go:156
  | k8s.io/apimachinery/pkg/util/wait.JitterUntil
  | \texternal/io_k8s_apimachinery/pkg/util/wait/wait.go:133
  | k8s.io/apimachinery/pkg/util/wait.JitterUntilWithContext
  | \texternal/io_k8s_apimachinery/pkg/util/wait/wait.go:185
  | k8s.io/apimachinery/pkg/util/wait.UntilWithContext
  | \texternal/io_k8s_apimachinery/pkg/util/wait/wait.go:99
  | runtime.goexit
  | \tsrc/runtime/asm_amd64.s:1581
Wraps: (2) error in opening stream
Wraps: (3) a container name must be specified for pod cockroachdb-vcheck-27429673-vb2pj, choose one of: [XXXX-init-container XXXXX-container crdb]
Error types: (1) *withstack.withStack (2) *errutil.withPrefix (3) *errors.StatusError",
```


Raw logs: 
```
{"level":"info","ts":1645793216.551859,"logger":"webhooks","msg":"default","name":"cockroachdb"}
{"level":"info","ts":1645793216.5547361,"logger":"controller.CrdbCluster","msg":"Running action with name: VersionCheckerAction","CrdbCluster":"default/cockroachdb","ReconcileId":"yRP8ZREfXn92VryjZEEEkA"}
{"level":"warn","ts":1645793216.554763,"logger":"controller.CrdbCluster","msg":"starting to check the crdb version of the container provided","CrdbCluster":"default/cockroachdb","ReconcileId":"yRP8ZREfXn92VryjZEEEkA"}
{"level":"warn","ts":1645793216.5548148,"logger":"controller.CrdbCluster","msg":"User set image.name, using that field instead of cockroachDBVersion","CrdbCluster":"default/cockroachdb","ReconcileId":"yRP8ZREfXn92VryjZEEEkA"}
{"level":"warn","ts":1645793216.5580683,"logger":"controller.CrdbCluster","msg":"version checker","CrdbCluster":"default/cockroachdb","ReconcileId":"yRP8ZREfXn92VryjZEEEkA","job":"cockroachdb-vcheck-27429886"}
{"level":"warn","ts":1645793216.5621202,"logger":"controller.CrdbCluster","msg":"job pod is ready","CrdbCluster":"default/cockroachdb","ReconcileId":"yRP8ZREfXn92VryjZEEEkA"}
{"level":"error","ts":1645793216.5788276,"logger":"controller.CrdbCluster","msg":"error in opening stream","CrdbCluster":"default/cockroachdb","ReconcileId":"yRP8ZREfXn92VryjZEEEkA","error":"a container name must be specified for pod cockroachdb-vcheck-27429886-hqfnm, choose one of: [XXXXXXXXXX-init-container XXXXXXXXXX-container crdb]","stacktrace":"github.com/go-logr/zapr.(*zapLogger).Error\n\texternal/com_github_go_logr_zapr/zapr.go:132\ngithub.com/cockroachdb/cockroach-operator/pkg/actor.(*versionChecker).Act\n\tpkg/actor/validate_version.go:213\ngithub.com/cockroachdb/cockroach-operator/pkg/controller.(*ClusterReconciler).Reconcile\n\tpkg/controller/cluster_controller.go:152\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n\texternal/io_k8s_sigs_controller_runtime/pkg/internal/controller/controller.go:297\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\texternal/io_k8s_sigs_controller_runtime/pkg/internal/controller/controller.go:252\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func1.2\n\texternal/io_k8s_sigs_controller_runtime/pkg/internal/controller/controller.go:215\nk8s.io/apimachinery/pkg/util/wait.JitterUntilWithContext.func1\n\texternal/io_k8s_apimachinery/pkg/util/wait/wait.go:185\nk8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1\n\texternal/io_k8s_apimachinery/pkg/util/wait/wait.go:155\nk8s.io/apimachinery/pkg/util/wait.BackoffUntil\n\texternal/io_k8s_apimachinery/pkg/util/wait/wait.go:156\nk8s.io/apimachinery/pkg/util/wait.JitterUntil\n\texternal/io_k8s_apimachinery/pkg/util/wait/wait.go:133\nk8s.io/apimachinery/pkg/util/wait.JitterUntilWithContext\n\texternal/io_k8s_apimachinery/pkg/util/wait/wait.go:185\nk8s.io/apimachinery/pkg/util/wait.UntilWithContext\n\texternal/io_k8s_apimachinery/pkg/util/wait/wait.go:99"}
{"level":"info","ts":1645793216.579,"logger":"controller.CrdbCluster","msg":"Error on action","CrdbCluster":"default/cockroachdb","ReconcileId":"yRP8ZREfXn92VryjZEEEkA","Action":"VersionCheckerAction","err":"error in opening stream: a container name must be specified for pod cockroachdb-vcheck-27429886-hqfnm, choose one of: [XXXXXXXXXX-init-container XXXXXXXXXX-container crdb]"}
{"level":"error","ts":1645793216.5790274,"logger":"controller.CrdbCluster","msg":"action failed","CrdbCluster":"default/cockroachdb","ReconcileId":"yRP8ZREfXn92VryjZEEEkA","error":"error in opening stream: a container name must be specified for pod cockroachdb-vcheck-27429886-hqfnm, choose one of: [XXXXXXXXXX-init-container XXXXXXXXXX-container crdb]","errorVerbose":"error in opening stream: a container name must be specified for pod cockroachdb-vcheck-27429886-hqfnm, choose one of: [XXXXXXXXXX-init-container XXXXXXXXXX-container crdb]\n(1) attached stack trace\n  -- stack trace:\n  | github.com/cockroachdb/cockroach-operator/pkg/actor.(*versionChecker).Act\n  | \tpkg/actor/validate_version.go:214\n  | github.com/cockroachdb/cockroach-operator/pkg/controller.(*ClusterReconciler).Reconcile\n  | \tpkg/controller/cluster_controller.go:152\n  | sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n  | \texternal/io_k8s_sigs_controller_runtime/pkg/internal/controller/controller.go:297\n  | sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n  | \texternal/io_k8s_sigs_controller_runtime/pkg/internal/controller/controller.go:252\n  | sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func1.2\n  | \texternal/io_k8s_sigs_controller_runtime/pkg/internal/controller/controller.go:215\n  | k8s.io/apimachinery/pkg/util/wait.JitterUntilWithContext.func1\n  | \texternal/io_k8s_apimachinery/pkg/util/wait/wait.go:185\n  | k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1\n  | \texternal/io_k8s_apimachinery/pkg/util/wait/wait.go:155\n  | k8s.io/apimachinery/pkg/util/wait.BackoffUntil\n  | \texternal/io_k8s_apimachinery/pkg/util/wait/wait.go:156\n  | k8s.io/apimachinery/pkg/util/wait.JitterUntil\n  | \texternal/io_k8s_apimachinery/pkg/util/wait/wait.go:133\n  | k8s.io/apimachinery/pkg/util/wait.JitterUntilWithContext\n  | \texternal/io_k8s_apimachinery/pkg/util/wait/wait.go:185\n  | k8s.io/apimachinery/pkg/util/wait.UntilWithContext\n  | \texternal/io_k8s_apimachinery/pkg/util/wait/wait.go:99\n  | runtime.goexit\n  | \tsrc/runtime/asm_amd64.s:1581\nWraps: (2) error in opening stream\nWraps: (3) a container name must be specified for pod cockroachdb-vcheck-27429886-hqfnm, choose one of: [XXXXXXXXXX-init-container XXXXXXXXXX-container crdb]\nError types: (1) *withstack.withStack (2) *errutil.withPrefix (3) *errors.StatusError","stacktrace":"github.com/go-logr/zapr.(*zapLogger).Error\n\texternal/com_github_go_logr_zapr/zapr.go:132\ngithub.com/cockroachdb/cockroach-operator/pkg/controller.(*ClusterReconciler).Reconcile\n\tpkg/controller/cluster_controller.go:179\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n\texternal/io_k8s_sigs_controller_runtime/pkg/internal/controller/controller.go:297\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\texternal/io_k8s_sigs_controller_runtime/pkg/internal/controller/controller.go:252\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func1.2\n\texternal/io_k8s_sigs_controller_runtime/pkg/internal/controller/controller.go:215\nk8s.io/apimachinery/pkg/util/wait.JitterUntilWithContext.func1\n\texternal/io_k8s_apimachinery/pkg/util/wait/wait.go:185\nk8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1\n\texternal/io_k8s_apimachinery/pkg/util/wait/wait.go:155\nk8s.io/apimachinery/pkg/util/wait.BackoffUntil\n\texternal/io_k8s_apimachinery/pkg/util/wait/wait.go:156\nk8s.io/apimachinery/pkg/util/wait.JitterUntil\n\texternal/io_k8s_apimachinery/pkg/util/wait/wait.go:133\nk8s.io/apimachinery/pkg/util/wait.JitterUntilWithContext\n\texternal/io_k8s_apimachinery/pkg/util/wait/wait.go:185\nk8s.io/apimachinery/pkg/util/wait.UntilWithContext\n\texternal/io_k8s_apimachinery/pkg/util/wait/wait.go:99"}
{"level":"error","ts":1645793216.5971644,"logger":"controller-runtime.manager.controller.crdbcluster","msg":"Reconciler error","reconciler group":"crdb.cockroachlabs.com","reconciler kind":"CrdbCluster","name":"cockroachdb","namespace":"default","error":"error in opening stream: a container name must be specified for pod cockroachdb-vcheck-27429886-hqfnm, choose one of: [XXXXXXXXXX-init-container XXXXXXXXXX-container crdb]","errorVerbose":"error in opening stream: a container name must be specified for pod cockroachdb-vcheck-27429886-hqfnm, choose one of: [XXXXXXXXXX-init-container XXXXXXXXXX-container crdb]\n(1) attached stack trace\n  -- stack trace:\n  | github.com/cockroachdb/cockroach-operator/pkg/actor.(*versionChecker).Act\n  | \tpkg/actor/validate_version.go:214\n  | github.com/cockroachdb/cockroach-operator/pkg/controller.(*ClusterReconciler).Reconcile\n  | \tpkg/controller/cluster_controller.go:152\n  | sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n  | \texternal/io_k8s_sigs_controller_runtime/pkg/internal/controller/controller.go:297\n  | sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n  | \texternal/io_k8s_sigs_controller_runtime/pkg/internal/controller/controller.go:252\n  | sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func1.2\n  | \texternal/io_k8s_sigs_controller_runtime/pkg/internal/controller/controller.go:215\n  | k8s.io/apimachinery/pkg/util/wait.JitterUntilWithContext.func1\n  | \texternal/io_k8s_apimachinery/pkg/util/wait/wait.go:185\n  | k8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1\n  | \texternal/io_k8s_apimachinery/pkg/util/wait/wait.go:155\n  | k8s.io/apimachinery/pkg/util/wait.BackoffUntil\n  | \texternal/io_k8s_apimachinery/pkg/util/wait/wait.go:156\n  | k8s.io/apimachinery/pkg/util/wait.JitterUntil\n  | \texternal/io_k8s_apimachinery/pkg/util/wait/wait.go:133\n  | k8s.io/apimachinery/pkg/util/wait.JitterUntilWithContext\n  | \texternal/io_k8s_apimachinery/pkg/util/wait/wait.go:185\n  | k8s.io/apimachinery/pkg/util/wait.UntilWithContext\n  | \texternal/io_k8s_apimachinery/pkg/util/wait/wait.go:99\n  | runtime.goexit\n  | \tsrc/runtime/asm_amd64.s:1581\nWraps: (2) error in opening stream\nWraps: (3) a container name must be specified for pod cockroachdb-vcheck-27429886-hqfnm, choose one of: [XXXXXXXXXX-init-container XXXXXXXXXX-container crdb]\nError types: (1) *withstack.withStack (2) *errutil.withPrefix (3) *errors.StatusError","stacktrace":"github.com/go-logr/zapr.(*zapLogger).Error\n\texternal/com_github_go_logr_zapr/zapr.go:132\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).reconcileHandler\n\texternal/io_k8s_sigs_controller_runtime/pkg/internal/controller/controller.go:301\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).processNextWorkItem\n\texternal/io_k8s_sigs_controller_runtime/pkg/internal/controller/controller.go:252\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func1.2\n\texternal/io_k8s_sigs_controller_runtime/pkg/internal/controller/controller.go:215\nk8s.io/apimachinery/pkg/util/wait.JitterUntilWithContext.func1\n\texternal/io_k8s_apimachinery/pkg/util/wait/wait.go:185\nk8s.io/apimachinery/pkg/util/wait.BackoffUntil.func1\n\texternal/io_k8s_apimachinery/pkg/util/wait/wait.go:155\nk8s.io/apimachinery/pkg/util/wait.BackoffUntil\n\texternal/io_k8s_apimachinery/pkg/util/wait/wait.go:156\nk8s.io/apimachinery/pkg/util/wait.JitterUntil\n\texternal/io_k8s_apimachinery/pkg/util/wait/wait.go:133\nk8s.io/apimachinery/pkg/util/wait.JitterUntilWithContext\n\texternal/io_k8s_apimachinery/pkg/util/wait/wait.go:185\nk8s.io/apimachinery/pkg/util/wait.UntilWithContext\n\texternal/io_k8s_apimachinery/pkg/util/wait/wait.go:99"}
```