### PR TITLE
Update CSV and metadata annotations for openshift certification

### DIFF
--- a/config/manifests/bases/cockroach-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/cockroach-operator.clusterserviceversion.yaml
@@ -29,6 +29,13 @@ metadata:
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/cockroachdb/cockroach-operator
     support: Cockroach Labs
+    features.operators.openshift.io/disconnected: "true"
+    features.operators.openshift.io/fips-compliant: "false"
+    features.operators.openshift.io/proxy-aware: "false"
+    features.operators.openshift.io/tls-profiles: "false"
+    features.operators.openshift.io/token-auth-aws: "false"
+    features.operators.openshift.io/token-auth-azure: "false"
+    features.operators.openshift.io/token-auth-gcp: "false"
   name: cockroach-operator.v0.0.0
   namespace: placeholder
 spec:

--- a/config/templates/csv.yaml.in
+++ b/config/templates/csv.yaml.in
@@ -29,6 +29,13 @@ metadata:
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/cockroachdb/cockroach-operator
     support: Cockroach Labs
+    features.operators.openshift.io/disconnected: "true"
+    features.operators.openshift.io/fips-compliant: "false"
+    features.operators.openshift.io/proxy-aware: "false"
+    features.operators.openshift.io/tls-profiles: "false"
+    features.operators.openshift.io/token-auth-aws: "false"
+    features.operators.openshift.io/token-auth-azure: "false"
+    features.operators.openshift.io/token-auth-gcp: "false"
   name: cockroach-operator.v0.0.0
   namespace: placeholder
 spec:

--- a/hack/bundle.sh
+++ b/hack/bundle.sh
@@ -75,8 +75,10 @@ generate_bundle() {
   --output-dir "${dir}"
 
   # Ensure package name is correct for the specific bundle and that the CSV name matches the package name. Also removing
-  # the testing annotations since these are handled automatically upstream.
+  # the testing annotations since these are handled automatically upstream. Also add openshift version annotation
+  local openshift_version_annotation="  com.redhat.openshift.versions: v4.8"
   sed \
+  -e "s+annotations:+annotations:\n  # Minimum Openshift version annotation\n${openshift_version_annotation}+" \
   -e "s/package.v1: cockroach-operator/package.v1: ${pkg}/g" \
   -e "/\s*# Annotations for testing/d" \
   -e "/\s*operators.operatorframework.io.test/d" \


### PR DESCRIPTION
Openshift certification needs some additional annotations which was not generated by `make release/generate-bundle`. I have added logic to generate those annotations so that the generated bundle passes certification in one attempt.