### PR TITLE
Fix support for full cluster restarts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 # [Unreleased](https://github.com/cockroachdb/cockroach-operator/compare/v2.6.0...master)
 
+## Fixed
+
+* Grant operator deletecollection permissions to fix fullcluster restart flow
+
 # [v2.6.0](https://github.com/cockroachdb/cockroach-operator/compare/v2.5.3...v2.6.0)
 
 ## Added

--- a/config/manager/patches/image.yaml
+++ b/config/manager/patches/image.yaml
@@ -132,3 +132,5 @@ spec:
               value: cockroachdb/cockroach:v21.2.7
             - name: RELATED_IMAGE_COCKROACH_v21_2_8
               value: cockroachdb/cockroach:v21.2.8
+            - name: RELATED_IMAGE_COCKROACH_v21_2_9
+              value: cockroachdb/cockroach:v21.2.9

--- a/config/manifests/bases/cockroach-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/cockroach-operator.clusterserviceversion.yaml
@@ -288,3 +288,5 @@ spec:
     image: registry.connect.redhat.com/cockroachdb/cockroach@sha256:6ca927f137be28481e3a226e6c6bcb7c5ac27664984f17ffc6c1419cd7d08eb7
   - name: RELATED_IMAGE_COCKROACH_v21_2_8
     image: registry.connect.redhat.com/cockroachdb/cockroach@sha256:32fdca575c334822e4356aab36a7ed97b685c065925fe85f1b8ba8425c57159b
+  - name: RELATED_IMAGE_COCKROACH_v21_2_9
+    image: registry.connect.redhat.com/cockroachdb/cockroach@sha256:2af60025ecb3bb933b61328be4c2b2bfd0e7d26f53b72430629208505e45c6d2

--- a/config/manifests/patches/deployment_patch.yaml
+++ b/config/manifests/patches/deployment_patch.yaml
@@ -141,4 +141,6 @@ spec:
               value: registry.connect.redhat.com/cockroachdb/cockroach@sha256:6ca927f137be28481e3a226e6c6bcb7c5ac27664984f17ffc6c1419cd7d08eb7
             - name: RELATED_IMAGE_COCKROACH_v21_2_8
               value: registry.connect.redhat.com/cockroachdb/cockroach@sha256:32fdca575c334822e4356aab36a7ed97b685c065925fe85f1b8ba8425c57159b
+            - name: RELATED_IMAGE_COCKROACH_v21_2_9
+              value: registry.connect.redhat.com/cockroachdb/cockroach@sha256:2af60025ecb3bb933b61328be4c2b2bfd0e7d26f53b72430629208505e45c6d2
           image: RH_COCKROACH_OP_IMAGE_PLACEHOLDER

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -148,6 +148,8 @@ rules:
   resources:
   - pods
   verbs:
+  - delete
+  - deletecollection
   - get
   - list
 - apiGroups:

--- a/config/samples/crdb-tls-example.yaml
+++ b/config/samples/crdb-tls-example.yaml
@@ -19,7 +19,7 @@ kind: CrdbCluster
 metadata:
   name: crdb-tls-example
 spec:
-  cockroachDBVersion: v21.2.8
+  cockroachDBVersion: v21.2.9
   dataStore:
     pvc:
       spec:

--- a/crdb-versions.yaml
+++ b/crdb-versions.yaml
@@ -181,3 +181,6 @@ CrdbVersions:
 - image: cockroachdb/cockroach:v21.2.8
   redhatImage: registry.connect.redhat.com/cockroachdb/cockroach@sha256:32fdca575c334822e4356aab36a7ed97b685c065925fe85f1b8ba8425c57159b
   tag: v21.2.8
+- image: cockroachdb/cockroach:v21.2.9
+  redhatImage: registry.connect.redhat.com/cockroachdb/cockroach@sha256:2af60025ecb3bb933b61328be4c2b2bfd0e7d26f53b72430629208505e45c6d2
+  tag: v21.2.9

--- a/e2e/decommission/decommission_test.go
+++ b/e2e/decommission/decommission_test.go
@@ -19,6 +19,7 @@ package decommission
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/cockroachdb/cockroach-operator/e2e"
 	"github.com/cockroachdb/cockroach-operator/pkg/controller"
@@ -86,6 +87,10 @@ func TestDecommissionFunctionalityWithPrune(t *testing.T) {
 				testutil.RequireDecommissionNode(t, sb, builder, 3)
 				testutil.RequireDatabaseToFunction(t, sb, builder)
 				t.Log("Done with decommission")
+
+				// Sleeping helps prevents flakes.
+				time.Sleep(5 * time.Second)
+
 				testutil.RequireNumberOfPVCs(t, context.TODO(), sb, builder, 3)
 			},
 		},

--- a/examples/client-secure-operator.yaml
+++ b/examples/client-secure-operator.yaml
@@ -23,7 +23,7 @@ spec:
   serviceAccountName: cockroachdb-sa
   containers:
   - name: cockroachdb-client-secure
-    image: cockroachdb/cockroach:v21.2.8
+    image: cockroachdb/cockroach:v21.2.9
     imagePullPolicy: IfNotPresent
     volumeMounts:
     - name: client-certs

--- a/examples/example.yaml
+++ b/examples/example.yaml
@@ -40,9 +40,9 @@ spec:
       memory: 8Gi
   tlsEnabled: true
 # You can set either a version of the db or a specific image name
-# cockroachDBVersion: v21.2.8
+# cockroachDBVersion: v21.2.9
   image:
-    name: cockroachdb/cockroach:v21.2.8
+    name: cockroachdb/cockroach:v21.2.9
   # nodes refers to the number of crdb pods that are created
   # via the statefulset
   nodes: 3

--- a/examples/smoketest.yaml
+++ b/examples/smoketest.yaml
@@ -39,5 +39,5 @@ spec:
       memory: 300Mi
   tlsEnabled: true
   image:
-    name: cockroachdb/cockroach:v21.2.8
+    name: cockroachdb/cockroach:v21.2.9
   nodes: 3

--- a/install/operator.yaml
+++ b/install/operator.yaml
@@ -161,6 +161,8 @@ rules:
   resources:
   - pods
   verbs:
+  - delete
+  - deletecollection
   - get
   - list
 - apiGroups:
@@ -481,6 +483,8 @@ spec:
           value: cockroachdb/cockroach:v21.2.7
         - name: RELATED_IMAGE_COCKROACH_v21_2_8
           value: cockroachdb/cockroach:v21.2.8
+        - name: RELATED_IMAGE_COCKROACH_v21_2_9
+          value: cockroachdb/cockroach:v21.2.9
         - name: OPERATOR_NAME
           value: cockroachdb
         - name: POD_NAME

--- a/pkg/controller/cluster_controller.go
+++ b/pkg/controller/cluster_controller.go
@@ -63,7 +63,7 @@ type ClusterReconciler struct {
 // +kubebuilder:rbac:groups=core,resources=configmaps,verbs=get;list;watch
 // +kubebuilder:rbac:groups=core,resources=configmaps/status,verbs=get
 // +kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;watch;create;update;patch
-// +kubebuilder:rbac:groups=core,resources=pods,verbs=get;list
+// +kubebuilder:rbac:groups=core,resources=pods,verbs=get;list;delete;deletecollection
 // +kubebuilder:rbac:groups=core,resources=pods/exec,verbs=create
 // +kubebuilder:rbac:groups=core,resources=pods/log,verbs=get
 // +kubebuilder:rbac:groups=core,resources=nodes,verbs=get;list


### PR DESCRIPTION
Previously, full cluster restarts were not working due to the operator
not having permissions. This PR grants the correct permissions.

Addresses issue #881.
