### PR TITLE
Fix the clusterStatus should reflect correct state of cluster

### DIFF
--- a/pkg/resource/cluster.go
+++ b/pkg/resource/cluster.go
@@ -210,7 +210,7 @@ func (cluster Cluster) LookupSupportedVersion(version string) (string, bool) {
 	return "", false
 }
 
-//GetVersionAnnotation  gets the current version of the cluster  retrieved by version checker action
+// GetVersionAnnotation  gets the current version of the cluster  retrieved by version checker action
 func (cluster Cluster) GetVersionAnnotation() string {
 	return cluster.getAnnotation(CrdbVersionAnnotation)
 }


### PR DESCRIPTION
Fixes #951 

Currently, we are storing the CR in resource.Cluster object and changing this CR during the course of reconcile and at last call the update function. This causes the `object has been already modified, please apply your changes to the latest version and try again`

With this change, we take the copy of the object before reconcile, run the changes on our CR, then patch will take diff for the before and after of object to find only the changed fields. This patch operation is more safer in terms of updating the CR.

With this change, cluster is in correct state after crdb is provisioned:
<img width="1440" alt="Screenshot 2023-04-18 at 3 00 49 AM" src="https://user-images.githubusercontent.com/26801029/232615284-4dcae142-2a0a-4518-bb81-e3806124ebfb.png">
