### PR TITLE
Fix cert permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 # [Unreleased](https://github.com/cockroachdb/cockroach-operator/compare/v2.8.0...master)
 
+## Fixed
+
+* Install init container certs with 600 permissions
+
 # [v2.8.0](https://github.com/cockroachdb/cockroach-operator/compare/v2.7.0...v2.8.0)
 
 ## Added

--- a/pkg/resource/statefulset.go
+++ b/pkg/resource/statefulset.go
@@ -43,7 +43,7 @@ const (
 	dataDirMountPath = "/cockroach/cockroach-data/"
 
 	certsDirName = "certs"
-	certCpCmd    = ">- cp -p /cockroach/cockroach-certs-prestage/..data/* /cockroach/cockroach-certs/ && chmod 700 /cockroach/cockroach-certs/*.key && chown 1000581000:1000581000 /cockroach/cockroach-certs/*.key"
+	certCpCmd    = ">- cp -p /cockroach/cockroach-certs-prestage/..data/* /cockroach/cockroach-certs/ && chmod 600 /cockroach/cockroach-certs/*.key && chown 1000581000:1000581000 /cockroach/cockroach-certs/*.key"
 	emptyDirName = "emptydir"
 
 	// DbContainerName is the name of the container definition in the pod spec

--- a/pkg/resource/testdata/TestStatefulSetBuilder/automount_sa.golden
+++ b/pkg/resource/testdata/TestStatefulSetBuilder/automount_sa.golden
@@ -92,7 +92,7 @@ spec:
         - /bin/sh
         - -c
         - '>- cp -p /cockroach/cockroach-certs-prestage/..data/* /cockroach/cockroach-certs/
-          && chmod 700 /cockroach/cockroach-certs/*.key && chown 1000581000:1000581000
+          && chmod 600 /cockroach/cockroach-certs/*.key && chown 1000581000:1000581000
           /cockroach/cockroach-certs/*.key'
         image: cockroachdb/cockroach:v21.1.0
         imagePullPolicy: IfNotPresent

--- a/pkg/resource/testdata/TestStatefulSetBuilder/default_secure.golden
+++ b/pkg/resource/testdata/TestStatefulSetBuilder/default_secure.golden
@@ -92,7 +92,7 @@ spec:
         - /bin/sh
         - -c
         - '>- cp -p /cockroach/cockroach-certs-prestage/..data/* /cockroach/cockroach-certs/
-          && chmod 700 /cockroach/cockroach-certs/*.key && chown 1000581000:1000581000
+          && chmod 600 /cockroach/cockroach-certs/*.key && chown 1000581000:1000581000
           /cockroach/cockroach-certs/*.key'
         image: cockroachdb/cockroach:v21.1.0
         imagePullPolicy: IfNotPresent


### PR DESCRIPTION
Installing certs with permission 700 was causing issues when querying CRDB. This PR fixes it by changing it to 600.

_Add a description of the problem this PR addresses and an overview of how this PR works_.

**Checklist**

* [x] I have added these changes to the changelog (or it's not applicable).
