### PR TITLE
Prefer user added --join flags over default when explicitly passed

### DIFF
--- a/pkg/resource/testdata/TestStatefulSetBuilder/default_secure.golden
+++ b/pkg/resource/testdata/TestStatefulSetBuilder/default_secure.golden
@@ -30,11 +30,12 @@ spec:
       - command:
         - /bin/bash
         - -ecx
-        - 'exec /cockroach/cockroach.sh start --join=test-cluster-0.test-cluster.test-ns:26258
+        - 'exec /cockroach/cockroach.sh start
           --advertise-host=$(POD_NAME).test-cluster.test-ns --certs-dir=/cockroach/cockroach-certs/
           --http-port=8080 --sql-addr=:26257 --listen-addr=:26258 --log="{sinks: {stderr:
           {channels: [OPS, HEALTH], redact: true}}}" --cache $(expr $MEMORY_LIMIT_MIB
-          / 4)MiB --max-sql-memory $(expr $MEMORY_LIMIT_MIB / 4)MiB'
+          / 4)MiB --max-sql-memory $(expr $MEMORY_LIMIT_MIB / 4)MiB
+          --join=test-cluster-0.test-cluster.test-ns:26258'
         env:
         - name: COCKROACH_CHANNEL
           value: kubernetes-operator-gke

--- a/pkg/resource/testdata/TestStatefulSetBuilder/insecure_statefulset_cli_args.golden
+++ b/pkg/resource/testdata/TestStatefulSetBuilder/insecure_statefulset_cli_args.golden
@@ -43,10 +43,11 @@ spec:
       - command:
         - /bin/bash
         - -ecx
-        - 'exec /cockroach/cockroach.sh start --join=test-cluster-0.test-cluster.test-ns:26258
+        - 'exec /cockroach/cockroach.sh start 
           --advertise-host=$(POD_NAME).test-cluster.test-ns --insecure --http-port=8080
           --sql-addr=:26257 --listen-addr=:26258 --log="{sinks: {stderr: {channels:
-          [OPS, HEALTH], redact: true}}}" --cache=30% --max-sql-memory=2GB --temp-dir=/tmp'
+          [OPS, HEALTH], redact: true}}}" --cache=30% --max-sql-memory=2GB --temp-dir=/tmp
+          --join=test-cluster-0.test-cluster.test-ns:26258'
         env:
         - name: COCKROACH_CHANNEL
           value: kubernetes-operator-gke

--- a/pkg/resource/testdata/TestStatefulSetBuilder/insecure_statefulset_cli_args_with_join.golden
+++ b/pkg/resource/testdata/TestStatefulSetBuilder/insecure_statefulset_cli_args_with_join.golden
@@ -4,6 +4,7 @@ metadata:
   annotations:
     crdb.io/containerimage: ""
     crdb.io/version: ""
+    key: "test-value"
   creationTimestamp: null
   name: test-cluster
 spec:
@@ -22,7 +23,25 @@ spec:
         app.kubernetes.io/component: database
         app.kubernetes.io/instance: test-cluster
         app.kubernetes.io/name: cockroachdb
+      annotations:
+        key: "test-value"
     spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app.kubernetes.io/instance
+                  operator: In
+                  values:
+                  - test-cluster
+              topologyKey: kubernetes.io/hostname
+            weight: 100
+      tolerations:
+        - key: "key"
+          operator: "Exists"
+          effect: "NoSchedule"
       automountServiceAccountToken: false
       containers:
       - command:
@@ -31,9 +50,8 @@ spec:
         - 'exec /cockroach/cockroach.sh start
           --advertise-host=$(POD_NAME).test-cluster.test-ns --insecure --http-port=8080
           --sql-addr=:26257 --listen-addr=:26258 --log="{sinks: {stderr: {channels:
-          [OPS, HEALTH], redact: true}}}" --cache $(expr $MEMORY_LIMIT_MIB / 4)MiB
-          --max-sql-memory $(expr $MEMORY_LIMIT_MIB / 4)MiB
-          --join=test-cluster-0.test-cluster.test-ns:26258'
+          [OPS, HEALTH], redact: true}}}" --cache=30% --max-sql-memory=2GB
+          --join=test-cluster-1.new-test-cluster.new-test-ns:26258'
         env:
         - name: COCKROACH_CHANNEL
           value: kubernetes-operator-gke
@@ -97,11 +115,11 @@ spec:
   volumeClaimTemplates:
   - metadata:
       creationTimestamp: null
+      name: datadir
       labels:
         app.kubernetes.io/component: database
         app.kubernetes.io/instance: test-cluster
         app.kubernetes.io/name: cockroachdb
-      name: datadir
     spec:
       accessModes:
       - ReadWriteOnce

--- a/pkg/resource/testdata/TestStatefulSetBuilder/insecure_statefulset_cli_args_with_join_in.yaml
+++ b/pkg/resource/testdata/TestStatefulSetBuilder/insecure_statefulset_cli_args_with_join_in.yaml
@@ -1,0 +1,61 @@
+# Copyright 2022 The Cockroach Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: crdb.cockroachlabs.com/v1alpha1
+kind: CrdbCluster
+metadata:
+  creationTimestamp: null
+  name: test-cluster
+  namespace: test-ns
+spec:
+  dataStore:
+    pvc:
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: "1Gi"
+        volumeMode: Filesystem
+  grpcPort: 26258
+  httpPort: 8080
+  image:
+    name: cockroachdb/cockroach:v21.1.0
+  cache: 30%
+  maxSQLMemory: 2GB
+  additionalArgs:
+    - --join=test-cluster-1.new-test-cluster.new-test-ns:26258
+  nodes: 1
+  topology:
+    zones:
+      - locality: ""
+  affinity:
+    podAntiAffinity:
+      preferredDuringSchedulingIgnoredDuringExecution:
+        - weight: 100
+          podAffinityTerm:
+            labelSelector:
+              matchExpressions:
+                - key: app.kubernetes.io/instance
+                  operator: In
+                  values:
+                    - test-cluster
+            topologyKey: kubernetes.io/hostname
+  tolerations:
+    - key: "key"
+      operator: "Exists"
+      effect: "NoSchedule"
+  additionalAnnotations:
+    key: "test-value"
+status: {}

--- a/pkg/resource/testdata/TestStatefulSetBuilder/insecure_statefulset_with_resources.golden
+++ b/pkg/resource/testdata/TestStatefulSetBuilder/insecure_statefulset_with_resources.golden
@@ -28,10 +28,11 @@ spec:
       - command:
         - /bin/bash
         - -ecx
-        - exec /cockroach/cockroach.sh start --join=test-cluster-0.test-cluster.test-ns:26258
+        - exec /cockroach/cockroach.sh start
           --advertise-host=$(POD_NAME).test-cluster.test-ns --insecure --http-port=8080
           --sql-addr=:26257 --listen-addr=:26258 --logtostderr=INFO --cache $(expr
           $MEMORY_LIMIT_MIB / 4)MiB --max-sql-memory $(expr $MEMORY_LIMIT_MIB / 4)MiB
+          --join=test-cluster-0.test-cluster.test-ns:26258
         env:
         - name: COCKROACH_CHANNEL
           value: kubernetes-operator-gke


### PR DESCRIPTION
We have been observing a slight issue with the currently default behavior of automatically including the `--join` flag for all the nodes within the StatefulSet. For most cases this works great, however, when we want to make the pods join a different set of nodes and we explicitly pass in the `--join` flag as a part of `additionalArgs` field, we have observed that the pods of the new cluster will still end up happy forming their own quorum even if they are temporarily not able to reach the nodes specified explicitly in the `--join` command that the we passed.

Ideally we'd like it to respect and prefer the `--join` command passed within the `additionalArgs` over the default. If there are reachability issues with the existing nodes then I think it's okay for those to be surfaced explicitly so the folks managing cluster operations can address that issue and have the nodes reconcile after that.

This is a small proposed change to address the above issue. This change is made in backwards compatible way by avoiding to add any new fields to the CRD but I will leave it to you folks to decide if we want any additional fields or not. If people using the Operator do not want to join the new nodes to nodes from an existing cluster they can avoid passing this flag and the hope is the default behavior should work as expected.