### PR TITLE
fix: add annotation for UI ingress

### DIFF
--- a/pkg/resource/ui_ingress.go
+++ b/pkg/resource/ui_ingress.go
@@ -69,6 +69,9 @@ func (b *UIIngressBuilder) BuildV1Ingress(obj client.Object) error {
 	}
 
 	kube.MergeAnnotations(ingress.ObjectMeta.Annotations, b.SSLPassThroughAnnotations())
+	if b.Spec().Ingress.UI.TLS != nil {
+		kube.MergeAnnotations(ingress.ObjectMeta.Annotations, b.BackendProtocolAnnotations())
+	}
 	ingressConfig := b.Spec().Ingress
 
 	if ingressConfig == nil {
@@ -113,6 +116,9 @@ func (b *UIIngressBuilder) BuildV1beta1Ingress(obj client.Object) error {
 	}
 
 	kube.MergeAnnotations(ingress.ObjectMeta.Annotations, b.SSLPassThroughAnnotations())
+	if b.Spec().Ingress.UI.TLS != nil {
+		kube.MergeAnnotations(ingress.ObjectMeta.Annotations, b.BackendProtocolAnnotations())
+	}
 	ingressConfig := b.Spec().Ingress
 
 	if ingressConfig == nil {
@@ -202,5 +208,11 @@ func getV1IngressRule(host, serviceName string, servicePort intstr.IntOrString) 
 func (b *UIIngressBuilder) SSLPassThroughAnnotations() map[string]string {
 	return map[string]string{
 		"nginx.ingress.kubernetes.io/ssl-passthrough": "true",
+	}
+}
+
+func (b *UIIngressBuilder) BackendProtocolAnnotations() map[string]string {
+	return map[string]string{
+		"nginx.ingress.kubernetes.io/backend-protocol": "HTTPS",
 	}
 }


### PR DESCRIPTION
Add the https annotation for UI ingress when using secure mode

I'm using the ingress to expose the adminUI service. It doesn't work under the master branch and return http status 307, meanwhile the location in response header is the requeset address forever

![image](https://user-images.githubusercontent.com/15819504/225275036-38d50110-51f6-409c-ae48-e2984b79d18f.png)

By adding the annotaion `nginx.ingress.kubernetes.io/backend-protocol:  HTTPS` can solve this problem.


![image](https://user-images.githubusercontent.com/15819504/225275597-c03fcc2a-0680-48f6-ad31-b4c2725506c9.png)

