### PR TITLE
controller: consolidate status update logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 * Delete the CancelLoop function, fixing a cluster status update bug
 * Correctly detect failed version checker Pods
+* retry cluster status updates, reducing test flakes
 
 # [v2.7.0](https://github.com/cockroachdb/cockroach-operator/compare/v2.6.0...v2.7.0)
 

--- a/pkg/controller/BUILD.bazel
+++ b/pkg/controller/BUILD.bazel
@@ -24,6 +24,7 @@ go_library(
         "@io_k8s_api//policy/v1beta1:go_default_library",
         "@io_k8s_apimachinery//pkg/runtime:go_default_library",
         "@io_k8s_client_go//kubernetes:go_default_library",
+        "@io_k8s_client_go//util/retry:go_default_library",
         "@io_k8s_sigs_controller_runtime//:go_default_library",
         "@io_k8s_sigs_controller_runtime//pkg/client:go_default_library",
         "@io_k8s_sigs_controller_runtime//pkg/reconcile:go_default_library",

--- a/pkg/resource/cluster.go
+++ b/pkg/resource/cluster.go
@@ -319,15 +319,6 @@ func (cluster Cluster) SecureMode() string {
 	return "--insecure"
 }
 
-func (cluster Cluster) IsFresh(fetcher Fetcher) (bool, error) {
-	actual := ClusterPlaceholder(cluster.Name())
-	if err := fetcher.Fetch(actual); err != nil {
-		return false, errors.Wrapf(err, "failed to fetch cluster resource")
-	}
-
-	return cluster.cr.ResourceVersion == actual.ResourceVersion, nil
-}
-
 func (cluster Cluster) LoggingConfiguration(fetcher Fetcher) (string, error) {
 	if cluster.Spec().LogConfigMap != "" {
 		cm := &corev1.ConfigMap{


### PR DESCRIPTION
    Previously, Status updates could fail due to version conflicts. This
    commit pulls all status update logic into a helper function that
    utilizes retry.RetryOnConflict to ensure that .Status updates get
    persisted in spite of resource version changes.
    Additionally, this commit removes an early bailout if the controller
    detects a divergence in the currently loaded resource and the API
    version. This change should have no notable affects as it took place
    after any actors ran.
    It also fixes a buglet that overwrote the reconcilers context,
    negating the maximum runtime for a single reconcilation loop.

_Add a description of the problem this PR addresses and an overview of how this PR works_.

**Checklist**

* [x] I have added these changes to the changelog (or it's not applicable).
