### PR TITLE
fix : missing service account cockroachdb-sa to be created #879

### DIFF
--- a/config/templates/client-secure-operator.yaml.in
+++ b/config/templates/client-secure-operator.yaml.in
@@ -14,6 +14,11 @@
 #
 # {{ .GeneratedWarning }}
 #
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cockroachdb-sa
+---
 
 apiVersion: v1
 kind: Pod


### PR DESCRIPTION
client-secure-operator.yaml has reference to a service account `cockroachdb-sa` which not being created but was referred.

**Checklist**

*In order to fix it I added code block to create  `cockroachdb-sa`  service account
