### PR TITLE
Update Openshift Release Process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,5 +63,5 @@ bundle/
 faq
 
 _artifacts
-bundle.Dockerfile
+artifacts
 tmp

--- a/Makefile
+++ b/Makefile
@@ -210,6 +210,12 @@ test/e2e/testrunner-openshift-packaging: test/openshift-package
 		--action_env=APP_VERSION=$(APP_VERSION) \
 		--action_env=DOCKER_REGISTRY=$(DOCKER_REGISTRY)
 
+# Run preflight checks for OpenShift. This expects a running OpenShift cluster.
+# Eg. make test/preflight-<operator|bundle|marketplace>
+test/preflight-%: CONTAINER=$*
+test/preflight-%: release/generate-bundle
+	@bazel run //hack:redhat-preflight -- $(CONTAINER)
+
 #
 # Different dev targets
 #
@@ -267,6 +273,7 @@ dev/up: dev/down
 
 .PHONY: dev/down
 dev/down:
+	@bazel build //hack/bin:k3d
 	@hack/dev.sh down
 #
 # Targets that allow to install the operator on an existing cluster

--- a/Makefile
+++ b/Makefile
@@ -339,7 +339,7 @@ release/image:
 # RedHat OpenShift targets
 #
 
-#RED HAT IMAGE BUNDLE
+#REDHAT IMAGE BUNDLE
 RH_BUNDLE_REGISTRY?=registry.connect.redhat.com/cockroachdb
 RH_BUNDLE_IMAGE_REPOSITORY?=cockroachdb-operator-bundle
 RH_BUNDLE_VERSION?=$(VERSION)
@@ -363,3 +363,16 @@ PKG_MAN_OPTS ?= "$(PKG_CHANNELS) $(PKG_DEFAULT_CHANNEL)"
 .PHONY: release/generate-bundle
 release/generate-bundle:
 	bazel run //hack:bundle -- $(RH_BUNDLE_VERSION) $(RH_OPERATOR_IMAGE) $(PKG_MAN_OPTS) $(RH_COCKROACH_DATABASE_IMAGE)
+
+.PHONY: release/publish-operator
+publish-operator:
+	./build/release/teamcity-publish-release.sh
+
+.PHONY: release/publish-operator-openshift
+publish-operator-openshift:
+	./build/release/teamcity-publish-openshift.sh
+
+.PHONY: release/publish-openshift-bundle
+release/publish-openshift-bundle:
+	./build/release/teamcity-publish-openshift-bundle.sh
+

--- a/config/default/BUILD.bazel
+++ b/config/default/BUILD.bazel
@@ -34,6 +34,7 @@ k8s_deploy(
         # when running locally, use the image from the local codebase
         "cockroachdb/cockroach-operator:$(APP_VERSION)": "//cmd/cockroach-operator:operator_image",
     },
+		resolver_args = ["--allow_unused_images"],
     template = ":manifest",
 )
 

--- a/config/default/BUILD.bazel
+++ b/config/default/BUILD.bazel
@@ -34,7 +34,7 @@ k8s_deploy(
         # when running locally, use the image from the local codebase
         "cockroachdb/cockroach-operator:$(APP_VERSION)": "//cmd/cockroach-operator:operator_image",
     },
-		resolver_args = ["--allow_unused_images"],
+    resolver_args = ["--allow_unused_images"],
     template = ":manifest",
 )
 

--- a/config/manifests/bases/cockroach-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/cockroach-operator.clusterserviceversion.yaml
@@ -178,6 +178,7 @@ spec:
   - email: support@cockroachlabs.com
     name: Cockroach Labs Support
   maturity: stable
+  minKubeVersion: 1.18.0
   provider:
     name: Cockroach Labs
   version: 0.0.0

--- a/config/manifests/kustomization.yaml
+++ b/config/manifests/kustomization.yaml
@@ -17,6 +17,8 @@ namespace: placeholder
 resources:
   - ../default
   - ../samples
+  - ../scorecard
+
 
 patchesStrategicMerge:
   - patches/deployment_patch.yaml

--- a/config/templates/csv.yaml.in
+++ b/config/templates/csv.yaml.in
@@ -178,6 +178,7 @@ spec:
   - email: support@cockroachlabs.com
     name: Cockroach Labs Support
   maturity: stable
+  minKubeVersion: 1.18.0
   provider:
     name: Cockroach Labs
   version: 0.0.0

--- a/hack/BUILD.bazel
+++ b/hack/BUILD.bazel
@@ -129,6 +129,17 @@ sh_binary(
     ],
 )
 
+sh_binary(
+    name = "redhat-preflight",
+    srcs = ["redhat.sh"],
+    data = [
+			JQ,
+      OPM,
+      "//hack/bin:preflight",
+      "@//:all-srcs",
+    ],
+)
+
 filegroup(
     name = "package-srcs",
     srcs = glob(["**"]),

--- a/hack/BUILD.bazel
+++ b/hack/BUILD.bazel
@@ -133,10 +133,10 @@ sh_binary(
     name = "redhat-preflight",
     srcs = ["redhat.sh"],
     data = [
-			JQ,
-      OPM,
-      "//hack/bin:preflight",
-      "@//:all-srcs",
+        JQ,
+        OPM,
+        "//hack/bin:preflight",
+        "@//:all-srcs",
     ],
 )
 

--- a/hack/bin/BUILD.bazel
+++ b/hack/bin/BUILD.bazel
@@ -39,6 +39,16 @@ genrule(
 )
 
 genrule(
+    name = "fetch_preflight",
+    srcs = select({
+        ":k8": ["@preflight_linux//file"],
+    }),
+    outs = ["preflight"],
+    cmd = "cp $(SRCS) $@",
+    visibility = ["//visibility:public"],
+)
+
+genrule(
     name = "fetch_faq",
     srcs = select({
         ":m1": ["@faq_osx//file"],

--- a/hack/bin/BUILD.bazel
+++ b/hack/bin/BUILD.bazel
@@ -214,9 +214,9 @@ genrule(
 genrule(
     name = "fetch_opm",
     srcs = select({
-        ":m1": ["@opm_darwin//file"],
-        ":darwin": ["@opm_darwin//file"],
-        ":k8": ["@opm_linux//file"],
+        ":m1": ["@opm_darwin//:file"],
+        ":darwin": ["@opm_darwin//:file"],
+        ":k8": ["@opm_linux//:file"],
     }),
     outs = ["opm"],
     cmd = "cp $(SRCS) $@",

--- a/hack/bin/deps.bzl
+++ b/hack/bin/deps.bzl
@@ -22,6 +22,13 @@ OPENSHIFT_REPO = "https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/o
 
 # filenames and versions from ${OPENSHIFT_REPO}/sha256sum.txt
 OPENSHIFT_BINS = {
+    "preflight": {
+        # currently, preflight is only available on linux
+        "preflight_linux": {
+            "url": "https://github.com/redhat-openshift-ecosystem/openshift-preflight/releases/download/1.2.1/preflight-linux-amd64",
+            "sha": "e5754a81d4baae4f4956fc0842179a3daeac4778e202450f886a9afb05d218ba",
+        },
+    },
     "oc": {
         "oc_darwin": {
             "url": "{}/openshift-client-mac-{}.tar.gz".format(OPENSHIFT_REPO, OPENSHIFT_VERSION),
@@ -71,6 +78,7 @@ def install():
     install_operator_sdk()
     install_opm()
     install_openshift()
+    install_preflight()
 
     # Install golang.org/x/build as kubernetes/repo-infra requires it for the
     # build-tar bazel target.
@@ -417,6 +425,17 @@ filegroup(
 )
 """
       )
+
+def install_preflight():
+    versions = OPENSHIFT_BINS["preflight"]
+
+    for k, v in versions.items():
+        http_file(
+            name = k,
+            executable = 1,
+            sha256 = v["sha"],
+            urls = [v["url"]]
+        )
 
 ## Fetch crdb used in our container
 def install_crdb():

--- a/hack/bin/deps.bzl
+++ b/hack/bin/deps.bzl
@@ -17,7 +17,7 @@ load("@io_bazel_rules_docker//container:container.bzl", "container_pull")
 load("@bazel_gazelle//:deps.bzl", "go_repository")
 
 # This controls the version for all openshift binaries (opm, oc, opernshift-install, etc.)
-OPENSHIFT_VERSION = "4.9.17"
+OPENSHIFT_VERSION = "4.10.18"
 OPENSHIFT_REPO = "https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/{}".format(OPENSHIFT_VERSION)
 
 # filenames and versions from ${OPENSHIFT_REPO}/sha256sum.txt
@@ -32,31 +32,31 @@ OPENSHIFT_BINS = {
     "oc": {
         "oc_darwin": {
             "url": "{}/openshift-client-mac-{}.tar.gz".format(OPENSHIFT_REPO, OPENSHIFT_VERSION),
-            "sha": "2b06b400ab929275b55d3dbb8d7c54b9f1dd17df0b50247b8fc24b9efc8b1566",
+            "sha": "285c307491d8ffd19c065a942515fda78e53f95289d4b4985aa4c92439f7f339",
         },
         "oc_linux": {
             "url": "{}/openshift-client-linux-{}.tar.gz".format(OPENSHIFT_REPO, OPENSHIFT_VERSION),
-            "sha": "390268a64029f2aea7492f493034b75d4979f676f98762dbbf33eb0da5b294db",
+            "sha": "101bc7e11604b829157b3b314de3760eec857e55f51eeca978825307ff61c190",
         },
     },
     "openshift-install": {
         "openshift_darwin": {
             "url": "{}/openshift-install-mac-{}.tar.gz".format(OPENSHIFT_REPO, OPENSHIFT_VERSION),
-            "sha": "0c51934bfff15f8a8bf666bb9b15c894994afd87d838ffc5579e998f56110738",
+            "sha": "3a36acb92a6759d964a1af62512c747e075a2937a6368203d0598d804db10da2",
          },
         "openshift_linux": {
             "url": "{}/openshift-install-linux-{}.tar.gz".format(OPENSHIFT_REPO, OPENSHIFT_VERSION),
-            "sha": "4213bf060c25a6f38f86f2245f1f28060185e8baa7431f272e726d50f0044604",
+            "sha": "27e6ccb60ce2c7dfe611e1639642277572af78a21c622a7443d5a19006b2e45b",
         },
     },
     "opm": {
         "opm_darwin": {
             "url": "{}/opm-mac-{}.tar.gz".format(OPENSHIFT_REPO, OPENSHIFT_VERSION),
-            "sha": "f6fb6205f242ffef62ac0f4db738b1c099d3302ebb98b23d94926ef2903ed5d8",
+            "sha": "36d7104b1fd29e77a880b63e3e1aa67639a48cca1fdf537411b40a0c36140dba",
          },
         "opm_linux": {
             "url": "{}/opm-linux-{}.tar.gz".format(OPENSHIFT_REPO, OPENSHIFT_VERSION),
-            "sha": "f88d3dcc18950d8cd8512e460de5addcf11e8eb8f31ae675f0dd879908843747",
+            "sha": "6d422682fd688cbebc7818247005e2baf87675efef4931d2f0a2e744dc613b88",
         },
     },
 }
@@ -401,12 +401,18 @@ def install_opm():
     versions = OPENSHIFT_BINS["opm"]
 
     for k, v in versions.items():
-      http_file(
-         name = k,
-         executable = 1,
-         sha256 = v["sha"],
-         urls = [v["url"]],
-      )
+      http_archive(
+          name = k,
+          sha256 = v["sha"],
+          urls = [v["url"]],
+          build_file_content = """
+filegroup(
+    name = "file",
+    srcs = ["opm"],
+    visibility = ["//visibility:public"],
+)
+"""
+			)
 
 ## Fetch openshift-installer
 def install_openshift():

--- a/hack/bundle.sh
+++ b/hack/bundle.sh
@@ -70,17 +70,17 @@ generate_bundle() {
 
   # Generate the new package bundle
   kustomize build config/manifests | operator-sdk generate bundle -q \
-    --version "${version}" \
-    ${opts} \
-    --output-dir "${dir}"
+  --version "${version}" \
+  ${opts} \
+  --output-dir "${dir}"
 
   # Ensure package name is correct for the specific bundle and that the CSV name matches the package name. Also removing
   # the testing annotations since these are handled automatically upstream.
   sed \
-    -e "s/package.v1: cockroach-operator/package.v1: ${pkg}/g" \
-    -e "/\s*# Annotations for testing/d" \
-    -e "/\s*operators.operatorframework.io.test/d" \
-    "${dir}/metadata/annotations.yaml" > "${dir}/metadata/annotations.yaml.new"
+  -e "s/package.v1: cockroach-operator/package.v1: ${pkg}/g" \
+  -e "/\s*# Annotations for testing/d" \
+  -e "/\s*operators.operatorframework.io.test/d" \
+  "${dir}/metadata/annotations.yaml" > "${dir}/metadata/annotations.yaml.new"
 
   mv "${dir}/metadata/annotations.yaml.new" "${dir}/metadata/annotations.yaml"
 
@@ -89,9 +89,9 @@ generate_bundle() {
 
   # move the dockerfile into the bundle directory and make it valid
   sed \
-    -e "/\s*tests\/scorecard/d" \
-    -e "s+${dir}/++g" \
-    bundle.Dockerfile > "${dir}/Dockerfile"
+  -e "/\s*tests\/scorecard/d" \
+  -e "s+${dir}/++g" \
+  bundle.Dockerfile > "${dir}/Dockerfile"
 
   rm bundle.Dockerfile
 	rm "${dir}/manifests/cockroach-operator-webhook-service_v1_service.yaml"
@@ -108,9 +108,9 @@ adapt_csv() {
 
   # replace RH_COCKROACH_OP_IMAGE_PLACEHOLDER with the proper image and CREATED_AT_PLACEHOLDER with the current time
   sed \
-    -e "s+RH_COCKROACH_OP_IMAGE_PLACEHOLDER+${img}+g" \
-    -e "s+CREATED_AT_PLACEHOLDER+"$(date +"%FT%H:%M:%SZ")"+g" \
-    "${csv}" > "${csv}.new"
+  -e "s+RH_COCKROACH_OP_IMAGE_PLACEHOLDER+${img}+g" \
+  -e "s+CREATED_AT_PLACEHOLDER+"$(date +"%FT%H:%M:%SZ")"+g" \
+  "${csv}" > "${csv}.new"
 
   mv "${csv}.new" "${csv}"
 }
@@ -122,7 +122,7 @@ patch_marketplace_csv() {
 
   local csv="${1}/cockroachdb-certified-rhmp/manifests/${2}.clusterserviceversion.yaml"
   sed "s+  annotations:+  annotations:\n${rhmp_annotations}+" \
-    "${csv}" > "${csv}.new"
+  "${csv}" > "${csv}.new"
   mv "${csv}.new" "${csv}"
 }
 

--- a/hack/bundle.sh
+++ b/hack/bundle.sh
@@ -89,6 +89,13 @@ generate_bundle() {
 
   # Update CSV with correct images, and timestamps
   adapt_csv "${dir}" "${img}"
+
+  # move the dockerfile into the bundle directory and make it valid
+  sed \
+    -e "s+${dir}/++g" bundle.Dockerfile \ # fix up paths
+    -e "/\s*COPY tests/d" > "${dir}/Dockerfile" # remove scorecard tests
+
+  rm bundle.Dockerfile
 }
 
 adapt_csv() {

--- a/hack/bundle.sh
+++ b/hack/bundle.sh
@@ -85,17 +85,19 @@ generate_bundle() {
   mv "${dir}/metadata/annotations.yaml.new" "${dir}/metadata/annotations.yaml"
 
   # add supported openshift versions
-  echo "  com.redhat.openshift.versions: 4.7-4.9" >> "${dir}/metadata/annotations.yaml"
+  echo "  com.redhat.openshift.versions: 4.7-4.10" >> "${dir}/metadata/annotations.yaml"
 
   # Update CSV with correct images, and timestamps
   adapt_csv "${dir}" "${img}"
 
   # move the dockerfile into the bundle directory and make it valid
   sed \
-    -e "s+${dir}/++g" bundle.Dockerfile \ # fix up paths
-    -e "/\s*COPY tests/d" > "${dir}/Dockerfile" # remove scorecard tests
+    -e "/\s*tests\/scorecard/d" \
+    -e "s+${dir}/++g" \
+    bundle.Dockerfile > "${dir}/Dockerfile"
 
   rm bundle.Dockerfile
+	rm "${dir}/manifests/cockroach-operator-webhook-service_v1_service.yaml"
 }
 
 adapt_csv() {

--- a/hack/bundle.sh
+++ b/hack/bundle.sh
@@ -84,9 +84,6 @@ generate_bundle() {
 
   mv "${dir}/metadata/annotations.yaml.new" "${dir}/metadata/annotations.yaml"
 
-  # add supported openshift versions
-  echo "  com.redhat.openshift.versions: 4.7-4.10" >> "${dir}/metadata/annotations.yaml"
-
   # Update CSV with correct images, and timestamps
   adapt_csv "${dir}" "${img}"
 

--- a/hack/redhat.sh
+++ b/hack/redhat.sh
@@ -43,7 +43,7 @@ main() {
 
   case "${1:-}" in
     operator)
-			publish_operator_image
+      publish_operator_image
       preflight_operator;;
     bundle)
 			publish_bundle_image "${REGISTRY}/${BUNDLE_IMAGE}" "bundle/cockroachdb-certified"
@@ -65,15 +65,15 @@ main() {
 publish_operator_image() {
   echo "Publishing operator image to local repo..."
   APP_VERSION="v${VERSION}" \
-    DOCKER_REGISTRY="${REGISTRY}" \
-    DOCKER_IMAGE_REPOSITORY="${IMAGE%:*}" \
-    bazel run --stamp --platforms=@io_bazel_rules_go//go/toolchain:linux_amd64 //:push_operator_image
+  DOCKER_REGISTRY="${REGISTRY}" \
+  DOCKER_IMAGE_REPOSITORY="${IMAGE%:*}" \
+  bazel run --stamp --platforms=@io_bazel_rules_go//go/toolchain:linux_amd64 //:push_operator_image
 }
 
 preflight_operator() {
   echo "Running preflight checks on operator image..."
   preflight check container "${REGISTRY}/${IMAGE}" \
-    --docker-config "${HOME}/.docker/config.json"
+  --docker-config "${HOME}/.docker/config.json"
 }
 
 publish_bundle_image() {
@@ -93,9 +93,9 @@ publish_bundle_index() {
 
   echo "Publishing ${index_img}..."
   opm index add \
-    --container-tool docker \
-    --bundles "${bundle_img}" \
-    --tag "${index_img}"
+  --container-tool docker \
+  --bundles "${bundle_img}" \
+  --tag "${index_img}"
 }
 
 preflight_bundle() {
@@ -103,7 +103,7 @@ preflight_bundle() {
 	local index_img="${2}"
 
   echo "Running preflight checks on bundle image..."
-	echo "  IMAGE: ${bundle_img}"
+	echo "IMAGE: ${bundle_img}"
 
 	PFLT_INDEXIMAGE="${index_img}" preflight check operator "${bundle_img}"
 }

--- a/hack/redhat.sh
+++ b/hack/redhat.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Copyright 2022 The Cockroach Authors
+# Copyright 2023 The Cockroach Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/hack/redhat.sh
+++ b/hack/redhat.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+
+# Copyright 2022 The Cockroach Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+set -euo pipefail
+
+# include bazel binaries in the path
+PATH="bazel-bin/hack/bin:${PATH}"
+
+# Global preflight settings
+export PFLT_DOCKERCONFIG="${HOME}/.docker/config.json"
+export PFLT_LOGLEVEL=debug
+
+OPERATOR="cockroachdb/cockroach-operator"
+REGISTRY="gcr.io/${GCP_PROJECT}"
+VERSION="$(cat version.txt)"
+IMAGE="${OPERATOR}:v${VERSION}"
+BUNDLE_IMAGE="${OPERATOR}-bundle:v${VERSION}"
+BUNDLE_INDEX="${OPERATOR}-index:v${VERSION}"
+RHMP_BUNDLE_IMAGE="${OPERATOR}-bundle-rhmp:v${VERSION}"
+RHMP_BUNDLE_INDEX="${OPERATOR}-index-rhmp:v${VERSION}"
+
+main() {
+  # Switch to the build directory. The bundle directory is not part of source
+  # controller and therefore isn't a bazel target. This means when we run this
+  # script, there's no way to reference the Dockerfile created by the call to
+  # make release/generate-bundle (prerequisite of make test/preflight). By cd'ing
+  # into the build directory, we'll have access to _all_ the files.
+  if [[ -n "${BUILD_WORKSPACE_DIRECTORY}" ]]; then
+    cd "${BUILD_WORKSPACE_DIRECTORY}"
+  fi
+
+  case "${1:-}" in
+    operator)
+			publish_operator_image
+      preflight_operator;;
+    bundle)
+			publish_bundle_image "${REGISTRY}/${BUNDLE_IMAGE}" "bundle/cockroachdb-certified"
+			publish_bundle_index "${REGISTRY}/${BUNDLE_IMAGE}" "${REGISTRY}/${BUNDLE_INDEX}"
+			preflight_bundle "${REGISTRY}/${BUNDLE_IMAGE}" "${REGISTRY}/${BUNDLE_INDEX}"
+			ensure_success;;
+    marketplace)
+			publish_bundle_image "${REGISTRY}/${RHMP_BUNDLE_IMAGE}" "bundle/cockroachdb-certified-rhmp"
+			publish_bundle_index "${REGISTRY}/${RHMP_BUNDLE_IMAGE}" "${REGISTRY}/${RHMP_BUNDLE_INDEX}"
+			preflight_bundle "${REGISTRY}/${RHMP_BUNDLE_IMAGE}" "${REGISTRY}/${RHMP_BUNDLE_INDEX}"
+			ensure_success;;
+    *)
+      echo "ERROR: Unknown command: ${1}" 1>&2
+      echo "Usage bazel run //hack:redhat-preflight -- <operator|bundle|marketplace>." 1>&2
+      exit 1;;
+  esac
+}
+
+publish_operator_image() {
+  echo "Publishing operator image to local repo..."
+  APP_VERSION="v${VERSION}" \
+    DOCKER_REGISTRY="${REGISTRY}" \
+    DOCKER_IMAGE_REPOSITORY="${IMAGE%:*}" \
+    bazel run --stamp --platforms=@io_bazel_rules_go//go/toolchain:linux_amd64 //:push_operator_image
+}
+
+preflight_operator() {
+  echo "Running preflight checks on operator image..."
+  preflight check container "${REGISTRY}/${IMAGE}" \
+    --docker-config "${HOME}/.docker/config.json"
+}
+
+publish_bundle_image() {
+	local img="${1}"
+	local dir="${2}"
+
+  echo "Publishing ${img}..."
+  pushd "${dir}"
+  docker build -t "${img}" .
+  docker push "${img}"
+  popd
+}
+
+publish_bundle_index() {
+	local bundle_img="${1}"
+	local index_img="${2}"
+
+  echo "Publishing ${index_img}..."
+  opm index add \
+    --container-tool docker \
+    --bundles "${bundle_img}" \
+    --tag "${index_img}"
+}
+
+preflight_bundle() {
+	local bundle_img="${1}"
+	local index_img="${2}"
+
+  echo "Running preflight checks on bundle image..."
+	echo "  IMAGE: ${bundle_img}"
+
+	PFLT_INDEXIMAGE="${index_img}" preflight check operator "${bundle_img}"
+}
+
+ensure_success() {
+	if [[ $(cat artifacts/results.json | jq -r .passed) == 'false' ]]; then
+		# error already displayed
+		exit 1
+	fi
+}
+
+main "$@"


### PR DESCRIPTION
**Install preflight binary on Linux machines**
```
Adding preflight to the list of OpenShift binaries installed. For now,
this is only available on Linux machines and won't be added to anyone
using Darwin.
```

**Publish operator and bundle images for RedHat/OpenShift**
```
Updating the build/release scripts to handle publishing the bundle
images and running preflight on them.

The publish-openshift script downloads the tagged release from
DockerHub, retags it correctly for the RedHat scanning repo, pushes it,
and finally runs the preflight check on it.

The openshift-bundle script largely does the same, only it publishes the
bundle image rather than the operator image. The same script is used for
both the certified and marketplace bundles. Passing `MARKETPLACE=1` will
use the marketplace bundle values rather than the certified ones
(default).
```

**Support Openshift version 4.10 and 4.11 as we have support for k8s 1.25**

Fixes: #938 

**Checklist**

* [ ] I have added these changes to the changelog (or it's not applicable).
