### PR TITLE
Add error checking and comments around custom logging config.

### DIFF
--- a/apis/v1alpha1/cluster_types.go
+++ b/apis/v1alpha1/cluster_types.go
@@ -134,6 +134,8 @@ type CrdbClusterSpec struct {
 	// proper channels in the cockroachdb. Logging configuration is available for cockroach version v21.1.0 onwards.
 	// The logging configuration is taken in format of yaml file, you can check the logging configuration here (https://www.cockroachlabs.com/docs/stable/configure-logs.html#default-logging-configuration)
 	// The default logging for cockroach version v20.x or less is stderr, logging API is ignored for older versions.
+	// NOTE: The `data` field of map must contain an entry called `logging.yaml`
+	// that contains config options.
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Cockroach Database Logging configuration config map"
 	// +optional
 	LogConfigMap string `json:"logConfigMap,omitempty"`

--- a/config/crd/bases/crdb.cockroachlabs.com_crdbclusters.yaml
+++ b/config/crd/bases/crdb.cockroachlabs.com_crdbclusters.yaml
@@ -974,13 +974,16 @@ spec:
                     type: object
                 type: object
               logConfigMap:
-                description: (Optional) LogConfigMap define the config map which contains
-                  log configuration used to send the logs through the proper channels
-                  in the cockroachdb. Logging configuration is available for cockroach
-                  version v21.1.0 onwards. The logging configuration is taken in format
-                  of yaml file, you can check the logging configuration here (https://www.cockroachlabs.com/docs/stable/configure-logs.html#default-logging-configuration)
+                description: '(Optional) LogConfigMap define the config map which
+                  contains log configuration used to send the logs through the proper
+                  channels in the cockroachdb. Logging configuration is available
+                  for cockroach version v21.1.0 onwards. The logging configuration
+                  is taken in format of yaml file, you can check the logging configuration
+                  here (https://www.cockroachlabs.com/docs/stable/configure-logs.html#default-logging-configuration)
                   The default logging for cockroach version v20.x or less is stderr,
-                  logging API is ignored for older versions.
+                  logging API is ignored for older versions. NOTE: The `data` field
+                  of map must contain an entry called `logging.yaml` that contains
+                  config options.'
                 type: string
               maxSQLMemory:
                 description: '(Optional) The maximum in-memory storage capacity available

--- a/install/crds.yaml
+++ b/install/crds.yaml
@@ -972,13 +972,16 @@ spec:
                     type: object
                 type: object
               logConfigMap:
-                description: (Optional) LogConfigMap define the config map which contains
-                  log configuration used to send the logs through the proper channels
-                  in the cockroachdb. Logging configuration is available for cockroach
-                  version v21.1.0 onwards. The logging configuration is taken in format
-                  of yaml file, you can check the logging configuration here (https://www.cockroachlabs.com/docs/stable/configure-logs.html#default-logging-configuration)
+                description: '(Optional) LogConfigMap define the config map which
+                  contains log configuration used to send the logs through the proper
+                  channels in the cockroachdb. Logging configuration is available
+                  for cockroach version v21.1.0 onwards. The logging configuration
+                  is taken in format of yaml file, you can check the logging configuration
+                  here (https://www.cockroachlabs.com/docs/stable/configure-logs.html#default-logging-configuration)
                   The default logging for cockroach version v20.x or less is stderr,
-                  logging API is ignored for older versions.
+                  logging API is ignored for older versions. NOTE: The `data` field
+                  of map must contain an entry called `logging.yaml` that contains
+                  config options.'
                 type: string
               maxSQLMemory:
                 description: '(Optional) The maximum in-memory storage capacity available

--- a/pkg/resource/cluster.go
+++ b/pkg/resource/cluster.go
@@ -334,6 +334,9 @@ func (cluster Cluster) LoggingConfiguration(fetcher Fetcher) (string, error) {
 
 		if val, ok := cm.Data["logging.yaml"]; ok {
 			return `"` + val + `"`, nil
+		} else {
+			return "", errors.Newf(
+				"`logging.yaml` entry not found in configMap %s", cluster.Spec().LogConfigMap)
 		}
 	}
 


### PR DESCRIPTION
Previously, custom logging configs were now allowed, but there was not a
lot of documentation and error checking. This PR adds this.
