### PR TITLE
fix error message if invalid value for topologySpreadConstraints flags passed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 # [Unreleased](https://github.com/cockroachdb/cockroach-operator/compare/v2.10.0...master)
 
+* Bug fix to return correct error message if value passed for `whenUnsatisfiable` under `topologySpreadConstraints` field is invalid.
+
 # [v2.10.0](https://github.com/cockroachdb/cockroach-operator/compare/v2.9.0...v2.10.0)
 
 ## Added

--- a/pkg/actor/validate_version.go
+++ b/pkg/actor/validate_version.go
@@ -54,7 +54,7 @@ type versionChecker struct {
 	action
 }
 
-//GetActionType returns api.VersionCheckerAction action used to set the cluster status errors
+// GetActionType returns api.VersionCheckerAction action used to set the cluster status errors
 func (v *versionChecker) GetActionType() api.ActionType {
 	return api.VersionCheckerAction
 }
@@ -126,12 +126,14 @@ func (v *versionChecker) Act(ctx context.Context, cluster *resource.Cluster, log
 		Owner:  owner,
 		Scheme: v.scheme,
 	}).Reconcile()
-	if err != nil && kube.IgnoreNotFound(err) == nil {
-		err := errors.Wrap(err, "failed to reconcile job not found")
-		log.Error(err, "failed to reconcile job")
+	if err != nil {
+		if kube.IgnoreNotFound(err) == nil {
+			err := errors.Wrap(err, "failed to reconcile job not found")
+			log.Error(err, "failed to reconcile job")
+			return err
+		}
+		log.Error(err, "failed to reconcile job only err: ", err.Error())
 		return err
-	} else if err != nil {
-		log.Error(err, "failed to reconcile job only err")
 	}
 
 	if changed {


### PR DESCRIPTION
_Add a description of the problem this PR addresses and an overview of how this PR works_.

**Checklist**

* [x] I have added these changes to the changelog (or it's not applicable).

Output with the fix if we add invalid value for `whenUnsatisfiable` under `topologySpreadConstraints`:

```
himanshu@crlMBP-TT9JHHY615MjIz ~ % kubectl get crdbcluster test-cluster -o yaml
apiVersion: crdb.cockroachlabs.com/v1alpha1
kind: CrdbCluster
metadata:
  creationTimestamp: "2023-05-09T10:04:06Z"
  generation: 1
  name: test-cluster
  namespace: default
  resourceVersion: "3547286"
  uid: c842fb07-2289-4634-acae-3db8067735ff
spec:
  additionalLabels:
    crdb: is-cool
  dataStore:
    pvc:
      spec:
        accessModes:
        - ReadWriteOnce
        resources:
          requests:
            storage: 1Gi
        volumeMode: Filesystem
  image:
    name: cockroachdb/cockroach:v21.2.10
  nodes: 3
  resources:
    limits:
      cpu: 2
      memory: 2Gi
    requests:
      cpu: 100m
      memory: 1Gi
  tlsEnabled: true
  topologySpreadConstraints:
  - maxSkew: 3
    topologyKey: MYKEY
    whenUnsatisfiable: DoNotScedule
status:
  clusterStatus: Failed
  conditions:
  - lastTransitionTime: "2023-05-09T10:04:06Z"
    status: "False"
    type: Initialized
  - lastTransitionTime: "2023-05-09T10:04:06Z"
    status: "False"
    type: CrdbVersionChecked
  operatorActions:
  - lastTransitionTime: "2023-05-09T17:43:41Z"
    message: 'Job.batch "test-cluster-vcheck-28060903" is invalid: spec.template.spec.topologySpreadConstraints[0].whenUnsatisfiable:
      Unsupported value: "DoNotScedule": supported values: "DoNotSchedule", "ScheduleAnyway"'
    status: Failed
    type: VersionCheckerAction
```
