### PR TITLE
controller: fix permissions for pvcs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 ## Fixed
 
 * Grant operator deletecollection permissions to fix fullcluster restart flow
+* Grant operator list and update permissions on pvcs to fix pvc resize flow
 
 # [v2.6.0](https://github.com/cockroachdb/cockroach-operator/compare/v2.5.3...v2.6.0)
 

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -146,6 +146,13 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - persistentvolumeclaims
+  verbs:
+  - list
+  - update
+- apiGroups:
+  - ""
+  resources:
   - pods
   verbs:
   - delete

--- a/install/operator.yaml
+++ b/install/operator.yaml
@@ -159,6 +159,13 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - persistentvolumeclaims
+  verbs:
+  - list
+  - update
+- apiGroups:
+  - ""
+  resources:
   - pods
   verbs:
   - delete

--- a/pkg/controller/cluster_controller.go
+++ b/pkg/controller/cluster_controller.go
@@ -67,6 +67,7 @@ type ClusterReconciler struct {
 // +kubebuilder:rbac:groups=core,resources=pods/exec,verbs=create
 // +kubebuilder:rbac:groups=core,resources=pods/log,verbs=get
 // +kubebuilder:rbac:groups=core,resources=nodes,verbs=get;list
+// +kubebuilder:rbac:groups=core,resources=persistentvolumeclaims,verbs=list;update
 // +kubebuilder:rbac:groups=core,resources=serviceaccounts,verbs=get;list;create;watch
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=roles,verbs=get;list;create;watch
 // +kubebuilder:rbac:groups=rbac.authorization.k8s.io,resources=rolebindings,verbs=get;list;create;watch


### PR DESCRIPTION
Previously, resizing PVCs was broken due to missing permissions. This
patch adds in those missing permissions.

**Checklist**

* [x] I have added these changes to the changelog (or it's not applicable).

Fixes https://github.com/cockroachdb/cockroach-operator/issues/890
