### PR TITLE
Enable support for leader election.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 # [Unreleased](https://github.com/cockroachdb/cockroach-operator/compare/v2.5.1...master)
 
+## Fixed
+
+* #863 - Add flag for `leader-election-id` to enable leader election support
+
 ## Changed
 
 * Image digests now calculated when generating templates, rather than when creating bundles

--- a/cmd/cockroach-operator/main.go
+++ b/cmd/cockroach-operator/main.go
@@ -34,8 +34,9 @@ import (
 )
 
 const (
-	certDir              = "/tmp/k8s-webhook-server/serving-certs"
-	watchNamespaceEnvVar = "WATCH_NAMESPACE"
+	certDir                 = "/tmp/k8s-webhook-server/serving-certs"
+	defaultLeaderElectionID = "crdb-operator.cockroachlabs.com"
+	watchNamespaceEnvVar    = "WATCH_NAMESPACE"
 )
 
 var (
@@ -49,7 +50,7 @@ func init() {
 }
 
 func main() {
-	var metricsAddr, featureGatesString string
+	var metricsAddr, featureGatesString, leaderElectionID string
 	var enableLeaderElection, skipWebhookConfig bool
 
 	// use zap logging cli options
@@ -58,6 +59,7 @@ func main() {
 
 	flag.StringVar(&metricsAddr, "metrics-addr", ":8080", "The address the metric endpoint binds to.")
 	flag.StringVar(&featureGatesString, "feature-gates", "", "Feature gate to enable, format is a command separated list enabling features, for instance RunAsNonRoot=false")
+	flag.StringVar(&leaderElectionID, "leader-election-id", defaultLeaderElectionID, "The ID to use for leader election")
 	flag.BoolVar(&enableLeaderElection, "enable-leader-election", false,
 		"Enable leader election for controller manager. Enabling this will ensure there is only one active controller manager.")
 	flag.BoolVar(&skipWebhookConfig, "skip-webhook-config", false,
@@ -90,6 +92,7 @@ func main() {
 		Namespace:          watchNamespace,
 		MetricsBindAddress: metricsAddr,
 		LeaderElection:     enableLeaderElection,
+		LeaderElectionID:   leaderElectionID,
 		Port:               9443,
 		CertDir:            certDir,
 	}


### PR DESCRIPTION
As mentioned in #863, there is no longer a default value for
`LeaderElectionID` on the manager options. This means that when
`--enable-leader-election` is supplied, the operator fails to start.

I've supplied a default value for the flag here, since most cases won't
need to change this. However, if you intend on running multiple versions
of the operator, having the CLI flag makes it easy to avoid name
collisions.

Fixes #863

**Checklist**

* [x] I have added these changes to the changelog (or it's not applicable).
