### PR TITLE
fix: #957 add . a readiness and heath probe

### DIFF
--- a/install/operator.yaml
+++ b/install/operator.yaml
@@ -569,6 +569,20 @@ spec:
         image: cockroachdb/cockroach-operator:v2.10.0
         imagePullPolicy: IfNotPresent
         name: cockroach-operator
+        readinessProbe:
+          httpGet:
+            path: /ready
+            port: 9443
+            scheme: HTTPS
+          periodSeconds: 5
+          initialDelaySeconds: 5
+        livenessProbe:
+          httpGet:
+            path: /live
+            port: 9443
+            scheme: HTTPS
+          initialDelaySeconds: 10
+          periodSeconds: 5
         resources:
           requests:
             cpu: 10m


### PR DESCRIPTION
Thinking something like this might fix #957

But I'm not a bazel user.. build fails with:

```
compilepkg: missing strict dependencies:
	/home/chirino/.cache/bazel/_bazel_chirino/da5a820a69fa786d5aef66a3a74e00bd/sandbox/linux-sandbox/77/execroot/com_github_coachroachdb_cockroach_operator/cmd/cockroach-operator/main.go: import of "sigs.k8s.io/controller-runtime/pkg/healthz"
No dependencies were provided.
```