### PR TITLE
Increase TerminationGracePeriod to 5m

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 * Grant operator deletecollection permissions to fix fullcluster restart flow
 * Grant operator list and update permissions on pvcs to fix pvc resize flow
+* Bump TerminationGracePeriodSeconds from 1m to 5m
 
 # [v2.6.0](https://github.com/cockroachdb/cockroach-operator/compare/v2.5.3...v2.6.0)
 

--- a/e2e/decommission/decommission_test.go
+++ b/e2e/decommission/decommission_test.go
@@ -88,10 +88,10 @@ func TestDecommissionFunctionalityWithPrune(t *testing.T) {
 				testutil.RequireDatabaseToFunction(t, sb, builder)
 				t.Log("Done with decommission")
 
-				// Sleeping helps prevents flakes.
-				time.Sleep(5 * time.Second)
-
-				testutil.RequireNumberOfPVCs(t, context.TODO(), sb, builder, 3)
+				// Give some time for the PVCs to be cleaned up.
+				require.Eventually(t, func() bool {
+					return testutil.HasNumPVCs(context.TODO(), sb, builder, 3)
+				}, 1*time.Minute, 3*time.Second)
 			},
 		},
 	}.Run(t)

--- a/pkg/resource/statefulset.go
+++ b/pkg/resource/statefulset.go
@@ -48,6 +48,8 @@ const (
 
 	// DbContainerName is the name of the container definition in the pod spec
 	DbContainerName = "db"
+
+	terminationGracePeriodSecs = 300
 )
 
 type StatefulSetBuilder struct {
@@ -207,7 +209,7 @@ func (b StatefulSetBuilder) makePodTemplate() corev1.PodTemplateSpec {
 				RunAsUser: ptr.Int64(1000581000),
 				FSGroup:   ptr.Int64(1000581000),
 			},
-			TerminationGracePeriodSeconds: ptr.Int64(60),
+			TerminationGracePeriodSeconds: ptr.Int64(terminationGracePeriodSecs),
 			Containers:                    b.MakeContainers(),
 			AutomountServiceAccountToken:  ptr.Bool(false),
 			ServiceAccountName:            b.ServiceAccountName(),

--- a/pkg/resource/testdata/TestStatefulSetBuilder/default_insecure_statefulset.golden
+++ b/pkg/resource/testdata/TestStatefulSetBuilder/default_insecure_statefulset.golden
@@ -28,7 +28,11 @@ spec:
       - command:
         - /bin/bash
         - -ecx
-        - "exec /cockroach/cockroach.sh start --join=test-cluster-0.test-cluster.test-ns:26258 --advertise-host=$(POD_NAME).test-cluster.test-ns --insecure --http-port=8080 --sql-addr=:26257 --listen-addr=:26258 --log=\"{sinks: {stderr: {channels: [OPS, HEALTH], redact: true}}}\" --cache $(expr $MEMORY_LIMIT_MIB / 4)MiB --max-sql-memory $(expr $MEMORY_LIMIT_MIB / 4)MiB"
+        - 'exec /cockroach/cockroach.sh start --join=test-cluster-0.test-cluster.test-ns:26258
+          --advertise-host=$(POD_NAME).test-cluster.test-ns --insecure --http-port=8080
+          --sql-addr=:26257 --listen-addr=:26258 --log="{sinks: {stderr: {channels:
+          [OPS, HEALTH], redact: true}}}" --cache $(expr $MEMORY_LIMIT_MIB / 4)MiB
+          --max-sql-memory $(expr $MEMORY_LIMIT_MIB / 4)MiB'
         env:
         - name: COCKROACH_CHANNEL
           value: kubernetes-operator-gke
@@ -82,7 +86,7 @@ spec:
         fsGroup: 1000581000
         runAsUser: 1000581000
       serviceAccountName: test-cluster-sa
-      terminationGracePeriodSeconds: 60
+      terminationGracePeriodSeconds: 300
       volumes:
       - name: datadir
         persistentVolumeClaim:
@@ -92,11 +96,11 @@ spec:
   volumeClaimTemplates:
   - metadata:
       creationTimestamp: null
-      name: datadir
       labels:
         app.kubernetes.io/component: database
         app.kubernetes.io/instance: test-cluster
         app.kubernetes.io/name: cockroachdb
+      name: datadir
     spec:
       accessModes:
       - ReadWriteOnce

--- a/pkg/resource/testdata/TestStatefulSetBuilder/default_secure.golden
+++ b/pkg/resource/testdata/TestStatefulSetBuilder/default_secure.golden
@@ -30,7 +30,11 @@ spec:
       - command:
         - /bin/bash
         - -ecx
-        - "exec /cockroach/cockroach.sh start --join=test-cluster-0.test-cluster.test-ns:26258 --advertise-host=$(POD_NAME).test-cluster.test-ns --certs-dir=/cockroach/cockroach-certs/ --http-port=8080 --sql-addr=:26257 --listen-addr=:26258 --log=\"{sinks: {stderr: {channels: [OPS, HEALTH], redact: true}}}\" --cache $(expr $MEMORY_LIMIT_MIB / 4)MiB --max-sql-memory $(expr $MEMORY_LIMIT_MIB / 4)MiB"
+        - 'exec /cockroach/cockroach.sh start --join=test-cluster-0.test-cluster.test-ns:26258
+          --advertise-host=$(POD_NAME).test-cluster.test-ns --certs-dir=/cockroach/cockroach-certs/
+          --http-port=8080 --sql-addr=:26257 --listen-addr=:26258 --log="{sinks: {stderr:
+          {channels: [OPS, HEALTH], redact: true}}}" --cache $(expr $MEMORY_LIMIT_MIB
+          / 4)MiB --max-sql-memory $(expr $MEMORY_LIMIT_MIB / 4)MiB'
         env:
         - name: COCKROACH_CHANNEL
           value: kubernetes-operator-gke
@@ -56,7 +60,8 @@ spec:
               command:
               - sh
               - -c
-              - /cockroach/cockroach node drain --certs-dir=/cockroach/cockroach-certs/ || exit 0
+              - /cockroach/cockroach node drain --certs-dir=/cockroach/cockroach-certs/
+                || exit 0
         name: db
         ports:
         - containerPort: 26258
@@ -86,7 +91,9 @@ spec:
       - command:
         - /bin/sh
         - -c
-        - '>- cp -p /cockroach/cockroach-certs-prestage/..data/* /cockroach/cockroach-certs/ && chmod 700 /cockroach/cockroach-certs/*.key && chown 1000581000:1000581000 /cockroach/cockroach-certs/*.key'
+        - '>- cp -p /cockroach/cockroach-certs-prestage/..data/* /cockroach/cockroach-certs/
+          && chmod 700 /cockroach/cockroach-certs/*.key && chown 1000581000:1000581000
+          /cockroach/cockroach-certs/*.key'
         image: cockroachdb/cockroach:v21.1.0
         imagePullPolicy: IfNotPresent
         name: db-init
@@ -103,7 +110,7 @@ spec:
         fsGroup: 1000581000
         runAsUser: 1000581000
       serviceAccountName: test-cluster-sa
-      terminationGracePeriodSeconds: 60
+      terminationGracePeriodSeconds: 300
       volumes:
       - name: datadir
         persistentVolumeClaim:
@@ -140,12 +147,12 @@ spec:
   volumeClaimTemplates:
   - metadata:
       creationTimestamp: null
-      name: datadir
       labels:
         app.kubernetes.io/component: database
         app.kubernetes.io/instance: test-cluster
         app.kubernetes.io/name: cockroachdb
         car: koenigsegg
+      name: datadir
     spec:
       accessModes:
       - ReadWriteOnce

--- a/pkg/resource/testdata/TestStatefulSetBuilder/insecure_statefulset_cli_args.golden
+++ b/pkg/resource/testdata/TestStatefulSetBuilder/insecure_statefulset_cli_args.golden
@@ -4,7 +4,7 @@ metadata:
   annotations:
     crdb.io/containerimage: ""
     crdb.io/version: ""
-    key: "test-value"
+    key: test-value
   creationTimestamp: null
   name: test-cluster
 spec:
@@ -18,13 +18,13 @@ spec:
   serviceName: test-cluster
   template:
     metadata:
+      annotations:
+        key: test-value
       creationTimestamp: null
       labels:
         app.kubernetes.io/component: database
         app.kubernetes.io/instance: test-cluster
         app.kubernetes.io/name: cockroachdb
-      annotations:
-        key: "test-value"
     spec:
       affinity:
         podAntiAffinity:
@@ -38,16 +38,15 @@ spec:
                   - test-cluster
               topologyKey: kubernetes.io/hostname
             weight: 100
-      tolerations:
-        - key: "key"
-          operator: "Exists"
-          effect: "NoSchedule"
       automountServiceAccountToken: false
       containers:
       - command:
         - /bin/bash
         - -ecx
-        - "exec /cockroach/cockroach.sh start --join=test-cluster-0.test-cluster.test-ns:26258 --advertise-host=$(POD_NAME).test-cluster.test-ns --insecure --http-port=8080 --sql-addr=:26257 --listen-addr=:26258 --log=\"{sinks: {stderr: {channels: [OPS, HEALTH], redact: true}}}\" --cache=30% --max-sql-memory=2GB --temp-dir=/tmp"
+        - 'exec /cockroach/cockroach.sh start --join=test-cluster-0.test-cluster.test-ns:26258
+          --advertise-host=$(POD_NAME).test-cluster.test-ns --insecure --http-port=8080
+          --sql-addr=:26257 --listen-addr=:26258 --log="{sinks: {stderr: {channels:
+          [OPS, HEALTH], redact: true}}}" --cache=30% --max-sql-memory=2GB --temp-dir=/tmp'
         env:
         - name: COCKROACH_CHANNEL
           value: kubernetes-operator-gke
@@ -101,7 +100,11 @@ spec:
         fsGroup: 1000581000
         runAsUser: 1000581000
       serviceAccountName: test-cluster-sa
-      terminationGracePeriodSeconds: 60
+      terminationGracePeriodSeconds: 300
+      tolerations:
+      - effect: NoSchedule
+        key: key
+        operator: Exists
       volumes:
       - name: datadir
         persistentVolumeClaim:
@@ -111,11 +114,11 @@ spec:
   volumeClaimTemplates:
   - metadata:
       creationTimestamp: null
-      name: datadir
       labels:
         app.kubernetes.io/component: database
         app.kubernetes.io/instance: test-cluster
         app.kubernetes.io/name: cockroachdb
+      name: datadir
     spec:
       accessModes:
       - ReadWriteOnce

--- a/pkg/resource/testdata/TestStatefulSetBuilder/insecure_statefulset_with_resources.golden
+++ b/pkg/resource/testdata/TestStatefulSetBuilder/insecure_statefulset_with_resources.golden
@@ -28,7 +28,10 @@ spec:
       - command:
         - /bin/bash
         - -ecx
-        - exec /cockroach/cockroach.sh start --join=test-cluster-0.test-cluster.test-ns:26258 --advertise-host=$(POD_NAME).test-cluster.test-ns --insecure --http-port=8080 --sql-addr=:26257 --listen-addr=:26258 --logtostderr=INFO --cache $(expr $MEMORY_LIMIT_MIB / 4)MiB --max-sql-memory $(expr $MEMORY_LIMIT_MIB / 4)MiB
+        - exec /cockroach/cockroach.sh start --join=test-cluster-0.test-cluster.test-ns:26258
+          --advertise-host=$(POD_NAME).test-cluster.test-ns --insecure --http-port=8080
+          --sql-addr=:26257 --listen-addr=:26258 --logtostderr=INFO --cache $(expr
+          $MEMORY_LIMIT_MIB / 4)MiB --max-sql-memory $(expr $MEMORY_LIMIT_MIB / 4)MiB
         env:
         - name: COCKROACH_CHANNEL
           value: kubernetes-operator-gke
@@ -86,7 +89,7 @@ spec:
         fsGroup: 1000581000
         runAsUser: 1000581000
       serviceAccountName: test-cluster-sa
-      terminationGracePeriodSeconds: 60
+      terminationGracePeriodSeconds: 300
       volumes:
       - name: datadir
         persistentVolumeClaim:
@@ -96,11 +99,11 @@ spec:
   volumeClaimTemplates:
   - metadata:
       creationTimestamp: null
-      name: datadir
       labels:
         app.kubernetes.io/component: database
         app.kubernetes.io/instance: test-cluster
         app.kubernetes.io/name: cockroachdb
+      name: datadir
     spec:
       accessModes:
       - ReadWriteOnce

--- a/pkg/testutil/require.go
+++ b/pkg/testutil/require.go
@@ -563,6 +563,24 @@ func RequireNumberOfPVCs(t *testing.T, ctx context.Context, sb testenv.DiffingSa
 	require.Equal(t, quantity, boundPVCCount)
 }
 
+// HasNumPVCs returns true when the number of bound PVCs is equal to the supplied
+// quantity. If an error occurs, it returns false.
+func HasNumPVCs(ctx context.Context, sb testenv.DiffingSandbox, b ClusterBuilder, quantity int) bool {
+	pvcList, err := fetchPVCs(ctx, sb, b)
+	if err != nil {
+		return false
+	}
+
+	boundPVCCount := 0
+	for _, pvc := range pvcList.Items {
+		if pvc.Status.Phase == corev1.ClaimBound {
+			boundPVCCount = boundPVCCount + 1
+		}
+	}
+
+	return boundPVCCount == quantity
+}
+
 func fetchPVCs(ctx context.Context, sb testenv.DiffingSandbox, b ClusterBuilder) (*corev1.PersistentVolumeClaimList, error) {
 	cluster := b.Cluster()
 	var pvcList *corev1.PersistentVolumeClaimList


### PR DESCRIPTION
Currently we have the termination grace period set to 1m. This seems a
bit low since we need to do a number of things (e.g. drain connections)
before properly shutting down and it could take a bit longer on busy clusters.

I've bumped this to 5m to give the nodes a little more time. This
represents an upperbound of the time, so should have no speed/perf
penalty in most cases.

**Checklist**

* [x] I have added these changes to the changelog (or it's not applicable).
