### PR TITLE
Bump e2e cluster creation timeout to 20m

### DIFF
--- a/e2e/e2e.go
+++ b/e2e/e2e.go
@@ -23,7 +23,7 @@ import (
 var (
 	// CreateClusterTimeout is the amount of time to wait for a new cluster to be
 	// ready.
-	CreateClusterTimeout = 10 * time.Minute
+	CreateClusterTimeout = 20 * time.Minute
 )
 
 // Some common values used in e2e test suites.


### PR DESCRIPTION
We continue to experience timeouts when running GKE nightlies. The
errors are timeouts, particularly in the upgrade e2e test. I don't see
anything obvious in the code, nor any meaningful changes from when they
worked to fix. So I've doubled the timeout from 10m to 20m.

If this works, as in, it provides the necessary amount of time, we can
tighten it over time.