### PR TITLE
reject mutations to additionalLabels field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,9 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 * Correctly detect failed version checker Pods
 * retry cluster status updates, reducing test flakes
 
+## Changed
+* Update validation webhook to reject changes to cluster spec's AdditionalLabels field
+
 # [v2.7.0](https://github.com/cockroachdb/cockroach-operator/compare/v2.6.0...v2.7.0)
 
 ## Fixed

--- a/apis/v1alpha1/webhook_test.go
+++ b/apis/v1alpha1/webhook_test.go
@@ -23,6 +23,7 @@ import (
 	. "github.com/cockroachdb/cockroach-operator/apis/v1alpha1"
 	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 )
 
 func TestCrdbClusterDefault(t *testing.T) {
@@ -179,5 +180,91 @@ func TestUpdateCrdbCluster(t *testing.T) {
 		err := testcase.Cluster.ValidateUpdate(&oldCluster)
 		require.Error(t, err)
 		require.Equal(t, err.Error(), testcase.ErrMsg)
+	}
+}
+
+func TestUpdateCrdbClusterLabels(t *testing.T) {
+	oldCluster := CrdbCluster{
+		Spec: CrdbClusterSpec{
+			Image: &PodImage{},
+			AdditionalLabels: map[string]string{
+				"k": "v",
+			},
+		},
+	}
+	fs := v1.PersistentVolumeFilesystem
+
+	testcases := []struct {
+		Cluster     *CrdbCluster
+		ShouldError bool
+	}{
+		{
+			Cluster: &CrdbCluster{Spec: CrdbClusterSpec{
+				Image:            &PodImage{Name: "testImage"},
+				AdditionalLabels: map[string]string{"k": "v"},
+				DataStore: Volume{
+					VolumeClaim: &VolumeClaim{
+						PersistentVolumeClaimSpec: v1.PersistentVolumeClaimSpec{
+							VolumeMode: &fs,
+						},
+					},
+				},
+			}},
+			ShouldError: false,
+		},
+		{
+			Cluster: &CrdbCluster{Spec: CrdbClusterSpec{
+				Image:            &PodImage{Name: "testImage"},
+				AdditionalLabels: map[string]string{"k": "x"},
+				DataStore: Volume{
+					VolumeClaim: &VolumeClaim{
+						PersistentVolumeClaimSpec: v1.PersistentVolumeClaimSpec{
+							VolumeMode: &fs,
+						},
+					},
+				},
+			}},
+			// label k has a different value.
+			ShouldError: true,
+		},
+		{
+			Cluster: &CrdbCluster{Spec: CrdbClusterSpec{
+				Image: &PodImage{Name: "testImage"},
+				DataStore: Volume{
+					VolumeClaim: &VolumeClaim{
+						PersistentVolumeClaimSpec: v1.PersistentVolumeClaimSpec{
+							VolumeMode: &fs,
+						},
+					},
+				},
+			}},
+			// labels are missing / empty.
+			ShouldError: true,
+		},
+		{
+			Cluster: &CrdbCluster{Spec: CrdbClusterSpec{
+				Image:            &PodImage{Name: "testImage"},
+				AdditionalLabels: map[string]string{"k": "v", "kk": "v"},
+				DataStore: Volume{
+					VolumeClaim: &VolumeClaim{
+						PersistentVolumeClaimSpec: v1.PersistentVolumeClaimSpec{
+							VolumeMode: &fs,
+						},
+					},
+				},
+			}},
+			// labels contain additional kv.
+			ShouldError: true,
+		},
+	}
+
+	for _, tc := range testcases {
+		err := tc.Cluster.ValidateUpdate(runtime.Object(&oldCluster))
+		if tc.ShouldError {
+			require.Error(t, err)
+			require.Equal(t, err.Error(), "mutating additionalLabels field is not supported")
+		} else {
+			require.NoError(t, err)
+		}
 	}
 }


### PR DESCRIPTION
K8s does not support mutating selectors and labels
on statefulsets at the same time:
https://github.com/kubernetes/kubernetes/issues/90519.

This PR adds a validation hook to reject
mutating additionalLabels, which will cause
mutating selectors and labels on the underlying sts,
and a constant reconciliation loop.

_Add a description of the problem this PR addresses and an overview of how this PR works_.

**Checklist**

* [x] I have added these changes to the changelog (or it's not applicable).
