### PR TITLE
Add Support for linux arm64 images

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -2,7 +2,8 @@
 # gazelle:proto disable_global
 # gazelle:exclude docs/generated/reference/generate/json_swagger
 
-load("@io_bazel_rules_docker//container:container.bzl", "container_push")
+load("@bazel_skylib//rules:native_binary.bzl", "native_binary")
+load("@aspect_bazel_lib//lib:expand_template.bzl", "expand_template")
 
 # export WORKSPACE so workspace_binary rules can be used outside the root
 exports_files([
@@ -14,16 +15,23 @@ exports_files([
 
 # TODO
 load("@bazel_gazelle//:def.bzl", "gazelle")
+load("@rules_oci//oci:defs.bzl", "oci_push")
 
 gazelle(name = "gazelle")
 
-container_push(
+expand_template(
+    name = "tags",
+    stamp_substitutions = {
+        "APP_VERSION": "{{STABLE_DOCKER_TAG}}",
+    },
+    template = ["APP_VERSION"],
+)
+
+oci_push(
     name = "push_operator_image",
-    format = "Docker",
-    image = "//cmd/cockroach-operator:operator_image",
-    registry = "{STABLE_DOCKER_REGISTRY}",
-    repository = "{STABLE_IMAGE_REPOSITORY}",
-    tag = "{STABLE_DOCKER_TAG}",
+    image = "//cmd/cockroach-operator:index",
+    remote_tags = ":tags",
+    repository = "${DOCKER_REGISTRY}/${DOCKER_IMAGE_REPOSITORY}",
 )
 
 filegroup(

--- a/Makefile
+++ b/Makefile
@@ -330,7 +330,7 @@ release/image:
 	DOCKER_REGISTRY=$(DOCKER_REGISTRY) \
 	DOCKER_IMAGE_REPOSITORY=$(DOCKER_IMAGE_REPOSITORY) \
 	APP_VERSION=$(APP_VERSION) \
-	bazel run --stamp --platforms=@io_bazel_rules_go//go/toolchain:linux_amd64 \
+	bazel run --stamp \
 		//:push_operator_image
 
 #

--- a/cmd/cockroach-operator/BUILD.bazel
+++ b/cmd/cockroach-operator/BUILD.bazel
@@ -1,8 +1,25 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
-load("@io_bazel_rules_docker//container:container.bzl", "container_image")
-load("@io_bazel_rules_docker//go:image.bzl", "go_image")
+load("@rules_oci//oci:defs.bzl", "oci_image", "oci_image_index")
 load("@rules_pkg//:pkg.bzl", "pkg_tar")
-load("@io_bazel_rules_docker//docker/util:run.bzl", "container_run_and_commit_layer")
+load("@aspect_bazel_lib//lib:expand_template.bzl", "expand_template")
+
+expand_template(
+    name = "labels",
+    out = "labels.txt",
+    stamp_substitutions = {
+        "APP_VERSION": "{{STABLE_DOCKER_TAG}}",
+        "NUMBER_COMMITS_ON_BRANCH": "{{NUMBER_COMMITS_ON_BRANCH}}",
+    },
+    template = [
+        "name=CockroachDB Operator",
+        "vendor=Cockroach Labs",
+        "release=NUMBER_COMMITS_ON_BRANCH",
+        "version=APP_VERSION",
+        "summary=CockroachDB is a distributed SQL database",
+        "description=CockroachDB is a PostgreSQL wire-compatible distributed SQL database",
+        "maintainer=Cockroach Labs",
+    ],
+)
 
 go_library(
     name = "go_default_library",
@@ -31,8 +48,20 @@ go_library(
 )
 
 go_binary(
-    name = "cockroach-operator",
+    name = "cockroach-operator-linux-amd64",
+    out = "cockroach-operator",
     embed = [":go_default_library"],
+    goarch = "amd64",
+    goos = "linux",
+    visibility = ["//visibility:public"],
+)
+
+go_binary(
+    name = "cockroach-operator-linux-arm64",
+    out = "cockroach-operator",
+    embed = [":go_default_library"],
+    goarch = "arm64",
+    goos = "linux",
     visibility = ["//visibility:public"],
 )
 
@@ -43,67 +72,48 @@ pkg_tar(
     package_dir = "/licenses",
 )
 
-container_run_and_commit_layer(
-    name = "ubi_update",
-    commands = [
-        "microdnf install yum",
-        "yum -v -y update --all",
-        "microdnf clean all && rm -rf /var/cache/yum",
+oci_image_index(
+    name = "index",
+    images = [
+        ":cockroach_image_linux_amd64",
+        ":cockroach_image_linux_arm64",
     ],
-    image = "@redhat_ubi_minimal//image",
+    visibility = ["//visibility:public"],
 )
 
-container_image(
-    name = "ubi_base_image",
-    architecture = "amd64",
+oci_image(
+    name = "cockroach_image_linux_amd64",
     # References container_pull from WORKSPACE
-    base = "@redhat_ubi_minimal//image",
-    labels = {
-        "name": "CockroachDB Operator",
-        "vendor": "Cockroach Labs",
-        "release": "{NUMBER_COMMITS_ON_BRANCH}",
-        "version": "{STABLE_DOCKER_TAG}",
-        "summary": "CockroachDB is a distributed SQL database",
-        "description": "CockroachDB is a PostgreSQL wire-compatible distributed SQL database",
-    },
-    layers = [
-        ":ubi_update",
-    ],
-    stamp = True,
+    base = "@redhat_ubi_minimal_linux_amd64",
+    labels = ":labels",
     tars = [
         ":licenses",
+        "//cmd/cockroach-operator/linux-amd64:cockroach-linux-amd64-tar",
+        ":operator_image_linux_amd64",
     ],
 )
 
-#  fetch_crdb downloads the cockroach binary
-genrule(
-    name = "fetch_crdb_container",
-    srcs = ["@crdb_linux//:file"],
-    outs = ["cockroach"],
-    cmd = "cp $(SRCS) $@",
+oci_image(
+    name = "cockroach_image_linux_arm64",
+    # References container_pull from WORKSPACE
+    base = "@redhat_ubi_minimal_linux_arm64",
+    labels = ":labels",
+    tars = [
+        ":licenses",
+        "//cmd/cockroach-operator/linux-arm64:cockroach-linux-arm64-tar",
+        ":operator_image_linux_arm64",
+    ],
+)
+
+pkg_tar(
+    name = "operator_image_linux_amd64",
+    srcs = [":cockroach-operator-linux-amd64"],
     visibility = ["//visibility:public"],
 )
 
 pkg_tar(
-    name = "cockroach-tar",
-    srcs = [":fetch_crdb_container"],
-    mode = "0755",
-    package_dir = "/usr/local/bin",
-)
-
-# include cockroach in an image
-container_image(
-    name = "cockroach_image",
-    base = ":ubi_base_image",
-    tars = [
-        ":cockroach-tar",
-    ],
-)
-
-go_image(
-    name = "operator_image",
-    base = ":cockroach_image",  # include the cr binary
-    binary = ":cockroach-operator",
+    name = "operator_image_linux_arm64",
+    srcs = [":cockroach-operator-linux-arm64"],
     visibility = ["//visibility:public"],
 )
 
@@ -116,7 +126,11 @@ filegroup(
 
 filegroup(
     name = "all-srcs",
-    srcs = [":package-srcs"],
+    srcs = [
+        ":package-srcs",
+        "//cmd/cockroach-operator/linux-amd64:all-srcs",
+        "//cmd/cockroach-operator/linux-arm64:all-srcs",
+    ],
     tags = ["automanaged"],
     visibility = ["//visibility:public"],
 )

--- a/cmd/cockroach-operator/linux-amd64/BUILD.bazel
+++ b/cmd/cockroach-operator/linux-amd64/BUILD.bazel
@@ -1,0 +1,31 @@
+load("@rules_pkg//:pkg.bzl", "pkg_tar")
+
+genrule(
+    name = "fetch_linux_amd64_crdb_container",
+    srcs = ["@crdb_linux_amd64//:file"],
+    outs = ["cockroach"],
+    cmd = "cp $(SRCS) $@",
+    visibility = ["//visibility:public"],
+)
+
+pkg_tar(
+    name = "cockroach-linux-amd64-tar",
+    srcs = [":fetch_linux_amd64_crdb_container"],
+    mode = "0755",
+    package_dir = "/usr/local/bin",
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/cmd/cockroach-operator/linux-arm64/BUILD.bazel
+++ b/cmd/cockroach-operator/linux-arm64/BUILD.bazel
@@ -1,0 +1,31 @@
+load("@rules_pkg//:pkg.bzl", "pkg_tar")
+
+genrule(
+    name = "fetch_linux_arm64_crdb_container",
+    srcs = ["@crdb_linux_arm64//:file"],
+    outs = ["cockroach"],
+    cmd = "cp $(SRCS) $@",
+    visibility = ["//visibility:public"],
+)
+
+pkg_tar(
+    name = "cockroach-linux-arm64-tar",
+    srcs = [":fetch_linux_arm64_crdb_container"],
+    mode = "0755",
+    package_dir = "/usr/local/bin",
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "package-srcs",
+    srcs = glob(["**"]),
+    tags = ["automanaged"],
+    visibility = ["//visibility:private"],
+)
+
+filegroup(
+    name = "all-srcs",
+    srcs = [":package-srcs"],
+    tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)

--- a/config/manager/deployment.yaml
+++ b/config/manager/deployment.yaml
@@ -33,6 +33,8 @@ spec:
         - name: cockroach-operator
           image: cockroachdb/cockroach-operator:latest
           imagePullPolicy: IfNotPresent
+          command:
+            - ./cockroach-operator
           args:
             - -zap-log-level
             - info

--- a/hack/bin/BUILD.bazel
+++ b/hack/bin/BUILD.bazel
@@ -233,7 +233,7 @@ genrule(
     srcs = select({
         ":m1": ["@crdb_darwin//:file"],
         ":darwin": ["@crdb_darwin//:file"],
-        ":k8": ["@crdb_linux//:file"],
+        ":k8": ["@crdb_linux_amd64//:file"],
     }),
     outs = ["cockroach"],
     cmd = "cp $(SRCS) $@",

--- a/hack/bin/deps.bzl
+++ b/hack/bin/deps.bzl
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file", "http_archive")
-load("@io_bazel_rules_docker//container:container.bzl", "container_pull")
 load("@bazel_gazelle//:deps.bzl", "go_repository")
 
 # This controls the version for all openshift binaries (opm, oc, opernshift-install, etc.)
@@ -456,13 +455,13 @@ def install_preflight():
 def install_crdb():
     http_archive(
        name = "crdb_darwin", # todo fix or remove
-       sha256 = "bbbd0a75f81d3df4acd139fdc7f0961480161454db24f25263c9276c3959db54",
-       urls = ["https://binaries.cockroachdb.com/cockroach-v21.2.0.darwin-10.9-amd64.tgz"],
+       sha256 = "79fb1669678b802ae891ec3e005efa801c0f970fec4eb6af7ac89cdb6b991b42",
+       urls = ["https://binaries.cockroachdb.com/cockroach-v22.2.19.darwin-10.9-amd64.tgz"],
        build_file_content = """
 filegroup(
     name = "file",
     srcs = [
-        "cockroach-v21.2.0.darwin-10.9-amd64/cockroach",
+        "cockroach-v22.2.19.darwin-10.9-amd64/cockroach",
     ],
     visibility = ["//visibility:public"],
 )
@@ -470,14 +469,29 @@ filegroup(
    )
 
     http_archive(
-        name = "crdb_linux",
-        sha256 = "c9fda447b9db98ade4444f5855ceb6ffe94549a20bd7cad8fdf70c398add8c02",
-        urls = ["https://binaries.cockroachdb.com/cockroach-v21.2.0.linux-amd64.tgz"],
+           name = "crdb_linux_arm64",
+           sha256 = "9fefea6e5c9715396648bb8865f55b10946b758de7997ccddb4876db56bcbb7a",
+           urls = ["https://binaries.cockroachdb.com/cockroach-v22.2.19.linux-arm64.tgz"],
+           build_file_content = """
+filegroup(
+     name = "file",
+     srcs = [
+            "cockroach-v22.2.19.linux-arm64/cockroach",
+     ],
+     visibility = ["//visibility:public"],
+)
+""",
+)
+
+    http_archive(
+        name = "crdb_linux_amd64",
+        sha256 = "3b48271a6fd62c2e5866b97ff9d5790d945a1d35ebf1815dc972d94327b4355b",
+        urls = ["https://binaries.cockroachdb.com/cockroach-v22.2.19.linux-amd64.tgz"],
         build_file_content = """
 filegroup(
     name = "file",
     srcs = [
-        "cockroach-v21.2.0.linux-amd64/cockroach",
+        "cockroach-v22.2.19.linux-amd64/cockroach",
     ],
     visibility = ["//visibility:public"],
 )

--- a/install/operator.yaml
+++ b/install/operator.yaml
@@ -384,6 +384,8 @@ spec:
       - args:
         - -zap-log-level
         - info
+        command:
+        - ./cockroach-operator
         env:
         - name: RELATED_IMAGE_COCKROACH_v21_1_0
           value: cockroachdb/cockroach:v21.1.0


### PR DESCRIPTION
- Add support for linux arm64 images.
- Upgrade cockroach binary from v21.2.0 to v22.2.19 as it has official support of arm64 image.