### PR TITLE
Update the golangci-lint version from 1.50.1 to 1.51.1

### DIFF
--- a/config/manager/patches/image.yaml
+++ b/config/manager/patches/image.yaml
@@ -186,6 +186,10 @@ spec:
               value: cockroachdb/cockroach:v22.1.14
             - name: RELATED_IMAGE_COCKROACH_v22_1_15
               value: cockroachdb/cockroach:v22.1.15
+            - name: RELATED_IMAGE_COCKROACH_v22_1_16
+              value: cockroachdb/cockroach:v22.1.16
+            - name: RELATED_IMAGE_COCKROACH_v22_1_18
+              value: cockroachdb/cockroach:v22.1.18
             - name: RELATED_IMAGE_COCKROACH_v22_2_0
               value: cockroachdb/cockroach:v22.2.0
             - name: RELATED_IMAGE_COCKROACH_v22_2_1
@@ -198,3 +202,9 @@ spec:
               value: cockroachdb/cockroach:v22.2.4
             - name: RELATED_IMAGE_COCKROACH_v22_2_5
               value: cockroachdb/cockroach:v22.2.5
+            - name: RELATED_IMAGE_COCKROACH_v22_2_6
+              value: cockroachdb/cockroach:v22.2.6
+            - name: RELATED_IMAGE_COCKROACH_v22_2_7
+              value: cockroachdb/cockroach:v22.2.7
+            - name: RELATED_IMAGE_COCKROACH_v22_2_8
+              value: cockroachdb/cockroach:v22.2.8

--- a/config/manifests/bases/cockroach-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/cockroach-operator.clusterserviceversion.yaml
@@ -342,6 +342,10 @@ spec:
     image: registry.connect.redhat.com/cockroachdb/cockroach@sha256:7b907d03b001b758d8a4b5e898725c73dda2ec2aa4b7425b685320b947154d11
   - name: RELATED_IMAGE_COCKROACH_v22_1_15
     image: registry.connect.redhat.com/cockroachdb/cockroach@sha256:0ec1dc184a2199736b4bd7de3241a357be7427caea5da1c931b08bc06f5c3dc0
+  - name: RELATED_IMAGE_COCKROACH_v22_1_16
+    image: registry.connect.redhat.com/cockroachdb/cockroach@sha256:1d590946b2f7c7ec0c7ec057a338e81f864d6a9e3d3ac4e0769aa5756a8e13fc
+  - name: RELATED_IMAGE_COCKROACH_v22_1_18
+    image: registry.connect.redhat.com/cockroachdb/cockroach@sha256:363d8feb560324a848c5771edd224dc19020013af7641979ee81ae8ee536d7e3
   - name: RELATED_IMAGE_COCKROACH_v22_2_0
     image: registry.connect.redhat.com/cockroachdb/cockroach@sha256:e50aab39722af22ccbf3d1db19e37972d52b0fc9a40998a64618dc966b2bac57
   - name: RELATED_IMAGE_COCKROACH_v22_2_1
@@ -354,3 +358,9 @@ spec:
     image: registry.connect.redhat.com/cockroachdb/cockroach@sha256:086d7b435993fdf21fd59b0093f52105a9028d6b769398b0033f98a65dfb7e79
   - name: RELATED_IMAGE_COCKROACH_v22_2_5
     image: registry.connect.redhat.com/cockroachdb/cockroach@sha256:0fea6ed8a78ea624240ee6ffb3573d5cf1115186aa9180fcd7d1273351deaaa3
+  - name: RELATED_IMAGE_COCKROACH_v22_2_6
+    image: registry.connect.redhat.com/cockroachdb/cockroach@sha256:53c7b960a2ed70a0998a4f8e28a4f78f7f676e01cffebe665e91e3a7629d88ed
+  - name: RELATED_IMAGE_COCKROACH_v22_2_7
+    image: registry.connect.redhat.com/cockroachdb/cockroach@sha256:d14f77f70aea0422a906510c1ac2652ff76e131ed705cb002f80e13e887b0cd9
+  - name: RELATED_IMAGE_COCKROACH_v22_2_8
+    image: registry.connect.redhat.com/cockroachdb/cockroach@sha256:1e5d85f5db10fa79d09263db90daa44549bcc3b025e9f3f98cf0d4e51766394b

--- a/config/manifests/patches/deployment_patch.yaml
+++ b/config/manifests/patches/deployment_patch.yaml
@@ -195,6 +195,10 @@ spec:
               value: registry.connect.redhat.com/cockroachdb/cockroach@sha256:7b907d03b001b758d8a4b5e898725c73dda2ec2aa4b7425b685320b947154d11
             - name: RELATED_IMAGE_COCKROACH_v22_1_15
               value: registry.connect.redhat.com/cockroachdb/cockroach@sha256:0ec1dc184a2199736b4bd7de3241a357be7427caea5da1c931b08bc06f5c3dc0
+            - name: RELATED_IMAGE_COCKROACH_v22_1_16
+              value: registry.connect.redhat.com/cockroachdb/cockroach@sha256:1d590946b2f7c7ec0c7ec057a338e81f864d6a9e3d3ac4e0769aa5756a8e13fc
+            - name: RELATED_IMAGE_COCKROACH_v22_1_18
+              value: registry.connect.redhat.com/cockroachdb/cockroach@sha256:363d8feb560324a848c5771edd224dc19020013af7641979ee81ae8ee536d7e3
             - name: RELATED_IMAGE_COCKROACH_v22_2_0
               value: registry.connect.redhat.com/cockroachdb/cockroach@sha256:e50aab39722af22ccbf3d1db19e37972d52b0fc9a40998a64618dc966b2bac57
             - name: RELATED_IMAGE_COCKROACH_v22_2_1
@@ -207,4 +211,10 @@ spec:
               value: registry.connect.redhat.com/cockroachdb/cockroach@sha256:086d7b435993fdf21fd59b0093f52105a9028d6b769398b0033f98a65dfb7e79
             - name: RELATED_IMAGE_COCKROACH_v22_2_5
               value: registry.connect.redhat.com/cockroachdb/cockroach@sha256:0fea6ed8a78ea624240ee6ffb3573d5cf1115186aa9180fcd7d1273351deaaa3
+            - name: RELATED_IMAGE_COCKROACH_v22_2_6
+              value: registry.connect.redhat.com/cockroachdb/cockroach@sha256:53c7b960a2ed70a0998a4f8e28a4f78f7f676e01cffebe665e91e3a7629d88ed
+            - name: RELATED_IMAGE_COCKROACH_v22_2_7
+              value: registry.connect.redhat.com/cockroachdb/cockroach@sha256:d14f77f70aea0422a906510c1ac2652ff76e131ed705cb002f80e13e887b0cd9
+            - name: RELATED_IMAGE_COCKROACH_v22_2_8
+              value: registry.connect.redhat.com/cockroachdb/cockroach@sha256:1e5d85f5db10fa79d09263db90daa44549bcc3b025e9f3f98cf0d4e51766394b
           image: RH_COCKROACH_OP_IMAGE_PLACEHOLDER

--- a/config/samples/crdb-tls-example.yaml
+++ b/config/samples/crdb-tls-example.yaml
@@ -19,7 +19,7 @@ kind: CrdbCluster
 metadata:
   name: crdb-tls-example
 spec:
-  cockroachDBVersion: v22.2.5
+  cockroachDBVersion: v22.2.8
   dataStore:
     pvc:
       spec:

--- a/crdb-versions.yaml
+++ b/crdb-versions.yaml
@@ -262,6 +262,12 @@ CrdbVersions:
 - image: cockroachdb/cockroach:v22.1.15
   redhatImage: registry.connect.redhat.com/cockroachdb/cockroach@sha256:0ec1dc184a2199736b4bd7de3241a357be7427caea5da1c931b08bc06f5c3dc0
   tag: v22.1.15
+- image: cockroachdb/cockroach:v22.1.16
+  redhatImage: registry.connect.redhat.com/cockroachdb/cockroach@sha256:1d590946b2f7c7ec0c7ec057a338e81f864d6a9e3d3ac4e0769aa5756a8e13fc
+  tag: v22.1.16
+- image: cockroachdb/cockroach:v22.1.18
+  redhatImage: registry.connect.redhat.com/cockroachdb/cockroach@sha256:363d8feb560324a848c5771edd224dc19020013af7641979ee81ae8ee536d7e3
+  tag: v22.1.18
 - image: cockroachdb/cockroach:v22.2.0
   redhatImage: registry.connect.redhat.com/cockroachdb/cockroach@sha256:e50aab39722af22ccbf3d1db19e37972d52b0fc9a40998a64618dc966b2bac57
   tag: v22.2.0
@@ -280,3 +286,12 @@ CrdbVersions:
 - image: cockroachdb/cockroach:v22.2.5
   redhatImage: registry.connect.redhat.com/cockroachdb/cockroach@sha256:0fea6ed8a78ea624240ee6ffb3573d5cf1115186aa9180fcd7d1273351deaaa3
   tag: v22.2.5
+- image: cockroachdb/cockroach:v22.2.6
+  redhatImage: registry.connect.redhat.com/cockroachdb/cockroach@sha256:53c7b960a2ed70a0998a4f8e28a4f78f7f676e01cffebe665e91e3a7629d88ed
+  tag: v22.2.6
+- image: cockroachdb/cockroach:v22.2.7
+  redhatImage: registry.connect.redhat.com/cockroachdb/cockroach@sha256:d14f77f70aea0422a906510c1ac2652ff76e131ed705cb002f80e13e887b0cd9
+  tag: v22.2.7
+- image: cockroachdb/cockroach:v22.2.8
+  redhatImage: registry.connect.redhat.com/cockroachdb/cockroach@sha256:1e5d85f5db10fa79d09263db90daa44549bcc3b025e9f3f98cf0d4e51766394b
+  tag: v22.2.8

--- a/e2e/openshift/openshift_packaging_test.go
+++ b/e2e/openshift/openshift_packaging_test.go
@@ -233,9 +233,10 @@ var letters = []rune("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
 
 // randSeq returns a string of n letters
 func randSeq(n int) string {
+	r := rand.New(rand.NewSource(time.Now().UnixNano()))
 	b := make([]rune, n)
 	for i := range b {
-		b[i] = letters[rand.Intn(len(letters))]
+		b[i] = letters[r.Intn(len(letters))]
 	}
 	return string(b)
 }
@@ -243,7 +244,6 @@ func randSeq(n int) string {
 // wriiteFile writes out b byte array to a random file in the
 // os.TempDir and returns the name of that file.
 func writeFile(t *testing.T, b []byte) string {
-	rand.Seed(time.Now().UnixNano())
 	fileName := fmt.Sprintf("%s-test.yaml", randSeq(10))
 	fileName = filepath.Join(t.TempDir(), fileName)
 

--- a/examples/client-secure-operator.yaml
+++ b/examples/client-secure-operator.yaml
@@ -23,7 +23,7 @@ spec:
   serviceAccountName: cockroachdb-sa
   containers:
   - name: cockroachdb-client-secure
-    image: cockroachdb/cockroach:v22.2.5
+    image: cockroachdb/cockroach:v22.2.8
     imagePullPolicy: IfNotPresent
     volumeMounts:
     - name: client-certs

--- a/examples/example.yaml
+++ b/examples/example.yaml
@@ -40,9 +40,9 @@ spec:
       memory: 8Gi
   tlsEnabled: true
 # You can set either a version of the db or a specific image name
-# cockroachDBVersion: v22.2.5
+# cockroachDBVersion: v22.2.8
   image:
-    name: cockroachdb/cockroach:v22.2.5
+    name: cockroachdb/cockroach:v22.2.8
   # nodes refers to the number of crdb pods that are created
   # via the statefulset
   nodes: 3

--- a/examples/smoketest.yaml
+++ b/examples/smoketest.yaml
@@ -39,5 +39,5 @@ spec:
       memory: 300Mi
   tlsEnabled: true
   image:
-    name: cockroachdb/cockroach:v22.2.5
+    name: cockroachdb/cockroach:v22.2.8
   nodes: 3

--- a/hack/bin/deps.bzl
+++ b/hack/bin/deps.bzl
@@ -199,14 +199,14 @@ def install_k3d():
 def install_golangci_lint():
     http_archive(
         name = "golangci_lint_darwin",
-        sha256 = "0f615fb8c364f6e4a213f2ed2ff7aa1fc2b208addf29511e89c03534067bbf57",
-        urls = ["https://github.com/golangci/golangci-lint/releases/download/v1.50.1/golangci-lint-1.50.1-darwin-amd64.tar.gz"],
+        sha256 = "fba08acc4027f69f07cef48fbff70b8a7ecdfaa1c2aba9ad3fb31d60d9f5d4bc",
+        urls = ["https://github.com/golangci/golangci-lint/releases/download/v1.51.1/golangci-lint-1.51.1-darwin-amd64.tar.gz"],
         build_file_content =
          """
 filegroup(
      name = "file",
      srcs = [
-        "golangci-lint-1.50.1-darwin-amd64/golangci-lint",
+        "golangci-lint-1.51.1-darwin-amd64/golangci-lint",
      ],
      visibility = ["//visibility:public"],
 )
@@ -215,14 +215,14 @@ filegroup(
 
     http_archive(
             name = "golangci_lint_m1",
-            sha256 = "0f615fb8c364f6e4a213f2ed2ff7aa1fc2b208addf29511e89c03534067bbf57",
-            urls = ["https://github.com/golangci/golangci-lint/releases/download/v1.50.1/golangci-lint-1.50.1-darwin-arm64.tar.gz"],
+            sha256 = "75b8f0ff3a4e68147156be4161a49d4576f1be37a0b506473f8c482140c1e7f2",
+            urls = ["https://github.com/golangci/golangci-lint/releases/download/v1.51.1/golangci-lint-1.51.1-darwin-arm64.tar.gz"],
             build_file_content =
              """
 filegroup(
     name = "file",
     srcs = [
-       "golangci-lint-1.50.1-darwin-arm64/golangci-lint",
+       "golangci-lint-1.51.1-darwin-arm64/golangci-lint",
     ],
     visibility = ["//visibility:public"],
 )
@@ -231,14 +231,14 @@ filegroup(
 
     http_archive(
         name = "golangci_lint_linux",
-        sha256 = "4ba1dc9dbdf05b7bdc6f0e04bdfe6f63aa70576f51817be1b2540bbce017b69a",
-        urls = ["https://github.com/golangci/golangci-lint/releases/download/v1.50.1/golangci-lint-1.50.1-linux-amd64.tar.gz"],
+        sha256 = "17aeb26c76820c22efa0e1838b0ab93e90cfedef43fbfc9a2f33f27eb9e5e070",
+        urls = ["https://github.com/golangci/golangci-lint/releases/download/v1.51.1/golangci-lint-1.51.1-linux-amd64.tar.gz"],
         build_file_content =
          """
 filegroup(
      name = "file",
      srcs = [
-        "golangci-lint-1.50.1-linux-amd64/golangci-lint",
+        "golangci-lint-1.51.1-linux-amd64/golangci-lint",
      ],
      visibility = ["//visibility:public"],
 )

--- a/hack/update_crdb_versions/main_test.go
+++ b/hack/update_crdb_versions/main_test.go
@@ -79,8 +79,8 @@ func TestUpdateCrdbVersions(t *testing.T) {
 		w.WriteHeader(http.StatusOK)
 
 		// shuffle images to ensure semver sort is working
-		rand.Seed(time.Now().UnixNano())
-		rand.Shuffle(len(images), func(i, j int) { images[i], images[j] = images[j], images[i] })
+		rnd := rand.New(rand.NewSource(time.Now().UnixNano()))
+		rnd.Shuffle(len(images), func(i, j int) { images[i], images[j] = images[j], images[i] })
 
 		require.NoError(t, tmpl.Execute(w, images))
 	}))

--- a/install/operator.yaml
+++ b/install/operator.yaml
@@ -544,6 +544,10 @@ spec:
           value: cockroachdb/cockroach:v22.1.14
         - name: RELATED_IMAGE_COCKROACH_v22_1_15
           value: cockroachdb/cockroach:v22.1.15
+        - name: RELATED_IMAGE_COCKROACH_v22_1_16
+          value: cockroachdb/cockroach:v22.1.16
+        - name: RELATED_IMAGE_COCKROACH_v22_1_18
+          value: cockroachdb/cockroach:v22.1.18
         - name: RELATED_IMAGE_COCKROACH_v22_2_0
           value: cockroachdb/cockroach:v22.2.0
         - name: RELATED_IMAGE_COCKROACH_v22_2_1
@@ -556,6 +560,12 @@ spec:
           value: cockroachdb/cockroach:v22.2.4
         - name: RELATED_IMAGE_COCKROACH_v22_2_5
           value: cockroachdb/cockroach:v22.2.5
+        - name: RELATED_IMAGE_COCKROACH_v22_2_6
+          value: cockroachdb/cockroach:v22.2.6
+        - name: RELATED_IMAGE_COCKROACH_v22_2_7
+          value: cockroachdb/cockroach:v22.2.7
+        - name: RELATED_IMAGE_COCKROACH_v22_2_8
+          value: cockroachdb/cockroach:v22.2.8
         - name: OPERATOR_NAME
           value: cockroachdb
         - name: POD_NAME


### PR DESCRIPTION
golangci-lint version is updated from the 1.50.1 because it is hitting the OOM issue with the Go 1.20 version and its fix has been done in 1.51.1.
