### PR TITLE
fix NPE error when accessing spec.Image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## Fixed
 
 * #863 - Add flag for `leader-election-id` to enable leader election support
+* Fix nil-pointer errors when `spec.Image` is not provided.
 
 ## Changed
 

--- a/e2e/create/create_test.go
+++ b/e2e/create/create_test.go
@@ -259,7 +259,7 @@ func TestCreateSecureClusterWithCRDBVersionSet(t *testing.T) {
 
 				builder := testutil.NewBuilder("crdb").WithNodeCount(3).WithTLS().
 					WithPVDataStore("1Gi", "standard" /* default storage class in KIND */).
-					WithCockroachDBVersion(crdbVersion)
+					WithCockroachDBVersion(crdbVersion).WithImageObject(nil)
 
 				require.NoError(subT, sb.Create(builder.Cr()))
 				testutil.RequireClusterToBeReadyEventuallyTimeout(subT, sb, builder,

--- a/pkg/resource/cluster.go
+++ b/pkg/resource/cluster.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach-operator/pkg/condition"
 	"github.com/cockroachdb/errors"
 	"github.com/gosimple/slug"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 )
@@ -270,6 +271,20 @@ func (cluster Cluster) GetCockroachDBImageName() string {
 	}
 	//we validate the version after the job runs with exec
 	return cluster.Spec().Image.Name
+}
+
+func (cluster Cluster) GetImagePullPolicy() corev1.PullPolicy {
+	if cluster.Spec().Image == nil || cluster.Spec().Image.PullPolicyName == nil {
+		return corev1.PullIfNotPresent
+	}
+	return *cluster.Spec().Image.PullPolicyName
+}
+
+func (cluster Cluster) GetImagePullSecret() *string {
+	if cluster.Spec().Image == nil {
+		return nil
+	}
+	return cluster.Spec().Image.PullSecret
 }
 
 func (cluster Cluster) NodeTLSSecretName() string {

--- a/pkg/resource/job.go
+++ b/pkg/resource/job.go
@@ -114,7 +114,7 @@ func (b JobBuilder) buildPodTemplate() corev1.PodTemplateSpec {
 		pod.Spec.TopologySpreadConstraints = b.Spec().TopologySpreadConstraints
 	}
 
-	secret := b.Spec().Image.PullSecret
+	secret := b.GetImagePullSecret()
 	if secret != nil {
 		local := corev1.LocalObjectReference{
 			Name: *secret,
@@ -138,7 +138,7 @@ func (b JobBuilder) MakeContainers() []corev1.Container {
 		{
 			Name:            JobContainerName,
 			Image:           b.GetCockroachDBImageName(),
-			ImagePullPolicy: *b.Spec().Image.PullPolicyName,
+			ImagePullPolicy: b.GetImagePullPolicy(),
 			Resources: corev1.ResourceRequirements{
 				Limits: corev1.ResourceList{
 					corev1.ResourceCPU:    apiresource.MustParse("300m"),

--- a/pkg/resource/statefulset.go
+++ b/pkg/resource/statefulset.go
@@ -234,7 +234,7 @@ func (b StatefulSetBuilder) makePodTemplate() corev1.PodTemplateSpec {
 		pod.Spec.NodeSelector = b.Spec().NodeSelector
 	}
 
-	secret := b.Spec().Image.PullSecret
+	secret := b.GetImagePullSecret()
 	if secret != nil {
 		local := corev1.LocalObjectReference{
 			Name: *secret,
@@ -256,7 +256,7 @@ func (b StatefulSetBuilder) MakeInitContainers() []corev1.Container {
 			Name:            initContainer,
 			Image:           image,
 			Command:         []string{"/bin/sh", "-c", certCpCmd},
-			ImagePullPolicy: *b.Spec().Image.PullPolicyName,
+			ImagePullPolicy: b.GetImagePullPolicy(),
 			SecurityContext: &corev1.SecurityContext{
 				RunAsUser:                ptr.Int64(0),
 				AllowPrivilegeEscalation: ptr.Bool(false),
@@ -273,7 +273,7 @@ func (b StatefulSetBuilder) MakeContainers() []corev1.Container {
 		{
 			Name:            DbContainerName,
 			Image:           image,
-			ImagePullPolicy: *b.Spec().Image.PullPolicyName,
+			ImagePullPolicy: b.GetImagePullPolicy(),
 			Lifecycle: &corev1.Lifecycle{
 				PreStop: &corev1.Handler{
 					Exec: &corev1.ExecAction{

--- a/pkg/testutil/builder.go
+++ b/pkg/testutil/builder.go
@@ -107,6 +107,11 @@ func (b ClusterBuilder) WithCockroachDBVersion(version string) ClusterBuilder {
 	return b
 }
 
+func (b ClusterBuilder) WithImageObject(image *api.PodImage) ClusterBuilder {
+	b.cluster.Spec.Image = image
+	return b
+}
+
 func (b ClusterBuilder) WithMaxUnavailable(max *int32) ClusterBuilder {
 	b.cluster.Spec.MaxUnavailable = max
 	return b


### PR DESCRIPTION
This patch fixes several accesses to
`spec.Image` fields that did not check
for potential `nil` value.

This bug eluded e2e tests because
the `Image` field was always set to
non-nil. A knob to the test cluster
builder is added so that we can properly
test.


