### PR TITLE
Allow option to auto-mount service account token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 # [v2.7.0](https://github.com/cockroachdb/cockroach-operator/compare/v2.6.0...v2.7.0)
 
+## Added
+
+* `AutomountServiceAccountToken` field for cluster spec to allow mounting the default service account token.
+
 ## Fixed
 
 * Grant operator deletecollection permissions to fix fullcluster restart flow

--- a/apis/v1alpha1/cluster_types.go
+++ b/apis/v1alpha1/cluster_types.go
@@ -139,6 +139,12 @@ type CrdbClusterSpec struct {
 	// +operator-sdk:csv:customresourcedefinitions:type=spec,displayName="Cockroach Database Logging configuration config map"
 	// +optional
 	LogConfigMap string `json:"logConfigMap,omitempty"`
+	// (Optional) AutomountServiceAccountToken determines whether or not the stateful set pods should
+	// automount the service account token. This is the default behavior in Kubernetes. For backward
+	// compatibility reasons, this value defaults to `false` here.
+	// Default: false
+	// +optional
+	AutomountServiceAccountToken bool `json:"automountServiceAccountToken,omitempty"`
 }
 
 // +k8s:openapi-gen=true

--- a/config/crd/bases/crdb.cockroachlabs.com_crdbclusters.yaml
+++ b/config/crd/bases/crdb.cockroachlabs.com_crdbclusters.yaml
@@ -665,6 +665,13 @@ spec:
                         type: array
                     type: object
                 type: object
+              automountServiceAccountToken:
+                description: '(Optional) AutomountServiceAccountToken determines whether
+                  or not the stateful set pods should automount the service account
+                  token. This is the default behavior in Kubernetes. For backward
+                  compatibility reasons, this value defaults to `false` here. Default:
+                  false'
+                type: boolean
               cache:
                 description: '(Optional) The total size for caches (`--cache` command
                   line parameter) Default: "25%"'

--- a/e2e/upgrades/upgrades_test.go
+++ b/e2e/upgrades/upgrades_test.go
@@ -204,7 +204,10 @@ func TestUpgradesMinorVersionThenRollback(t *testing.T) {
 	sb := testenv.NewDiffingSandbox(t, env)
 	sb.StartManager(t, controller.InitClusterReconcilerWithLogger(testLog))
 
-	builder := testutil.NewBuilder("crdb").WithNodeCount(3).WithTLS().
+	builder := testutil.NewBuilder("crdb").
+		WithAutomountServiceAccountToken(true).
+		WithNodeCount(3).
+		WithTLS().
 		WithImage(e2e.MinorVersion1).
 		WithPVDataStore("1Gi")
 

--- a/install/crds.yaml
+++ b/install/crds.yaml
@@ -663,6 +663,13 @@ spec:
                         type: array
                     type: object
                 type: object
+              automountServiceAccountToken:
+                description: '(Optional) AutomountServiceAccountToken determines whether
+                  or not the stateful set pods should automount the service account
+                  token. This is the default behavior in Kubernetes. For backward
+                  compatibility reasons, this value defaults to `false` here. Default:
+                  false'
+                type: boolean
               cache:
                 description: '(Optional) The total size for caches (`--cache` command
                   line parameter) Default: "25%"'

--- a/pkg/resource/statefulset.go
+++ b/pkg/resource/statefulset.go
@@ -211,7 +211,7 @@ func (b StatefulSetBuilder) makePodTemplate() corev1.PodTemplateSpec {
 			},
 			TerminationGracePeriodSeconds: ptr.Int64(terminationGracePeriodSecs),
 			Containers:                    b.MakeContainers(),
-			AutomountServiceAccountToken:  ptr.Bool(false),
+			AutomountServiceAccountToken:  ptr.Bool(b.Spec().AutomountServiceAccountToken),
 			ServiceAccountName:            b.ServiceAccountName(),
 		},
 	}

--- a/pkg/resource/testdata/TestStatefulSetBuilder/automount_sa.golden
+++ b/pkg/resource/testdata/TestStatefulSetBuilder/automount_sa.golden
@@ -14,6 +14,7 @@ spec:
       app.kubernetes.io/component: database
       app.kubernetes.io/instance: test-cluster
       app.kubernetes.io/name: cockroachdb
+      car: koenigsegg
   serviceName: test-cluster
   template:
     metadata:
@@ -22,16 +23,18 @@ spec:
         app.kubernetes.io/component: database
         app.kubernetes.io/instance: test-cluster
         app.kubernetes.io/name: cockroachdb
+        car: koenigsegg
     spec:
-      automountServiceAccountToken: false
+      automountServiceAccountToken: true
       containers:
       - command:
         - /bin/bash
         - -ecx
         - 'exec /cockroach/cockroach.sh start --advertise-host=$(POD_NAME).test-cluster.test-ns
-          --insecure --http-port=8080 --sql-addr=:26257 --listen-addr=:26258 --log="{sinks:
-          {stderr: {channels: [OPS, HEALTH], redact: true}}}" --cache $(expr $MEMORY_LIMIT_MIB
-          / 4)MiB --max-sql-memory $(expr $MEMORY_LIMIT_MIB / 4)MiB --join=test-cluster-0.test-cluster.test-ns:26258'
+          --certs-dir=/cockroach/cockroach-certs/ --http-port=8080 --sql-addr=:26257
+          --listen-addr=:26258 --log="{sinks: {stderr: {channels: [OPS, HEALTH], redact:
+          true}}}" --cache $(expr $MEMORY_LIMIT_MIB / 4)MiB --max-sql-memory $(expr
+          $MEMORY_LIMIT_MIB / 4)MiB --join=test-cluster-0.test-cluster.test-ns:26258'
         env:
         - name: COCKROACH_CHANNEL
           value: kubernetes-operator-gke
@@ -57,7 +60,8 @@ spec:
               command:
               - sh
               - -c
-              - /cockroach/cockroach node drain --insecure || exit 0
+              - /cockroach/cockroach node drain --certs-dir=/cockroach/cockroach-certs/
+                || exit 0
         name: db
         ports:
         - containerPort: 26258
@@ -74,13 +78,34 @@ spec:
           httpGet:
             path: /health?ready=1
             port: http
-            scheme: HTTP
+            scheme: HTTPS
           initialDelaySeconds: 10
           periodSeconds: 5
         resources: {}
         volumeMounts:
         - mountPath: /cockroach/cockroach-data/
           name: datadir
+        - mountPath: /cockroach/cockroach-certs/
+          name: emptydir
+      initContainers:
+      - command:
+        - /bin/sh
+        - -c
+        - '>- cp -p /cockroach/cockroach-certs-prestage/..data/* /cockroach/cockroach-certs/
+          && chmod 700 /cockroach/cockroach-certs/*.key && chown 1000581000:1000581000
+          /cockroach/cockroach-certs/*.key'
+        image: cockroachdb/cockroach:v21.1.0
+        imagePullPolicy: IfNotPresent
+        name: db-init
+        resources: {}
+        securityContext:
+          allowPrivilegeEscalation: false
+          runAsUser: 0
+        volumeMounts:
+        - mountPath: /cockroach/cockroach-certs-prestage/
+          name: certs
+        - mountPath: /cockroach/cockroach-certs/
+          name: emptydir
       securityContext:
         fsGroup: 1000581000
         runAsUser: 1000581000
@@ -90,6 +115,33 @@ spec:
       - name: datadir
         persistentVolumeClaim:
           claimName: ""
+      - emptyDir: {}
+        name: emptydir
+      - name: certs
+        projected:
+          defaultMode: 400
+          sources:
+          - secret:
+              items:
+              - key: ca.crt
+                mode: 504
+                path: ca.crt
+              - key: tls.crt
+                mode: 504
+                path: node.crt
+              - key: tls.key
+                mode: 400
+                path: node.key
+              name: test-cluster-node
+          - secret:
+              items:
+              - key: tls.crt
+                mode: 504
+                path: client.root.crt
+              - key: tls.key
+                mode: 400
+                path: client.root.key
+              name: test-cluster-root
   updateStrategy:
     rollingUpdate: {}
   volumeClaimTemplates:
@@ -99,6 +151,7 @@ spec:
         app.kubernetes.io/component: database
         app.kubernetes.io/instance: test-cluster
         app.kubernetes.io/name: cockroachdb
+        car: koenigsegg
       name: datadir
     spec:
       accessModes:

--- a/pkg/resource/testdata/TestStatefulSetBuilder/automount_sa_in.yaml
+++ b/pkg/resource/testdata/TestStatefulSetBuilder/automount_sa_in.yaml
@@ -1,0 +1,43 @@
+# Copyright 2022 The Cockroach Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: crdb.cockroachlabs.com/v1alpha1
+kind: CrdbCluster
+metadata:
+  creationTimestamp: null
+  name: test-cluster
+  namespace: test-ns
+spec:
+  automountServiceAccountToken: true
+  dataStore:
+    pvc:
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        resources:
+          requests:
+            storage: "1Gi"
+        volumeMode: Filesystem
+  grpcPort: 26258
+  httpPort: 8080
+  image:
+    name: cockroachdb/cockroach:v21.1.0
+  nodes: 1
+  tlsEnabled: true
+  topology:
+    zones:
+      - locality: ""
+  additionalLabels:
+    car: koenigsegg
+status: {}

--- a/pkg/resource/testdata/TestStatefulSetBuilder/default_secure.golden
+++ b/pkg/resource/testdata/TestStatefulSetBuilder/default_secure.golden
@@ -30,12 +30,11 @@ spec:
       - command:
         - /bin/bash
         - -ecx
-        - 'exec /cockroach/cockroach.sh start
-          --advertise-host=$(POD_NAME).test-cluster.test-ns --certs-dir=/cockroach/cockroach-certs/
-          --http-port=8080 --sql-addr=:26257 --listen-addr=:26258 --log="{sinks: {stderr:
-          {channels: [OPS, HEALTH], redact: true}}}" --cache $(expr $MEMORY_LIMIT_MIB
-          / 4)MiB --max-sql-memory $(expr $MEMORY_LIMIT_MIB / 4)MiB
-          --join=test-cluster-0.test-cluster.test-ns:26258'
+        - 'exec /cockroach/cockroach.sh start --advertise-host=$(POD_NAME).test-cluster.test-ns
+          --certs-dir=/cockroach/cockroach-certs/ --http-port=8080 --sql-addr=:26257
+          --listen-addr=:26258 --log="{sinks: {stderr: {channels: [OPS, HEALTH], redact:
+          true}}}" --cache $(expr $MEMORY_LIMIT_MIB / 4)MiB --max-sql-memory $(expr
+          $MEMORY_LIMIT_MIB / 4)MiB --join=test-cluster-0.test-cluster.test-ns:26258'
         env:
         - name: COCKROACH_CHANNEL
           value: kubernetes-operator-gke

--- a/pkg/resource/testdata/TestStatefulSetBuilder/insecure_statefulset_cli_args.golden
+++ b/pkg/resource/testdata/TestStatefulSetBuilder/insecure_statefulset_cli_args.golden
@@ -43,11 +43,10 @@ spec:
       - command:
         - /bin/bash
         - -ecx
-        - 'exec /cockroach/cockroach.sh start 
-          --advertise-host=$(POD_NAME).test-cluster.test-ns --insecure --http-port=8080
-          --sql-addr=:26257 --listen-addr=:26258 --log="{sinks: {stderr: {channels:
-          [OPS, HEALTH], redact: true}}}" --cache=30% --max-sql-memory=2GB --temp-dir=/tmp
-          --join=test-cluster-0.test-cluster.test-ns:26258'
+        - 'exec /cockroach/cockroach.sh start --advertise-host=$(POD_NAME).test-cluster.test-ns
+          --insecure --http-port=8080 --sql-addr=:26257 --listen-addr=:26258 --log="{sinks:
+          {stderr: {channels: [OPS, HEALTH], redact: true}}}" --cache=30% --max-sql-memory=2GB
+          --temp-dir=/tmp --join=test-cluster-0.test-cluster.test-ns:26258'
         env:
         - name: COCKROACH_CHANNEL
           value: kubernetes-operator-gke

--- a/pkg/resource/testdata/TestStatefulSetBuilder/insecure_statefulset_cli_args_with_join.golden
+++ b/pkg/resource/testdata/TestStatefulSetBuilder/insecure_statefulset_cli_args_with_join.golden
@@ -4,7 +4,7 @@ metadata:
   annotations:
     crdb.io/containerimage: ""
     crdb.io/version: ""
-    key: "test-value"
+    key: test-value
   creationTimestamp: null
   name: test-cluster
 spec:
@@ -18,13 +18,13 @@ spec:
   serviceName: test-cluster
   template:
     metadata:
+      annotations:
+        key: test-value
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: database
         app.kubernetes.io/instance: test-cluster
         app.kubernetes.io/name: cockroachdb
-      annotations:
-        key: "test-value"
     spec:
       affinity:
         podAntiAffinity:
@@ -38,19 +38,14 @@ spec:
                   - test-cluster
               topologyKey: kubernetes.io/hostname
             weight: 100
-      tolerations:
-        - key: "key"
-          operator: "Exists"
-          effect: "NoSchedule"
       automountServiceAccountToken: false
       containers:
       - command:
         - /bin/bash
         - -ecx
-        - 'exec /cockroach/cockroach.sh start
-          --advertise-host=$(POD_NAME).test-cluster.test-ns --insecure --http-port=8080
-          --sql-addr=:26257 --listen-addr=:26258 --log="{sinks: {stderr: {channels:
-          [OPS, HEALTH], redact: true}}}" --cache=30% --max-sql-memory=2GB
+        - 'exec /cockroach/cockroach.sh start --advertise-host=$(POD_NAME).test-cluster.test-ns
+          --insecure --http-port=8080 --sql-addr=:26257 --listen-addr=:26258 --log="{sinks:
+          {stderr: {channels: [OPS, HEALTH], redact: true}}}" --cache=30% --max-sql-memory=2GB
           --join=test-cluster-1.new-test-cluster.new-test-ns:26258'
         env:
         - name: COCKROACH_CHANNEL
@@ -106,6 +101,10 @@ spec:
         runAsUser: 1000581000
       serviceAccountName: test-cluster-sa
       terminationGracePeriodSeconds: 300
+      tolerations:
+      - effect: NoSchedule
+        key: key
+        operator: Exists
       volumes:
       - name: datadir
         persistentVolumeClaim:
@@ -115,11 +114,11 @@ spec:
   volumeClaimTemplates:
   - metadata:
       creationTimestamp: null
-      name: datadir
       labels:
         app.kubernetes.io/component: database
         app.kubernetes.io/instance: test-cluster
         app.kubernetes.io/name: cockroachdb
+      name: datadir
     spec:
       accessModes:
       - ReadWriteOnce

--- a/pkg/resource/testdata/TestStatefulSetBuilder/insecure_statefulset_with_resources.golden
+++ b/pkg/resource/testdata/TestStatefulSetBuilder/insecure_statefulset_with_resources.golden
@@ -28,11 +28,10 @@ spec:
       - command:
         - /bin/bash
         - -ecx
-        - exec /cockroach/cockroach.sh start
-          --advertise-host=$(POD_NAME).test-cluster.test-ns --insecure --http-port=8080
-          --sql-addr=:26257 --listen-addr=:26258 --logtostderr=INFO --cache $(expr
-          $MEMORY_LIMIT_MIB / 4)MiB --max-sql-memory $(expr $MEMORY_LIMIT_MIB / 4)MiB
-          --join=test-cluster-0.test-cluster.test-ns:26258
+        - exec /cockroach/cockroach.sh start --advertise-host=$(POD_NAME).test-cluster.test-ns
+          --insecure --http-port=8080 --sql-addr=:26257 --listen-addr=:26258 --logtostderr=INFO
+          --cache $(expr $MEMORY_LIMIT_MIB / 4)MiB --max-sql-memory $(expr $MEMORY_LIMIT_MIB
+          / 4)MiB --join=test-cluster-0.test-cluster.test-ns:26258
         env:
         - name: COCKROACH_CHANNEL
           value: kubernetes-operator-gke

--- a/pkg/testutil/builder.go
+++ b/pkg/testutil/builder.go
@@ -51,6 +51,11 @@ func (b ClusterBuilder) Namespaced(namespace string) ClusterBuilder {
 	return b
 }
 
+func (b ClusterBuilder) WithAutomountServiceAccountToken(mount bool) ClusterBuilder {
+	b.cluster.Spec.AutomountServiceAccountToken = mount
+	return b
+}
+
 func (b ClusterBuilder) WithUID(uid string) ClusterBuilder {
 	b.cluster.ObjectMeta.UID = amtypes.UID(uid)
 	return b


### PR DESCRIPTION
In #107 auto-mounting of the default service account token was disabled.
Presumably this was because it wasn't necessary in order to run
Cockroach.

We've had a number of users request the ability to re-enable this as
it's the default behaviour in Kubernetes and is often used to grant
access to other systems through IAM grants (e.g. backups in S3).

This PR adds an `AutomountServiceAccountToken` field to the cluster spec.
When set, the service account token will be mounted. By default
this value is `false` for backward compatibility reasons.

**Checklist**

* [x] I have added these changes to the changelog (or it's not applicable).
