### PR TITLE
Update the CRDB versions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,7 @@ test/e2e-short:
 test/e2e/testrunner-k3d-%: PACKAGE=$*
 test/e2e/testrunner-k3d-%:
 	bazel run //hack/k8s:k8s -- -type k3d
-	bazel test --stamp //e2e/$(PACKAGE)/... --test_arg=-test.v --test_arg=-test.parallel=8 --test_arg=parallel=true
+	bazel test --stamp //e2e/$(PACKAGE)/... --test_arg=-test.v --test_arg=-test.parallel=4 --test_arg=parallel=true
 
 # Use this target to run e2e tests using a k3d k8s cluster.
 # This target uses k3d to start a k8s cluster  and runs the e2e tests

--- a/config/manager/patches/image.yaml
+++ b/config/manager/patches/image.yaml
@@ -190,6 +190,8 @@ spec:
               value: cockroachdb/cockroach:v22.1.16
             - name: RELATED_IMAGE_COCKROACH_v22_1_18
               value: cockroachdb/cockroach:v22.1.18
+            - name: RELATED_IMAGE_COCKROACH_v22_1_20
+              value: cockroachdb/cockroach:v22.1.20
             - name: RELATED_IMAGE_COCKROACH_v22_2_0
               value: cockroachdb/cockroach:v22.2.0
             - name: RELATED_IMAGE_COCKROACH_v22_2_1
@@ -208,3 +210,11 @@ spec:
               value: cockroachdb/cockroach:v22.2.7
             - name: RELATED_IMAGE_COCKROACH_v22_2_8
               value: cockroachdb/cockroach:v22.2.8
+            - name: RELATED_IMAGE_COCKROACH_v22_2_9
+              value: cockroachdb/cockroach:v22.2.9
+            - name: RELATED_IMAGE_COCKROACH_v23_1_0
+              value: cockroachdb/cockroach:v23.1.0
+            - name: RELATED_IMAGE_COCKROACH_v23_1_1
+              value: cockroachdb/cockroach:v23.1.1
+            - name: RELATED_IMAGE_COCKROACH_v23_1_2
+              value: cockroachdb/cockroach:v23.1.2

--- a/config/manifests/bases/cockroach-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/cockroach-operator.clusterserviceversion.yaml
@@ -346,6 +346,8 @@ spec:
     image: registry.connect.redhat.com/cockroachdb/cockroach@sha256:1d590946b2f7c7ec0c7ec057a338e81f864d6a9e3d3ac4e0769aa5756a8e13fc
   - name: RELATED_IMAGE_COCKROACH_v22_1_18
     image: registry.connect.redhat.com/cockroachdb/cockroach@sha256:363d8feb560324a848c5771edd224dc19020013af7641979ee81ae8ee536d7e3
+  - name: RELATED_IMAGE_COCKROACH_v22_1_20
+    image: registry.connect.redhat.com/cockroachdb/cockroach@sha256:9c85c25d5392817d17b68714dca6195ad53255d43e9c65b021d75b12d97e0579
   - name: RELATED_IMAGE_COCKROACH_v22_2_0
     image: registry.connect.redhat.com/cockroachdb/cockroach@sha256:e50aab39722af22ccbf3d1db19e37972d52b0fc9a40998a64618dc966b2bac57
   - name: RELATED_IMAGE_COCKROACH_v22_2_1
@@ -364,3 +366,11 @@ spec:
     image: registry.connect.redhat.com/cockroachdb/cockroach@sha256:d14f77f70aea0422a906510c1ac2652ff76e131ed705cb002f80e13e887b0cd9
   - name: RELATED_IMAGE_COCKROACH_v22_2_8
     image: registry.connect.redhat.com/cockroachdb/cockroach@sha256:1e5d85f5db10fa79d09263db90daa44549bcc3b025e9f3f98cf0d4e51766394b
+  - name: RELATED_IMAGE_COCKROACH_v22_2_9
+    image: registry.connect.redhat.com/cockroachdb/cockroach@sha256:9ab968e4ca62f23bf9848e5475ef4076df7318a8560f63d5b2090a32af6fe4e2
+  - name: RELATED_IMAGE_COCKROACH_v23_1_0
+    image: registry.connect.redhat.com/cockroachdb/cockroach@sha256:f3ffebd812881a830ff46c860984814dd61edcd51b478ebd3667759fb7710682
+  - name: RELATED_IMAGE_COCKROACH_v23_1_1
+    image: registry.connect.redhat.com/cockroachdb/cockroach@sha256:bc4b75ed71845d5b18e1d9163d480fd9d0d3cb5ebbcfed00a2e4e1b174c0a5de
+  - name: RELATED_IMAGE_COCKROACH_v23_1_2
+    image: registry.connect.redhat.com/cockroachdb/cockroach@sha256:0b0e0588c1aadf0c3826cd584bd2b3a7d6781882dcb5c5e037b47ff5cb84509b

--- a/config/manifests/patches/deployment_patch.yaml
+++ b/config/manifests/patches/deployment_patch.yaml
@@ -199,6 +199,8 @@ spec:
               value: registry.connect.redhat.com/cockroachdb/cockroach@sha256:1d590946b2f7c7ec0c7ec057a338e81f864d6a9e3d3ac4e0769aa5756a8e13fc
             - name: RELATED_IMAGE_COCKROACH_v22_1_18
               value: registry.connect.redhat.com/cockroachdb/cockroach@sha256:363d8feb560324a848c5771edd224dc19020013af7641979ee81ae8ee536d7e3
+            - name: RELATED_IMAGE_COCKROACH_v22_1_20
+              value: registry.connect.redhat.com/cockroachdb/cockroach@sha256:9c85c25d5392817d17b68714dca6195ad53255d43e9c65b021d75b12d97e0579
             - name: RELATED_IMAGE_COCKROACH_v22_2_0
               value: registry.connect.redhat.com/cockroachdb/cockroach@sha256:e50aab39722af22ccbf3d1db19e37972d52b0fc9a40998a64618dc966b2bac57
             - name: RELATED_IMAGE_COCKROACH_v22_2_1
@@ -217,4 +219,12 @@ spec:
               value: registry.connect.redhat.com/cockroachdb/cockroach@sha256:d14f77f70aea0422a906510c1ac2652ff76e131ed705cb002f80e13e887b0cd9
             - name: RELATED_IMAGE_COCKROACH_v22_2_8
               value: registry.connect.redhat.com/cockroachdb/cockroach@sha256:1e5d85f5db10fa79d09263db90daa44549bcc3b025e9f3f98cf0d4e51766394b
+            - name: RELATED_IMAGE_COCKROACH_v22_2_9
+              value: registry.connect.redhat.com/cockroachdb/cockroach@sha256:9ab968e4ca62f23bf9848e5475ef4076df7318a8560f63d5b2090a32af6fe4e2
+            - name: RELATED_IMAGE_COCKROACH_v23_1_0
+              value: registry.connect.redhat.com/cockroachdb/cockroach@sha256:f3ffebd812881a830ff46c860984814dd61edcd51b478ebd3667759fb7710682
+            - name: RELATED_IMAGE_COCKROACH_v23_1_1
+              value: registry.connect.redhat.com/cockroachdb/cockroach@sha256:bc4b75ed71845d5b18e1d9163d480fd9d0d3cb5ebbcfed00a2e4e1b174c0a5de
+            - name: RELATED_IMAGE_COCKROACH_v23_1_2
+              value: registry.connect.redhat.com/cockroachdb/cockroach@sha256:0b0e0588c1aadf0c3826cd584bd2b3a7d6781882dcb5c5e037b47ff5cb84509b
           image: RH_COCKROACH_OP_IMAGE_PLACEHOLDER

--- a/config/samples/crdb-tls-example.yaml
+++ b/config/samples/crdb-tls-example.yaml
@@ -19,7 +19,7 @@ kind: CrdbCluster
 metadata:
   name: crdb-tls-example
 spec:
-  cockroachDBVersion: v22.2.8
+  cockroachDBVersion: v23.1.2
   dataStore:
     pvc:
       spec:

--- a/crdb-versions.yaml
+++ b/crdb-versions.yaml
@@ -268,6 +268,9 @@ CrdbVersions:
 - image: cockroachdb/cockroach:v22.1.18
   redhatImage: registry.connect.redhat.com/cockroachdb/cockroach@sha256:363d8feb560324a848c5771edd224dc19020013af7641979ee81ae8ee536d7e3
   tag: v22.1.18
+- image: cockroachdb/cockroach:v22.1.20
+  redhatImage: registry.connect.redhat.com/cockroachdb/cockroach@sha256:9c85c25d5392817d17b68714dca6195ad53255d43e9c65b021d75b12d97e0579
+  tag: v22.1.20
 - image: cockroachdb/cockroach:v22.2.0
   redhatImage: registry.connect.redhat.com/cockroachdb/cockroach@sha256:e50aab39722af22ccbf3d1db19e37972d52b0fc9a40998a64618dc966b2bac57
   tag: v22.2.0
@@ -295,3 +298,15 @@ CrdbVersions:
 - image: cockroachdb/cockroach:v22.2.8
   redhatImage: registry.connect.redhat.com/cockroachdb/cockroach@sha256:1e5d85f5db10fa79d09263db90daa44549bcc3b025e9f3f98cf0d4e51766394b
   tag: v22.2.8
+- image: cockroachdb/cockroach:v22.2.9
+  redhatImage: registry.connect.redhat.com/cockroachdb/cockroach@sha256:9ab968e4ca62f23bf9848e5475ef4076df7318a8560f63d5b2090a32af6fe4e2
+  tag: v22.2.9
+- image: cockroachdb/cockroach:v23.1.0
+  redhatImage: registry.connect.redhat.com/cockroachdb/cockroach@sha256:f3ffebd812881a830ff46c860984814dd61edcd51b478ebd3667759fb7710682
+  tag: v23.1.0
+- image: cockroachdb/cockroach:v23.1.1
+  redhatImage: registry.connect.redhat.com/cockroachdb/cockroach@sha256:bc4b75ed71845d5b18e1d9163d480fd9d0d3cb5ebbcfed00a2e4e1b174c0a5de
+  tag: v23.1.1
+- image: cockroachdb/cockroach:v23.1.2
+  redhatImage: registry.connect.redhat.com/cockroachdb/cockroach@sha256:0b0e0588c1aadf0c3826cd584bd2b3a7d6781882dcb5c5e037b47ff5cb84509b
+  tag: v23.1.2

--- a/examples/client-secure-operator.yaml
+++ b/examples/client-secure-operator.yaml
@@ -23,7 +23,7 @@ spec:
   serviceAccountName: cockroachdb-sa
   containers:
   - name: cockroachdb-client-secure
-    image: cockroachdb/cockroach:v22.2.8
+    image: cockroachdb/cockroach:v23.1.2
     imagePullPolicy: IfNotPresent
     volumeMounts:
     - name: client-certs

--- a/examples/example.yaml
+++ b/examples/example.yaml
@@ -40,9 +40,9 @@ spec:
       memory: 8Gi
   tlsEnabled: true
 # You can set either a version of the db or a specific image name
-# cockroachDBVersion: v22.2.8
+# cockroachDBVersion: v23.1.2
   image:
-    name: cockroachdb/cockroach:v22.2.8
+    name: cockroachdb/cockroach:v23.1.2
   # nodes refers to the number of crdb pods that are created
   # via the statefulset
   nodes: 3

--- a/examples/smoketest.yaml
+++ b/examples/smoketest.yaml
@@ -39,5 +39,5 @@ spec:
       memory: 300Mi
   tlsEnabled: true
   image:
-    name: cockroachdb/cockroach:v22.2.8
+    name: cockroachdb/cockroach:v23.1.2
   nodes: 3

--- a/hack/bin/BUILD.bazel
+++ b/hack/bin/BUILD.bazel
@@ -133,6 +133,7 @@ genrule(
     srcs = select({
         ":darwin": ["@k3d_darwin//file"],
         ":k8": ["@k3d_linux//file"],
+        ":m1": ["@k3d_m1//file"],
     }),
     outs = ["k3d"],
     cmd = "cp $(SRCS) $@",

--- a/hack/bin/deps.bzl
+++ b/hack/bin/deps.bzl
@@ -178,13 +178,17 @@ def install_kubectl():
 def install_k3d():
     versions = {
         "k3d_darwin": {
-            "url": "https://github.com/rancher/k3d/releases/download/v5.2.2/k3d-darwin-amd64",
+            "url": "https://github.com/k3d-io/k3d/releases/download/v5.2.2/k3d-darwin-amd64",
             "sha": "40ac312bc762611de80daff24cb66d79aaaf17bf90e5e8d61caf90e63b57542d",
         },
         "k3d_linux": {
-            "url": "https://github.com/rancher/k3d/releases/download/v5.2.2/k3d-linux-amd64",
+            "url": "https://github.com/k3d-io/k3d/releases/download/v5.2.2/k3d-linux-amd64",
             "sha": "7ddb900e6e50120b65d61568f6af007a82331bf83918608a6a7be8910792faef",
         },
+        "k3d_m1": {
+            "url": "https://github.com/k3d-io/k3d/releases/download/v5.2.2/k3d-darwin-arm64",
+            "sha": "d0149ecb9b3fb831d617a0a880d8235722a70b9131f45f1389235e586050f8f9",
+        }
     }
 
     for k, v in versions.items():

--- a/install/operator.yaml
+++ b/install/operator.yaml
@@ -548,6 +548,8 @@ spec:
           value: cockroachdb/cockroach:v22.1.16
         - name: RELATED_IMAGE_COCKROACH_v22_1_18
           value: cockroachdb/cockroach:v22.1.18
+        - name: RELATED_IMAGE_COCKROACH_v22_1_20
+          value: cockroachdb/cockroach:v22.1.20
         - name: RELATED_IMAGE_COCKROACH_v22_2_0
           value: cockroachdb/cockroach:v22.2.0
         - name: RELATED_IMAGE_COCKROACH_v22_2_1
@@ -566,6 +568,14 @@ spec:
           value: cockroachdb/cockroach:v22.2.7
         - name: RELATED_IMAGE_COCKROACH_v22_2_8
           value: cockroachdb/cockroach:v22.2.8
+        - name: RELATED_IMAGE_COCKROACH_v22_2_9
+          value: cockroachdb/cockroach:v22.2.9
+        - name: RELATED_IMAGE_COCKROACH_v23_1_0
+          value: cockroachdb/cockroach:v23.1.0
+        - name: RELATED_IMAGE_COCKROACH_v23_1_1
+          value: cockroachdb/cockroach:v23.1.1
+        - name: RELATED_IMAGE_COCKROACH_v23_1_2
+          value: cockroachdb/cockroach:v23.1.2
         - name: OPERATOR_NAME
           value: cockroachdb
         - name: POD_NAME

--- a/pkg/testutil/require.go
+++ b/pkg/testutil/require.go
@@ -142,7 +142,7 @@ func RequireClusterToBeReadyEventually(t *testing.T, sb testenv.DiffingSandbox, 
 
 // RequireDbContainersToUseImage checks that the database is using the correct image
 func RequireDbContainersToUseImage(t *testing.T, sb testenv.DiffingSandbox, cr *api.CrdbCluster) {
-	err := wait.Poll(10*time.Second, 400*time.Second, func() (bool, error) {
+	err := wait.Poll(10*time.Second, 600*time.Second, func() (bool, error) {
 		pods, err := fetchPodsInStatefulSet(sb, labels.Common(cr).Selector(cr.Spec.AdditionalLabels))
 		if err != nil {
 			return false, err


### PR DESCRIPTION
- Update the cockroach operator with latest CRDB versions
- Added support for Mac m1 to run tests locally
- Upgrade test was failing because of 8 parallel process, reduced it to 4 parallel test cases.
