### PR TITLE
Use bazelisk in CI to avoid hard coded bazel versions

### DIFF
--- a/.github/workflows/e2e-kind-create.yaml
+++ b/.github/workflows/e2e-kind-create.yaml
@@ -29,15 +29,14 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        bazel: ["4.0.0"]
     steps:
       - uses: actions/checkout@v2
-
-      - name: Setup Bazel
-        uses: abhinavsingh/setup-bazel@v3
+      - uses: bazelbuild/setup-bazelisk@v1
+      - name: Mount bazel cache
+        uses: actions/cache@v2
         with:
-          version: ${{ matrix.bazel }}
+          path: "~/.cache/bazel"
+          key: bazel
 
       - name: End-to-end (kind)
         run: make test/e2e/kind-create

--- a/.github/workflows/e2e-kind-decommission.yaml
+++ b/.github/workflows/e2e-kind-decommission.yaml
@@ -29,15 +29,14 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        bazel: [ "4.0.0" ]
     steps:
       - uses: actions/checkout@v2
-
-      - name: Setup Bazel
-        uses: abhinavsingh/setup-bazel@v3
+      - uses: bazelbuild/setup-bazelisk@v1
+      - name: Mount bazel cache
+        uses: actions/cache@v2
         with:
-          version: ${{ matrix.bazel }}
+          path: "~/.cache/bazel"
+          key: bazel
 
       - name: End-to-end (kind)
         run: make test/e2e/kind-decommission

--- a/.github/workflows/e2e-kind-upgrades.yaml
+++ b/.github/workflows/e2e-kind-upgrades.yaml
@@ -29,15 +29,14 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        bazel: ["4.0.0"]
     steps:
       - uses: actions/checkout@v2
-
-      - name: Setup Bazel
-        uses: abhinavsingh/setup-bazel@v3
+      - uses: bazelbuild/setup-bazelisk@v1
+      - name: Mount bazel cache
+        uses: actions/cache@v2
         with:
-          version: ${{ matrix.bazel }}
+          path: "~/.cache/bazel"
+          key: bazel
 
       - name: End-to-end (kind)
         run: make test/e2e/kind-upgrades

--- a/.github/workflows/e2e-kind-upgradessha256.yaml
+++ b/.github/workflows/e2e-kind-upgradessha256.yaml
@@ -29,15 +29,14 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        bazel: [ "4.0.0" ]
     steps:
       - uses: actions/checkout@v2
-
-      - name: Setup Bazel
-        uses: abhinavsingh/setup-bazel@v3
+      - uses: bazelbuild/setup-bazelisk@v1
+      - name: Mount bazel cache
+        uses: actions/cache@v2
         with:
-          version: ${{ matrix.bazel }}
+          path: "~/.cache/bazel"
+          key: bazel
 
       - name: End-to-end (kind)
         run: make test/e2e/kind-upgradessha256

--- a/.github/workflows/e2e-kind-versionchecker.yaml
+++ b/.github/workflows/e2e-kind-versionchecker.yaml
@@ -29,15 +29,14 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        bazel: [ "4.0.0" ]
     steps:
       - uses: actions/checkout@v2
-
-      - name: Setup Bazel
-        uses: abhinavsingh/setup-bazel@v3
+      - uses: bazelbuild/setup-bazelisk@v1
+      - name: Mount bazel cache
+        uses: actions/cache@v2
         with:
-          version: ${{ matrix.bazel }}
+          path: "~/.cache/bazel"
+          key: bazel
 
       - name: End-to-end (kind)
         run: make test/e2e/kind-versionchecker

--- a/.github/workflows/nightly-smoketest.yaml
+++ b/.github/workflows/nightly-smoketest.yaml
@@ -34,11 +34,12 @@ jobs:
         NODE_VERSION: [1.18.19, 1.19.11, 1.20.7, 1.21.2, 1.22.1]
     steps:
       - uses: actions/checkout@v2
-
-      - name: Setup Bazel
-        uses: abhinavsingh/setup-bazel@v3
+      - uses: bazelbuild/setup-bazelisk@v1
+      - name: Mount bazel cache
+        uses: actions/cache@v2
         with:
-          version: 4.2.1
+          path: "~/.cache/bazel"
+          key: bazel
 
       - name: Bank Workload
         env:

--- a/.github/workflows/templates.yaml
+++ b/.github/workflows/templates.yaml
@@ -29,15 +29,14 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        bazel: ["4.0.0"]
     steps:
       - uses: actions/checkout@v2
-
-      - name: Setup Bazel
-        uses: abhinavsingh/setup-bazel@v3
+      - uses: bazelbuild/setup-bazelisk@v1
+      - name: Mount bazel cache
+        uses: actions/cache@v2
         with:
-          version: ${{ matrix.bazel }}
+          path: "~/.cache/bazel"
+          key: bazel
 
       - name: Tests
         run: |

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -29,15 +29,13 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
-      matrix:
-        bazel: ["4.0.0"]
     steps:
       - uses: actions/checkout@v2
-
-      - name: Setup Bazel
-        uses: abhinavsingh/setup-bazel@v3
+      - uses: bazelbuild/setup-bazelisk@v1
+      - name: Mount bazel cache
+        uses: actions/cache@v2
         with:
-          version: ${{ matrix.bazel }}
-
+          path: "~/.cache/bazel"
+          key: bazel
       - name: Tests
         run: make test/all

--- a/.github/workflows/update-crdb-versions.yaml
+++ b/.github/workflows/update-crdb-versions.yaml
@@ -26,6 +26,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: bazelbuild/setup-bazelisk@v1
+      - name: Mount bazel cache
+        uses: actions/cache@v2
+        with:
+          path: "~/.cache/bazel"
+          key: bazel
       - name: Update CRDB versions
         uses: technote-space/create-pr-action@v2
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## Changed
 
 * Image digests now calculated when generating templates, rather than when creating bundles
+* Use [bazelisk](https://github.com/bazelbuild/bazelisk) for CI workflows
 
 # [v2.5.1](https://github.com/cockroachdb/cockroach-operator/compare/v2.5.0...v2.5.1)
 


### PR DESCRIPTION
Rather than upgrading all of the `4.0.0` values in our workflows, I
think we should leverage [bazelisk] for this. This will ensure we've
always got the latest official release being used in CI.

If we ever wanted to fix a version we can always use the env or rcfile
options supported by bazelisk (not used here).

**Checklist**

* [x] I have added these changes to the changelog (or it's not applicable).

[bazelisk]: https://github.com/bazelbuild/bazelisk
