### PR TITLE
Bump golangci-lint to v1.50.1 and update code as necessary

### DIFF
--- a/cmd/cockroach-operator/prep_webhooks.go
+++ b/cmd/cockroach-operator/prep_webhooks.go
@@ -18,7 +18,6 @@ package main
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -84,12 +83,12 @@ func writeWebhookSecrets(cert security.Certificate, dir string) error {
 	// r/w for current user only
 	mode := os.FileMode(0600)
 
-	if err := ioutil.WriteFile(filepath.Join(dir, "tls.crt"), cert.Certificate(), mode); err != nil {
+	if err := os.WriteFile(filepath.Join(dir, "tls.crt"), cert.Certificate(), mode); err != nil {
 		return errors.Wrap(err, "failed to write TLS certificate")
 	}
 
 	return errors.Wrap(
-		ioutil.WriteFile(filepath.Join(dir, "tls.key"), cert.PrivateKey(), mode),
+		os.WriteFile(filepath.Join(dir, "tls.key"), cert.PrivateKey(), mode),
 		"failed to write TLS private key",
 	)
 }

--- a/config/manager/patches/image.yaml
+++ b/config/manager/patches/image.yaml
@@ -174,5 +174,11 @@ spec:
               value: cockroachdb/cockroach:v22.1.7
             - name: RELATED_IMAGE_COCKROACH_v22_1_8
               value: cockroachdb/cockroach:v22.1.8
-            - name: RELATED_IMAGE_COCKROACH_v22_1_9
-              value: cockroachdb/cockroach:v22.1.9
+            - name: RELATED_IMAGE_COCKROACH_v22_1_10
+              value: cockroachdb/cockroach:v22.1.10
+            - name: RELATED_IMAGE_COCKROACH_v22_1_11
+              value: cockroachdb/cockroach:v22.1.11
+            - name: RELATED_IMAGE_COCKROACH_v22_1_12
+              value: cockroachdb/cockroach:v22.1.12
+            - name: RELATED_IMAGE_COCKROACH_v22_2_0
+              value: cockroachdb/cockroach:v22.2.0

--- a/config/manifests/bases/cockroach-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/cockroach-operator.clusterserviceversion.yaml
@@ -330,5 +330,11 @@ spec:
     image: registry.connect.redhat.com/cockroachdb/cockroach@sha256:da367cf0ac52045002e1c186f8e6964267ad87d5c25f9e72fd2c9b9a98a32702
   - name: RELATED_IMAGE_COCKROACH_v22_1_8
     image: registry.connect.redhat.com/cockroachdb/cockroach@sha256:f6bb15b36d64eebb6e4c1db5a5466e108b271d53383c58e0b6c78cec214756a9
-  - name: RELATED_IMAGE_COCKROACH_v22_1_9
-    image: registry.connect.redhat.com/cockroachdb/cockroach@sha256:851144827007c2e6fc03bfb9b500294fe574b5007000bf2cea96a22881be8517
+  - name: RELATED_IMAGE_COCKROACH_v22_1_10
+    image: registry.connect.redhat.com/cockroachdb/cockroach@sha256:ec6eb7c28c213cc83b2d7919cd87988f9a07f12276eb7351d0915f1567a5b095
+  - name: RELATED_IMAGE_COCKROACH_v22_1_11
+    image: registry.connect.redhat.com/cockroachdb/cockroach@sha256:f5a0ccc02dc9e938e484d5b5282ff650d1890d5f754c30a0c0d717989ed5d600
+  - name: RELATED_IMAGE_COCKROACH_v22_1_12
+    image: registry.connect.redhat.com/cockroachdb/cockroach@sha256:310310515625f099a928545865f7096997871ee4a16650a01c76c3799a18b684
+  - name: RELATED_IMAGE_COCKROACH_v22_2_0
+    image: registry.connect.redhat.com/cockroachdb/cockroach@sha256:e50aab39722af22ccbf3d1db19e37972d52b0fc9a40998a64618dc966b2bac57

--- a/config/manifests/patches/deployment_patch.yaml
+++ b/config/manifests/patches/deployment_patch.yaml
@@ -183,6 +183,12 @@ spec:
               value: registry.connect.redhat.com/cockroachdb/cockroach@sha256:da367cf0ac52045002e1c186f8e6964267ad87d5c25f9e72fd2c9b9a98a32702
             - name: RELATED_IMAGE_COCKROACH_v22_1_8
               value: registry.connect.redhat.com/cockroachdb/cockroach@sha256:f6bb15b36d64eebb6e4c1db5a5466e108b271d53383c58e0b6c78cec214756a9
-            - name: RELATED_IMAGE_COCKROACH_v22_1_9
-              value: registry.connect.redhat.com/cockroachdb/cockroach@sha256:851144827007c2e6fc03bfb9b500294fe574b5007000bf2cea96a22881be8517
+            - name: RELATED_IMAGE_COCKROACH_v22_1_10
+              value: registry.connect.redhat.com/cockroachdb/cockroach@sha256:ec6eb7c28c213cc83b2d7919cd87988f9a07f12276eb7351d0915f1567a5b095
+            - name: RELATED_IMAGE_COCKROACH_v22_1_11
+              value: registry.connect.redhat.com/cockroachdb/cockroach@sha256:f5a0ccc02dc9e938e484d5b5282ff650d1890d5f754c30a0c0d717989ed5d600
+            - name: RELATED_IMAGE_COCKROACH_v22_1_12
+              value: registry.connect.redhat.com/cockroachdb/cockroach@sha256:310310515625f099a928545865f7096997871ee4a16650a01c76c3799a18b684
+            - name: RELATED_IMAGE_COCKROACH_v22_2_0
+              value: registry.connect.redhat.com/cockroachdb/cockroach@sha256:e50aab39722af22ccbf3d1db19e37972d52b0fc9a40998a64618dc966b2bac57
           image: RH_COCKROACH_OP_IMAGE_PLACEHOLDER

--- a/config/samples/crdb-tls-example.yaml
+++ b/config/samples/crdb-tls-example.yaml
@@ -19,7 +19,7 @@ kind: CrdbCluster
 metadata:
   name: crdb-tls-example
 spec:
-  cockroachDBVersion: v22.1.9
+  cockroachDBVersion: v22.2.0
   dataStore:
     pvc:
       spec:

--- a/crdb-versions.yaml
+++ b/crdb-versions.yaml
@@ -244,6 +244,15 @@ CrdbVersions:
 - image: cockroachdb/cockroach:v22.1.8
   redhatImage: registry.connect.redhat.com/cockroachdb/cockroach@sha256:f6bb15b36d64eebb6e4c1db5a5466e108b271d53383c58e0b6c78cec214756a9
   tag: v22.1.8
-- image: cockroachdb/cockroach:v22.1.9
-  redhatImage: registry.connect.redhat.com/cockroachdb/cockroach@sha256:851144827007c2e6fc03bfb9b500294fe574b5007000bf2cea96a22881be8517
-  tag: v22.1.9
+- image: cockroachdb/cockroach:v22.1.10
+  redhatImage: registry.connect.redhat.com/cockroachdb/cockroach@sha256:ec6eb7c28c213cc83b2d7919cd87988f9a07f12276eb7351d0915f1567a5b095
+  tag: v22.1.10
+- image: cockroachdb/cockroach:v22.1.11
+  redhatImage: registry.connect.redhat.com/cockroachdb/cockroach@sha256:f5a0ccc02dc9e938e484d5b5282ff650d1890d5f754c30a0c0d717989ed5d600
+  tag: v22.1.11
+- image: cockroachdb/cockroach:v22.1.12
+  redhatImage: registry.connect.redhat.com/cockroachdb/cockroach@sha256:310310515625f099a928545865f7096997871ee4a16650a01c76c3799a18b684
+  tag: v22.1.12
+- image: cockroachdb/cockroach:v22.2.0
+  redhatImage: registry.connect.redhat.com/cockroachdb/cockroach@sha256:e50aab39722af22ccbf3d1db19e37972d52b0fc9a40998a64618dc966b2bac57
+  tag: v22.2.0

--- a/e2e/kubetest2-openshift/deployer/up.go
+++ b/e2e/kubetest2-openshift/deployer/up.go
@@ -19,7 +19,6 @@ package deployer
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -82,7 +81,7 @@ func (d *deployer) Up() error {
 		}
 	}
 
-	pullSecretContent, err := ioutil.ReadFile(d.PullSecret)
+	pullSecretContent, err := os.ReadFile(d.PullSecret)
 	if err != nil {
 		klog.Fatalf("unable to read pull secret file '%s': %v", d.PullSecret, err)
 		return err
@@ -110,7 +109,7 @@ func (d *deployer) Up() error {
 
 	installConfigFile := filepath.Join(baseDir, "install-config.yaml")
 
-	if err := ioutil.WriteFile(installConfigFile, b, 0644); err != nil {
+	if err := os.WriteFile(installConfigFile, b, 0644); err != nil {
 		klog.Fatalf("unable to write openshift install file %v", err)
 		return err
 	}

--- a/e2e/openshift/openshift_packaging_test.go
+++ b/e2e/openshift/openshift_packaging_test.go
@@ -27,7 +27,6 @@ import (
 	"text/template"
 	"time"
 
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -248,7 +247,7 @@ func writeFile(t *testing.T, b []byte) string {
 	fileName := fmt.Sprintf("%s-test.yaml", randSeq(10))
 	fileName = filepath.Join(t.TempDir(), fileName)
 
-	if err := ioutil.WriteFile(fileName, b, 0644); err != nil {
+	if err := os.WriteFile(fileName, b, 0644); err != nil {
 		t.Fatal("Failed to write to temporary file", err)
 	}
 

--- a/examples/client-secure-operator.yaml
+++ b/examples/client-secure-operator.yaml
@@ -23,7 +23,7 @@ spec:
   serviceAccountName: cockroachdb-sa
   containers:
   - name: cockroachdb-client-secure
-    image: cockroachdb/cockroach:v22.1.9
+    image: cockroachdb/cockroach:v22.2.0
     imagePullPolicy: IfNotPresent
     volumeMounts:
     - name: client-certs

--- a/examples/example.yaml
+++ b/examples/example.yaml
@@ -40,9 +40,9 @@ spec:
       memory: 8Gi
   tlsEnabled: true
 # You can set either a version of the db or a specific image name
-# cockroachDBVersion: v22.1.9
+# cockroachDBVersion: v22.2.0
   image:
-    name: cockroachdb/cockroach:v22.1.9
+    name: cockroachdb/cockroach:v22.2.0
   # nodes refers to the number of crdb pods that are created
   # via the statefulset
   nodes: 3

--- a/examples/smoketest.yaml
+++ b/examples/smoketest.yaml
@@ -39,5 +39,5 @@ spec:
       memory: 300Mi
   tlsEnabled: true
   image:
-    name: cockroachdb/cockroach:v22.1.9
+    name: cockroachdb/cockroach:v22.2.0
   nodes: 3

--- a/hack/bin/deps.bzl
+++ b/hack/bin/deps.bzl
@@ -199,14 +199,14 @@ def install_k3d():
 def install_golangci_lint():
     http_archive(
         name = "golangci_lint_darwin",
-        sha256 = "d4bd25b9814eeaa2134197dd2c7671bb791eae786d42010d9d788af20dee4bfa",
-        urls = ["https://github.com/golangci/golangci-lint/releases/download/v1.42.0/golangci-lint-1.42.0-darwin-amd64.tar.gz"],
+        sha256 = "0f615fb8c364f6e4a213f2ed2ff7aa1fc2b208addf29511e89c03534067bbf57",
+        urls = ["https://github.com/golangci/golangci-lint/releases/download/v1.50.1/golangci-lint-1.50.1-darwin-amd64.tar.gz"],
         build_file_content =
          """
 filegroup(
      name = "file",
      srcs = [
-        "golangci-lint-1.42.0-darwin-amd64/golangci-lint",
+        "golangci-lint-1.50.1-darwin-amd64/golangci-lint",
      ],
      visibility = ["//visibility:public"],
 )
@@ -215,14 +215,14 @@ filegroup(
 
     http_archive(
             name = "golangci_lint_m1",
-            sha256 = "f649893bf2b1d24b2632b5e109884a15f3bf25cfdad46b34fb8fd13a016098fd",
-            urls = ["https://github.com/golangci/golangci-lint/releases/download/v1.42.1/golangci-lint-1.42.1-darwin-arm64.tar.gz"],
+            sha256 = "0f615fb8c364f6e4a213f2ed2ff7aa1fc2b208addf29511e89c03534067bbf57",
+            urls = ["https://github.com/golangci/golangci-lint/releases/download/v1.50.1/golangci-lint-1.50.1-darwin-arm64.tar.gz"],
             build_file_content =
              """
 filegroup(
     name = "file",
     srcs = [
-       "golangci-lint-1.42.1-darwin-arm64/golangci-lint",
+       "golangci-lint-1.50.1-darwin-arm64/golangci-lint",
     ],
     visibility = ["//visibility:public"],
 )
@@ -231,14 +231,14 @@ filegroup(
 
     http_archive(
         name = "golangci_lint_linux",
-        sha256 = "6937f62f8e2329e94822dc11c10b871ace5557ae1fcc4ee2f9980cd6aecbc159",
-        urls = ["https://github.com/golangci/golangci-lint/releases/download/v1.42.0/golangci-lint-1.42.0-linux-amd64.tar.gz"],
+        sha256 = "4ba1dc9dbdf05b7bdc6f0e04bdfe6f63aa70576f51817be1b2540bbce017b69a",
+        urls = ["https://github.com/golangci/golangci-lint/releases/download/v1.50.1/golangci-lint-1.50.1-linux-amd64.tar.gz"],
         build_file_content =
          """
 filegroup(
      name = "file",
      srcs = [
-        "golangci-lint-1.42.0-linux-amd64/golangci-lint",
+        "golangci-lint-1.50.1-linux-amd64/golangci-lint",
      ],
      visibility = ["//visibility:public"],
 )

--- a/hack/crdbversions/main.go
+++ b/hack/crdbversions/main.go
@@ -24,7 +24,6 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -98,7 +97,7 @@ func main() {
 		outputFile := filepath.Join(*repoRoot, f.output)
 		log.Printf("generating `%s` from `%s`", outputFile, tplFile)
 		name := filepath.Base(outputFile)
-		tplContents, err := ioutil.ReadFile(tplFile)
+		tplContents, err := os.ReadFile(tplFile)
 		if err != nil {
 			log.Fatalf("Cannot read template file `%s`: %s", tplFile, err)
 		}
@@ -170,7 +169,7 @@ func generateFile(name string, tplText string, output io.Writer, data templateDa
 // verifyYamlLoads tries to open a YAML file and parses its content in order to
 // verify that the generated file doesn't have any syntax errors
 func verifyYamlLoads(fName string) error {
-	contents, err := ioutil.ReadFile(fName)
+	contents, err := os.ReadFile(fName)
 	if err != nil {
 		return fmt.Errorf("cannot read file `%s`: %w", fName, err)
 	}

--- a/hack/release/main.go
+++ b/hack/release/main.go
@@ -18,7 +18,6 @@ package main
 import (
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 
@@ -40,7 +39,7 @@ func main() {
 		EnsureUniqueVersion(func(cmd *exec.Cmd) error { return cmd.Run() }),
 		CreateReleaseBranch(process.ExecJUnit),
 		UpdateVersion(),
-		UpdateChangelog(ioutil.ReadFile),
+		UpdateChangelog(os.ReadFile),
 		GenerateFiles(process.ExecJUnit),
 	}
 

--- a/hack/release/steps.go
+++ b/hack/release/steps.go
@@ -18,7 +18,6 @@ package main
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"regexp"
@@ -94,7 +93,7 @@ func EnsureUniqueVersion(fn CmdFn) Step {
 func UpdateVersion() Step {
 	return StepFn(func(version string) error {
 		// setting the mode to 0644 to match the existing permissions: r/w for current user, read-only for everyone else.
-		return ioutil.WriteFile("version.txt", []byte(version), 0644)
+		return os.WriteFile("version.txt", []byte(version), 0644)
 	})
 }
 
@@ -149,6 +148,6 @@ func UpdateChangelog(fn FileFn) Step {
 		newUnreleased = append(newUnreleased, append([]byte("\n\n"), latestRelease...)...)
 		data = bytes.Replace(data, prevUnreleased, newUnreleased, 1)
 
-		return ioutil.WriteFile(fileName, data, 0644)
+		return os.WriteFile(fileName, data, 0644)
 	})
 }

--- a/hack/release/steps_test.go
+++ b/hack/release/steps_test.go
@@ -18,7 +18,6 @@ package main_test
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"testing"
@@ -96,7 +95,7 @@ func TestEnsureUniqueVersion(t *testing.T) {
 func TestUpdateVersion(t *testing.T) {
 	require.NoError(t, UpdateVersion().Apply("1.2.3"))
 
-	v, err := ioutil.ReadFile("version.txt")
+	v, err := os.ReadFile("version.txt")
 	require.NoError(t, err)
 	require.Equal(t, "1.2.3", string(v))
 
@@ -162,7 +161,7 @@ func TestUpdateChangelog(t *testing.T) {
 	err := UpdateChangelog(func(_ string) ([]byte, error) { return []byte(input), nil }).Apply("1.1.0")
 	require.NoError(t, err)
 
-	data, err := ioutil.ReadFile("CHANGELOG.md")
+	data, err := os.ReadFile("CHANGELOG.md")
 	require.NoError(t, err)
 	require.Equal(t, string(data), expected)
 }

--- a/hack/update_crdb_versions/main.go
+++ b/hack/update_crdb_versions/main.go
@@ -20,7 +20,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -68,7 +67,7 @@ var (
 
 func main() {
 	path := filepath.Join(os.Getenv("BUILD_WORKSPACE_DIRECTORY"), versionsFile)
-	if err := ioutil.WriteFile(path, []byte(fileHeader), 0644); err != nil {
+	if err := os.WriteFile(path, []byte(fileHeader), 0644); err != nil {
 		panic(err)
 	}
 

--- a/install/operator.yaml
+++ b/install/operator.yaml
@@ -532,8 +532,14 @@ spec:
           value: cockroachdb/cockroach:v22.1.7
         - name: RELATED_IMAGE_COCKROACH_v22_1_8
           value: cockroachdb/cockroach:v22.1.8
-        - name: RELATED_IMAGE_COCKROACH_v22_1_9
-          value: cockroachdb/cockroach:v22.1.9
+        - name: RELATED_IMAGE_COCKROACH_v22_1_10
+          value: cockroachdb/cockroach:v22.1.10
+        - name: RELATED_IMAGE_COCKROACH_v22_1_11
+          value: cockroachdb/cockroach:v22.1.11
+        - name: RELATED_IMAGE_COCKROACH_v22_1_12
+          value: cockroachdb/cockroach:v22.1.12
+        - name: RELATED_IMAGE_COCKROACH_v22_2_0
+          value: cockroachdb/cockroach:v22.2.0
         - name: OPERATOR_NAME
           value: cockroachdb
         - name: POD_NAME

--- a/pkg/actor/generate_cert.go
+++ b/pkg/actor/generate_cert.go
@@ -21,7 +21,7 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"time"
 
@@ -191,7 +191,7 @@ func (rc *generateCert) generateCA(ctx context.Context, log logr.Logger, cluster
 	// if the secret is ready then don't update the secret
 	// the Actor should have already generated the secret
 	if secret.ReadyCA() {
-		if err := ioutil.WriteFile(rc.CAKey, secret.CAKey(), 0600); err != nil {
+		if err := os.WriteFile(rc.CAKey, secret.CAKey(), 0600); err != nil {
 			return errors.Wrap(err, "failed to write CA key")
 		}
 		log.V(DEBUGLEVEL).Info("not updating ca key as it exists")
@@ -210,7 +210,7 @@ func (rc *generateCert) generateCA(ctx context.Context, log logr.Logger, cluster
 		return err
 	}
 	// Read the ca key into memory
-	cakey, err := ioutil.ReadFile(rc.CAKey)
+	cakey, err := os.ReadFile(rc.CAKey)
 	if err != nil {
 		return errors.Wrap(err, "unable to read ca.key")
 	}
@@ -259,7 +259,7 @@ func (rc *generateCert) generateNodeCert(ctx context.Context, log logr.Logger, c
 	if secret.Ready() {
 		if regenerateCert {
 			log.V(DEBUGLEVEL).Info("regenerating node certificate because of change in SQLHost")
-			if err = ioutil.WriteFile(filepath.Join(rc.CertsDir, "ca.crt"), secret.CA(), 0644); err != nil {
+			if err = os.WriteFile(filepath.Join(rc.CertsDir, "ca.crt"), secret.CA(), 0644); err != nil {
 				return "", errors.Wrap(err, "failed to write CA cert")
 			}
 		} else {
@@ -300,17 +300,17 @@ func (rc *generateCert) generateNodeCert(ctx context.Context, log logr.Logger, c
 	}
 
 	// Read the node certificates into memory
-	ca, err := ioutil.ReadFile(filepath.Join(rc.CertsDir, "ca.crt"))
+	ca, err := os.ReadFile(filepath.Join(rc.CertsDir, "ca.crt"))
 	if err != nil {
 		return "", errors.Wrap(err, "unable to read ca.crt")
 	}
 
-	pemCert, err := ioutil.ReadFile(filepath.Join(rc.CertsDir, "node.crt"))
+	pemCert, err := os.ReadFile(filepath.Join(rc.CertsDir, "node.crt"))
 	if err != nil {
 		return "", errors.Wrap(err, "unable to read node.crt")
 	}
 
-	pemKey, err := ioutil.ReadFile(filepath.Join(rc.CertsDir, "node.key"))
+	pemKey, err := os.ReadFile(filepath.Join(rc.CertsDir, "node.key"))
 	if err != nil {
 		return "", errors.Wrap(err, "unable to ready node.key")
 	}
@@ -368,17 +368,17 @@ func (rc *generateCert) generateClientCert(ctx context.Context, log logr.Logger,
 	}
 
 	// Load the certificates into memory
-	ca, err := ioutil.ReadFile(filepath.Join(rc.CertsDir, "ca.crt"))
+	ca, err := os.ReadFile(filepath.Join(rc.CertsDir, "ca.crt"))
 	if err != nil {
 		return errors.Wrap(err, "unable to read ca.crt")
 	}
 
-	pemCert, err := ioutil.ReadFile(filepath.Join(rc.CertsDir, "client.root.crt"))
+	pemCert, err := os.ReadFile(filepath.Join(rc.CertsDir, "client.root.crt"))
 	if err != nil {
 		return errors.Wrap(err, "unable to read client.root.crt")
 	}
 
-	pemKey, err := ioutil.ReadFile(filepath.Join(rc.CertsDir, "client.root.key"))
+	pemKey, err := os.ReadFile(filepath.Join(rc.CertsDir, "client.root.key"))
 	if err != nil {
 		return errors.Wrap(err, "unable to read client.root.key")
 	}

--- a/pkg/actor/partitioned_update_test.go
+++ b/pkg/actor/partitioned_update_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package actor
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -31,7 +30,7 @@ func TestDeployedInCluster(t *testing.T) {
 		t.Fatal("we should not be running inside of k8s")
 	}
 
-	file, err := ioutil.TempFile("/tmp", "foo")
+	file, err := os.CreateTemp("/tmp", "foo")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/kube/dialer.go
+++ b/pkg/kube/dialer.go
@@ -20,7 +20,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"strings"
@@ -160,7 +160,7 @@ func (k *PodDialer) Dial(network, addr string) (net.Conn, error) {
 
 	errorChan := make(chan error)
 	go func() {
-		message, err := ioutil.ReadAll(errStream)
+		message, err := io.ReadAll(errStream)
 		if err != nil {
 			errorChan <- err
 		}

--- a/pkg/kuberecord/recorder.go
+++ b/pkg/kuberecord/recorder.go
@@ -22,7 +22,7 @@ import (
 	"bytes"
 	"crypto/sha1"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"path/filepath"
 	"sync"
@@ -184,13 +184,13 @@ func (f *kubeRecorder) RoundTrip(r *http.Request) (*http.Response, error) {
 
 	var err error
 	if r.Body != nil {
-		body, err = ioutil.ReadAll(r.Body)
+		body, err = io.ReadAll(r.Body)
 		if err != nil {
 			return nil, err
 		}
 
 		// Reset the body to something usable
-		r.Body = ioutil.NopCloser(bytes.NewBuffer(body))
+		r.Body = io.NopCloser(bytes.NewBuffer(body))
 
 		if _, err := hasher.Write(body); err != nil {
 			// "It never returns an error."

--- a/pkg/resource/statefulset_test.go
+++ b/pkg/resource/statefulset_test.go
@@ -20,7 +20,7 @@ import (
 	"bytes"
 	"flag"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	api "github.com/cockroachdb/cockroach-operator/apis/v1alpha1"
@@ -111,7 +111,7 @@ func TestRHImage(t *testing.T) {
 }
 
 func load(t *testing.T, file string) []byte {
-	content, err := ioutil.ReadFile(file)
+	content, err := os.ReadFile(file)
 	if err != nil {
 		t.Fatalf("failed to load yaml file %s: %v", file, err)
 	}

--- a/pkg/security/certs_test.go
+++ b/pkg/security/certs_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package security_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -38,7 +37,7 @@ func TestMain(m *testing.M) {
 
 // tempDir is like testutils.TempDir but avoids a circular import.
 func tempDir(t *testing.T) (string, func()) {
-	certsDir, err := ioutil.TempDir("", "certs_test")
+	certsDir, err := os.MkdirTemp("", "certs_test")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/testutil/assert.go
+++ b/pkg/testutil/assert.go
@@ -31,11 +31,10 @@ import (
 // and fails if the two interfaces do not match.
 // This func removes all metadata calico annotations.
 func AssertDiff(t *testing.T, expected interface{}, actual interface{}) {
-
-	if actual, ok := actual.(string); ok {
+	if casted, ok := actual.(string); ok {
 		decode, encode := Yamlizers(t, InitScheme(t))
 		var newSlice []string
-		actualSlice := strings.Split(actual, "---")
+		actualSlice := strings.Split(casted, "---")
 
 		for _, str := range actualSlice {
 			// we are getting zero length string because the string starts with ---

--- a/pkg/testutil/helpers.go
+++ b/pkg/testutil/helpers.go
@@ -18,7 +18,7 @@ package testutil
 
 import (
 	"io"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -47,12 +47,12 @@ func ReadOrUpdateGoldenFile(t *testing.T, content string, update bool) string {
 
 	gf := filepath.Join("testdata", filepath.FromSlash(t.Name())+".golden")
 	if update {
-		if err := ioutil.WriteFile(gf, []byte(content), 0644); err != nil {
+		if err := os.WriteFile(gf, []byte(content), 0644); err != nil {
 			t.Fatalf("failed to update golden file %s: %v", gf, err)
 		}
 	}
 
-	g, err := ioutil.ReadFile(gf)
+	g, err := os.ReadFile(gf)
 	if err != nil {
 		t.Fatalf("failed to read goldenfile %s: %v", gf, err)
 	}

--- a/pkg/testutil/validate_headers.go
+++ b/pkg/testutil/validate_headers.go
@@ -20,7 +20,6 @@ import (
 	"bufio"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -165,7 +164,7 @@ func (v ValidateHeaders) readGlob(glob string, regex *regexp.Regexp) (filesPtr *
 }
 
 func (v ValidateHeaders) hasValidHeader(filename string) (bool, error) {
-	content, err := ioutil.ReadFile(filename)
+	content, err := os.ReadFile(filename)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/testutil/validate_headers_test.go
+++ b/pkg/testutil/validate_headers_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package testutil_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -84,12 +83,11 @@ package testutil
 func writeFile(data string, dir string, fileName string) error {
 	content := []byte(data)
 	tmpfn := filepath.Join(dir, fileName)
-	return ioutil.WriteFile(tmpfn, content, 0666)
+	return os.WriteFile(tmpfn, content, 0666)
 }
 
 func TestValidate(t *testing.T) {
-
-	dir, err := ioutil.TempDir("", "validate-headers-test")
+	dir, err := os.MkdirTemp("", "validate-headers-test")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/util/tmp_dir.go
+++ b/pkg/util/tmp_dir.go
@@ -17,7 +17,6 @@ limitations under the License.
 package util
 
 import (
-	"io/ioutil"
 	"os"
 )
 
@@ -25,7 +24,7 @@ import (
 // the directory name and also a function for removing the directory.
 // The funcation is often deferred for directory removal.
 func CreateTempDir(baseDirectory string) (string, func()) {
-	tmpDir, err := ioutil.TempDir("", baseDirectory)
+	tmpDir, err := os.MkdirTemp("", baseDirectory)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
Making tests on master pass. Also regenerated the templates since that was missed when adding new CRDB versions.

**Checklist**

* [x] I have added these changes to the changelog (or it's not applicable).
