### PR TITLE
Add Annotations to the pod created by the job

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * Bundle generation for updated OpenShift marketplace requirements
 * Related images added to manager env for supporting cockroachDBVersion in the spec
 * Fixed operator crash loop when cockroachDBVersion is used.
+* Fix add custom annotations to the pod created by the job
 
 ## Changed
 

--- a/pkg/resource/job.go
+++ b/pkg/resource/job.go
@@ -19,6 +19,7 @@ package resource
 import (
 	"errors"
 	"fmt"
+
 	"github.com/cockroachdb/cockroach-operator/pkg/features"
 	"github.com/cockroachdb/cockroach-operator/pkg/kube"
 	"github.com/cockroachdb/cockroach-operator/pkg/labels"
@@ -85,6 +86,9 @@ func (b JobBuilder) buildPodTemplate() corev1.PodTemplateSpec {
 				Labels: b.Selector,
 			},
 		*/
+		ObjectMeta: metav1.ObjectMeta{
+			Annotations: b.Spec().AdditionalAnnotations,
+		},
 		Spec: corev1.PodSpec{
 			SecurityContext: &corev1.PodSecurityContext{
 				RunAsUser: ptr.Int64(1000581000),


### PR DESCRIPTION
When `additionalAnnotations` is used, the pod created by the job doesn't contains any annotations.
The job resource is well annotated but not the pod created by this job.

Jobs description:
```
[root@b172fa08ae6d /]# kubectl describe jobs cockroachdb-vcheck-27429940
Name:           cockroachdb-vcheck-27429940
Namespace:      default
Selector:       controller-uid=338ec2fc-fe6f-4e3d-8199-4d58ef334b2d
Labels:         app.kubernetes.io/component=database
                app.kubernetes.io/instance=cockroachdb
                app.kubernetes.io/managed-by=cockroach-operator
                app.kubernetes.io/name=cockroachdb
                app.kubernetes.io/part-of=cockroachdb
                crdb=is-cool
Annotations:    crdb.io/last-applied: XXXXXXX
                my-additional-annotation: value_of_my_additional_annotation
Controlled By:  CrdbCluster/cockroachdb
Parallelism:    1
Completions:    1
...
```


POD Created by the job (annotations is empty):
```
[root@b172fa08ae6d /]# kubectl describe pod cockroachdb-vcheck-27429940-mtm89
Name:                      cockroachdb-vcheck-27429940-mtm89
Namespace:                 default
Priority:                  0
Node:                      REDACTED/10.128.0.38
Start Time:                Fri, 25 Feb 2022 13:40:21 +0000
Labels:                    controller-uid=338ec2fc-fe6f-4e3d-8199-4d58ef334b2d
                           job-name=cockroachdb-vcheck-27429940
Annotations:               <none>
Status:                    Terminating (lasts <invalid>)
Termination Grace Period:  60s
```
