### PR TITLE
resource/cluster: prefer custom node-tls or client-tls secrets

### DIFF
--- a/pkg/resource/BUILD.bazel
+++ b/pkg/resource/BUILD.bazel
@@ -57,6 +57,7 @@ go_library(
 go_test(
     name = "go_default_test",
     srcs = [
+        "cluster_test.go",
         "certificate_test.go",
         "discovery_service_test.go",
         "pod_distruption_budget_test.go",

--- a/pkg/resource/cluster.go
+++ b/pkg/resource/cluster.go
@@ -289,10 +289,18 @@ func (cluster Cluster) GetImagePullSecret() *string {
 }
 
 func (cluster Cluster) NodeTLSSecretName() string {
+	if cluster.Spec().NodeTLSSecret != "" {
+		return cluster.Spec().NodeTLSSecret
+	}
+
 	return fmt.Sprintf("%s-node", cluster.Name())
 }
 
 func (cluster Cluster) ClientTLSSecretName() string {
+	if cluster.Spec().ClientTLSSecret != "" {
+		return cluster.Spec().ClientTLSSecret
+	}
+
 	return fmt.Sprintf("%s-root", cluster.Name())
 }
 func (cluster Cluster) CASecretName() string {

--- a/pkg/resource/cluster_test.go
+++ b/pkg/resource/cluster_test.go
@@ -1,0 +1,87 @@
+/*
+Copyright 2022 The Cockroach Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    https://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package resource_test
+
+import (
+	"testing"
+
+	"fmt"
+
+	"github.com/cockroachdb/cockroach-operator/pkg/resource"
+	"github.com/cockroachdb/cockroach-operator/pkg/testutil"
+	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestClusterTLSSecrets(t *testing.T) {
+	var (
+		testCluster = "test-cluster"
+		testNS      = "test-ns"
+
+		customNodeTLS   = "custom-node-tls"
+		customClientTLS = "custom-client-tls"
+	)
+
+	clusterBuilder := testutil.NewBuilder(testCluster).Namespaced(testNS)
+
+	for _, tt := range []struct {
+		name                string
+		cluster             *resource.Cluster
+		nodeTLSSecretName   string
+		clientTLSSecretName string
+	}{
+		{
+			name:              "verify default node tls cert",
+			cluster:           clusterBuilder.Cluster(),
+			nodeTLSSecretName: "test-cluster-node",
+		},
+		{
+			name:                "verify default client tls cert",
+			cluster:             clusterBuilder.Cluster(),
+			clientTLSSecretName: "test-cluster-root",
+		},
+		{
+			name:              "verify custom node tls cert",
+			cluster:           clusterBuilder.WithNodeTLS(customNodeTLS).Cluster(),
+			nodeTLSSecretName: customNodeTLS,
+		},
+		{
+			name:                "verify custom client tls cert",
+			cluster:             clusterBuilder.WithClientTLS(customClientTLS).Cluster(),
+			clientTLSSecretName: customClientTLS,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			var expected, actual string
+
+			if tt.nodeTLSSecretName != "" {
+				expected = tt.nodeTLSSecretName
+				actual = tt.cluster.NodeTLSSecretName()
+
+			}
+
+			if tt.clientTLSSecretName != "" {
+				expected = tt.clientTLSSecretName
+				actual = tt.cluster.ClientTLSSecretName()
+			}
+
+			diff := cmp.Diff(expected, actual, testutil.RuntimeObjCmpOpts...)
+			if diff != "" {
+				assert.Fail(t, fmt.Sprintf("unexpected result (-want +got):\n%v", diff))
+			}
+		})
+	}
+}

--- a/pkg/testutil/builder.go
+++ b/pkg/testutil/builder.go
@@ -92,6 +92,11 @@ func (b ClusterBuilder) WithTLS() ClusterBuilder {
 	return b
 }
 
+func (b ClusterBuilder) WithClientTLS(secret string) ClusterBuilder {
+	b.cluster.Spec.ClientTLSSecret = secret
+	return b
+}
+
 func (b ClusterBuilder) WithNodeTLS(secret string) ClusterBuilder {
 	b.cluster.Spec.NodeTLSSecret = secret
 	return b


### PR DESCRIPTION
We had been seeing issues where the Operator fails to establish DB connection to the cluster when using custom Node and Client TLS certificates. On a closer examination it looked like they were always referencing hardcoded secret names, which were absent when using custom secrets that were passed to the `CrdbCluster` as inputs to `nodeTLSSecret` and `clientTLSSecret`.

