### PR TITLE
Add user parameter to client certificate logic

### DIFF
--- a/pkg/actor/decommission.go
+++ b/pkg/actor/decommission.go
@@ -107,7 +107,7 @@ func (d decommission) Act(ctx context.Context, cluster *resource.Cluster, log lo
 	// see https://github.com/cockroachdb/cockroach-operator/issues/204 for above TODO
 	if cluster.Spec().TLSEnabled {
 		conn.UseSSL = true
-		conn.ClientCertificateSecretName = cluster.ClientTLSSecretName()
+		conn.ClientCertificateSecretName = cluster.ClientTLSSecretName("root")
 		conn.RootCertificateSecretName = cluster.NodeTLSSecretName()
 	}
 	db, err := database.NewDbConnection(conn)

--- a/pkg/actor/partitioned_update.go
+++ b/pkg/actor/partitioned_update.go
@@ -155,7 +155,7 @@ func (up *partitionedUpdate) Act(ctx context.Context, cluster *resource.Cluster,
 
 	if cluster.Spec().TLSEnabled {
 		conn.UseSSL = true
-		conn.ClientCertificateSecretName = cluster.ClientTLSSecretName()
+		conn.ClientCertificateSecretName = cluster.ClientTLSSecretName("root")
 		conn.RootCertificateSecretName = cluster.NodeTLSSecretName()
 	}
 

--- a/pkg/resource/cluster.go
+++ b/pkg/resource/cluster.go
@@ -307,12 +307,12 @@ func (cluster Cluster) NodeTLSSecretName() string {
 	return fmt.Sprintf("%s-node", cluster.Name())
 }
 
-func (cluster Cluster) ClientTLSSecretName() string {
+func (cluster Cluster) ClientTLSSecretName(user string) string {
 	if cluster.Spec().ClientTLSSecret != "" {
 		return cluster.Spec().ClientTLSSecret
 	}
 
-	return fmt.Sprintf("%s-root", cluster.Name())
+	return fmt.Sprintf("%s-%s", cluster.Name(), user)
 }
 func (cluster Cluster) CASecretName() string {
 	return fmt.Sprintf("%s-ca", cluster.Name())

--- a/pkg/resource/cluster_test.go
+++ b/pkg/resource/cluster_test.go
@@ -5,7 +5,7 @@ Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
 
-    https://www.apache.org/licenses/LICENSE-2.0
+	https://www.apache.org/licenses/LICENSE-2.0
 
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
@@ -75,7 +75,7 @@ func TestClusterTLSSecrets(t *testing.T) {
 
 			if tt.clientTLSSecretName != "" {
 				expected = tt.clientTLSSecretName
-				actual = tt.cluster.ClientTLSSecretName()
+				actual = tt.cluster.ClientTLSSecretName("root")
 			}
 
 			diff := cmp.Diff(expected, actual, testutil.RuntimeObjCmpOpts...)

--- a/pkg/resource/statefulset.go
+++ b/pkg/resource/statefulset.go
@@ -344,7 +344,7 @@ func (b StatefulSetBuilder) nodeTLSSecretName() string {
 
 func (b StatefulSetBuilder) clientTLSSecretName() string {
 	if b.Spec().ClientTLSSecret == "" {
-		return b.Cluster.ClientTLSSecretName()
+		return b.Cluster.ClientTLSSecretName("root")
 	}
 
 	return b.Spec().ClientTLSSecret

--- a/pkg/testutil/require.go
+++ b/pkg/testutil/require.go
@@ -230,7 +230,7 @@ func RequireDownGradeOptionSet(t *testing.T, sb testenv.DiffingSandbox, b Cluste
 		DatabaseName: "system",
 
 		RunningInsideK8s:            false,
-		ClientCertificateSecretName: b.Cluster().ClientTLSSecretName(),
+		ClientCertificateSecretName: b.Cluster().ClientTLSSecretName("root"),
 		RootCertificateSecretName:   b.Cluster().NodeTLSSecretName(),
 	}
 
@@ -391,7 +391,7 @@ func requireDatabaseToFunction(t *testing.T, sb testenv.DiffingSandbox, b Cluste
 
 	// set the client certs since we are using SSL
 	if useSSL {
-		conn.ClientCertificateSecretName = b.Cluster().ClientTLSSecretName()
+		conn.ClientCertificateSecretName = b.Cluster().ClientTLSSecretName("root")
 		conn.RootCertificateSecretName = b.Cluster().NodeTLSSecretName()
 	}
 


### PR DESCRIPTION
prepare logic to allow more than just root as user for a client secret

**Checklist**

* [x] I have added these changes to the changelog (or it's not applicable).
