### PR TITLE
Sanity check if the image name has a colon

### DIFF
--- a/pkg/resource/cluster.go
+++ b/pkg/resource/cluster.go
@@ -347,7 +347,12 @@ func (cluster Cluster) IsLoggingAPIEnabled() bool {
 	if cluster.Spec().CockroachDBVersion != "" {
 		version = cluster.Spec().CockroachDBVersion
 	} else if cluster.Spec().Image != nil && cluster.Spec().Image.Name != "" {
-		version = strings.Split(cluster.Spec().Image.Name, ":")[1]
+		split_result := strings.Split(cluster.Spec().Image.Name, ":")
+		if len(split_result) > 1 {
+			version = split_result[1]
+		} else {
+			return false
+		}
 	} else {
 		return false
 	}


### PR DESCRIPTION
fix https://github.com/cockroachdb/cockroach-operator/issues/918

We fixed the issue by adding sanity check to examine whether a colon is contained in the image name in `IsLoggingAPIEnabled` function. If there is no colon in image name, we will not retrieve index 1 and will directly return false.

**Checklist**

* [ ] I have added these changes to the changelog (or it's not applicable).
