### PR TITLE
Bump test timeout for integration tests

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,2 +1,2 @@
 build --workspace_status_command hack/build/print-workspace-status.sh
-test --test_output=errors --test_timeout=-1,-1,-1,1800
+test --test_output=errors --test_timeout=-1,-1,-1,2400


### PR DESCRIPTION
GKE nightlies often fail due to the 30m timeout we have set for the test
category. Bumping this to 40m (2400s) to give them a bit more time to
run.