### PR TITLE
Fix e2e tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,11 @@
 
 SHELL:=/usr/bin/env bash -O globstar
 
+# Define path where we install binaries.
+# NOTE(all): We need to use absolute paths because kubetest2 on go 1.19 does
+# not support relative paths.
+BINPATH := $(abspath bazel-bin)
+
 # values used in workspace-status.sh
 CLUSTER_NAME?=bazel-test
 COCKROACH_DATABASE_VERSION=v21.2.3
@@ -104,15 +109,15 @@ test/e2e/testrunner-k3d-%:
 test/e2e/k3d-%: PACKAGE=$*
 test/e2e/k3d-%:
 	bazel build //hack/bin/... //e2e/kubetest2-k3d/...
-	PATH=bazel-bin/hack/bin:bazel-bin/e2e/kubetest2-k3d/kubetest2-k3d_/:${PATH} \
-		bazel-bin/hack/bin/kubetest2 k3d \
+	PATH=$(BINPATH)/hack/bin:$(BINPATH)/e2e/kubetest2-k3d/kubetest2-k3d_/:${PATH} \
+		kubetest2 k3d \
 		--cluster-name=$(CLUSTER_NAME) --image rancher/k3s:v1.23.3-k3s1 --servers 3 \
 		--up --down -v 10 --test=exec -- make test/e2e/testrunner-k3d-$(PACKAGE)
 
 # This target is used by kubetest2-eks to run e2e tests.
 .PHONY: test/e2e/testrunner-eks
 test/e2e/testrunner-eks:
-	KUBECONFIG=$(TMPDIR)/$(CLUSTER_NAME)-eks.kubeconfig.yaml bazel-bin/hack/bin/kubectl create -f hack/eks-storageclass.yaml
+	KUBECONFIG=$(TMPDIR)/$(CLUSTER_NAME)-eks.kubeconfig.yaml $(BINPATH)/hack/bin/kubectl create -f hack/eks-storageclass.yaml
 	bazel test --stamp //e2e/upgrades/...  --action_env=KUBECONFIG=$(TMPDIR)/$(CLUSTER_NAME)-eks.kubeconfig.yaml
 	bazel test --stamp //e2e/create/...  --action_env=KUBECONFIG=$(TMPDIR)/$(CLUSTER_NAME)-eks.kubeconfig.yaml
 	bazel test --stamp //e2e/decommission/...  --action_env=KUBECONFIG=$(TMPDIR)/$(CLUSTER_NAME)-eks.kubeconfig.yaml
@@ -123,8 +128,8 @@ test/e2e/testrunner-eks:
 .PHONY: test/e2e/eks
 test/e2e/eks:
 	bazel build //hack/bin/... //e2e/kubetest2-eks/...
-	PATH=${PATH}:bazel-bin/hack/bin:bazel-bin/e2e/kubetest2-eks/kubetest2-eks_/ \
-	bazel-bin/hack/bin/kubetest2 eks --cluster-name=$(CLUSTER_NAME)  --up --down -v 10 \
+	PATH=${PATH}:$(BINPATH)/hack/bin:$(BINPATH)/e2e/kubetest2-eks/kubetest2-eks_/ \
+	$(BINPATH)/hack/bin/kubetest2 eks --cluster-name=$(CLUSTER_NAME)  --up --down -v 10 \
 		--test=exec -- make test/e2e/testrunner-eks
 
 # This target is used by kubetest2-tester-exec when running a gke test
@@ -163,7 +168,7 @@ test/e2e/testrunner-gke:
 .PHONY: test/e2e/gke
 test/e2e/gke:
 	bazel build //hack/bin/...
-	PATH=${PATH}:bazel-bin/hack/bin bazel-bin/hack/bin/kubetest2 gke --cluster-name=$(CLUSTER_NAME) \
+	PATH=${PATH}:$(BINPATH)/hack/bin kubetest2 gke --cluster-name=$(CLUSTER_NAME) \
 		--zone=$(GCP_ZONE) --project=$(GCP_PROJECT) \
 		--version latest --up --down -v 10 --ignore-gcp-ssh-key \
 		--test=exec -- make test/e2e/testrunner-gke
@@ -185,8 +190,8 @@ test/e2e/testrunner-openshift:
 .PHONY: test/e2e/openshift
 test/e2e/openshift:
 	bazel build //hack/bin/... //e2e/kubetest2-openshift/...
-	PATH=${PATH}:bazel-bin/hack/bin:bazel-bin/e2e/kubetest2-openshift/kubetest2-openshift_/ \
-	     bazel-bin/hack/bin/kubetest2 openshift --cluster-name=$(CLUSTER_NAME) \
+	PATH=${PATH}:$(BINPATH)/hack/bin:$(BINPATH)/e2e/kubetest2-openshift/kubetest2-openshift_/ \
+	     kubetest2 openshift --cluster-name=$(CLUSTER_NAME) \
 	     --gcp-project-id=$(GCP_PROJECT) \
 	     --gcp-region=$(GCP_REGION) \
 	     --base-domain=$(BASE_DOMAIN) \

--- a/hack/bin/deps.bzl
+++ b/hack/bin/deps.bzl
@@ -268,16 +268,16 @@ filegroup(
 def install_kubetest2():
     # install kubetest2 binary
     http_file(
-       name = "kubetest2_darwin",
-       executable = 1,
-       sha256 = "5b20aadd05eca47dead180a7c8296d75e81c184aabf182d4a41ef96597db543d",
-       urls = ["https://storage.googleapis.com/crdb-bazel-artifacts/osx/kubetest2"],
+        name = "kubetest2_darwin",
+        executable = 1,
+        sha256 = "9fab82888e5c955778a8c49fdd2b9d2216be1a58f70615977fb92f678383e688",
+        urls = ["https://storage.googleapis.com/cockroach-operator-bazel-artifacts/kubetest2_darwin_amd64_v1/kubetest2"],
     )
 
     http_file(
         name = "kubetest2_linux",
         executable = 1,
-        # sha256 = "7f0b05654fa43ca1c607db297b5f3a775f65eea90355bb6b10137a7fffff5e1a",
+        sha256 = "f9306a103dc222d51753e788550bd77c05a910a957a7eb4901ccb7f78256f7b8",
         urls = ["https://storage.googleapis.com/cockroach-operator-bazel-artifacts/kubetest2_linux_amd64_v1/kubetest2"],
     )
 
@@ -286,10 +286,10 @@ def install_kubetest2_gke():
     # install kubetest2-gke binary
     # TODO osx support
     http_file(
-       name = "kubetest2_gke_darwin",
-       executable = 1,
-       sha256 = "a1cbe02f61931dbe6c8d1662442f42cb538c81e4ec8cdd40f548f0e05cbd55a7",
-       urls = ["https://storage.googleapis.com/crdb-bazel-artifacts/osx/kubetest2-gke"],
+        name = "kubetest2_gke_darwin",
+        executable = 1,
+        sha256 = "12d0b7cc9eb2ab2befe781f08672f2707631debd852f2805bed1565699e44a6e",
+        urls = ["https://storage.googleapis.com/cockroach-operator-bazel-artifacts/kubetest2-gke_darwin_amd64_v1/kubetest2-gke"],
     )
 
     http_file(
@@ -304,16 +304,16 @@ def install_kubetest2_exe():
     # install kubetest2-exe binary
     # TODO osx support
     http_file(
-       name = "kubetest2_exe_darwin",
-       executable = 1,
-       sha256 = "818690cb55590440e163b18dd139c8a8714df9480f869bafe19eb344047cf37c",
-       urls = ["https://storage.googleapis.com/crdb-bazel-artifacts/osx/kubetest2-tester-exec"],
+        name = "kubetest2_exe_darwin",
+        executable = 1,
+        sha256 = "15a6c8ff2e6b3962954553eacc9aeefb40ac81f67c326144db2ad94d58756357",
+        urls = ["https://storage.googleapis.com/cockroach-operator-bazel-artifacts/kubetest2-tester-exec_darwin_amd64_v1/kubetest2-tester-exec"],
     )
 
     http_file(
         name = "kubetest2_exe_linux",
         executable = 1,
-        # sha256 = "4483f40f48b98e8a6aa41f58bfdf1f2787066a4e1ad1343e4281892aa1326736",
+        sha256 = "b96c9b651c6a4449adfa41d6760ec1b34ec02230b5debd850976ced3926d80db",
         urls = ["https://storage.googleapis.com/cockroach-operator-bazel-artifacts/kubetest2-tester-exec_linux_amd64_v1/kubetest2-tester-exec"],
     )
 

--- a/hack/bin/deps.bzl
+++ b/hack/bin/deps.bzl
@@ -277,8 +277,8 @@ def install_kubetest2():
     http_file(
         name = "kubetest2_linux",
         executable = 1,
-        sha256 = "7f0b05654fa43ca1c607db297b5f3a775f65eea90355bb6b10137a7fffff5e1a",
-        urls = ["https://storage.googleapis.com/crdb-bazel-artifacts/linux/kubetest2"],
+        # sha256 = "7f0b05654fa43ca1c607db297b5f3a775f65eea90355bb6b10137a7fffff5e1a",
+        urls = ["https://storage.googleapis.com/cockroach-operator-bazel-artifacts/kubetest2_linux_amd64_v1/kubetest2"],
     )
 
 ## Fetch kubetest2-gke binary used during e2e tests
@@ -295,9 +295,10 @@ def install_kubetest2_gke():
     http_file(
         name = "kubetest2_gke_linux",
         executable = 1,
-        sha256 = "9ac658234efc7f59968888662dd2d21908587789f6b812392ac5b6766b17c0b4",
-        urls = ["https://storage.googleapis.com/crdb-bazel-artifacts/linux/kubetest2-gke"],
+        sha256 = "2b294abe037243e8bf71fcef6f02d93ee69abadfd0034681237478fa69474097",
+        urls = ["https://storage.googleapis.com/cockroach-operator-bazel-artifacts/kubetest2-gke_linux_amd64_v1/kubetest2-gke"],
     )
+
 ## Fetch kubetest2-tester-exe binary used during e2e tests
 def install_kubetest2_exe():
     # install kubetest2-exe binary
@@ -312,8 +313,8 @@ def install_kubetest2_exe():
     http_file(
         name = "kubetest2_exe_linux",
         executable = 1,
-        sha256 = "4483f40f48b98e8a6aa41f58bfdf1f2787066a4e1ad1343e4281892aa1326736",
-        urls = ["https://storage.googleapis.com/crdb-bazel-artifacts/linux/kubetest2-tester-exec"],
+        # sha256 = "4483f40f48b98e8a6aa41f58bfdf1f2787066a4e1ad1343e4281892aa1326736",
+        urls = ["https://storage.googleapis.com/cockroach-operator-bazel-artifacts/kubetest2-tester-exec_linux_amd64_v1/kubetest2-tester-exec"],
     )
 
 ## Fetch operator-sdk used on generating csv


### PR DESCRIPTION
Previously, buckets holding kubetest binaries were problematic so a new
one was created. Since these new binaries were built with go 1.19, PATH
entries must also be absolute:
https://cs.opensource.google/go/go/+/refs/tags/go1.19.2:src/os/exec/lp_unix.go;l=60

**Checklist**

* [x] I have added these changes to the changelog (or it's not applicable).
