### PR TITLE
vcheck job resource limits should be greater than resource requests

### DIFF
--- a/pkg/resource/job.go
+++ b/pkg/resource/job.go
@@ -141,7 +141,7 @@ func (b JobBuilder) MakeContainers() []corev1.Container {
 			Resources: corev1.ResourceRequirements{
 				Limits: corev1.ResourceList{
 					corev1.ResourceCPU:    apiresource.MustParse("300m"),
-					corev1.ResourceMemory: apiresource.MustParse("256Mi"),
+					corev1.ResourceMemory: apiresource.MustParse("512Mi"),
 				},
 				Requests: corev1.ResourceList{
 					corev1.ResourceCPU:    apiresource.MustParse("300m"),


### PR DESCRIPTION
version checker job is getting OOM on openshift sometimes. The resource requests and limits are same for the version checker job which is not ideal. There should be some wiggle room if there is memory spike at some point, hence increased the resource limits for the version checker job.