### PR TITLE
Allow Innovative upgrades to be skipped during upgrade

### DIFF
--- a/pkg/update/internal.go
+++ b/pkg/update/internal.go
@@ -25,6 +25,16 @@ const (
 	AdminRole   = "admin"
 )
 
+// ReleaseType represents the type of a release
+type ReleaseType int
+
+const (
+	// Regular releases are mandatory upgrades that cannot be skipped.
+	Regular ReleaseType = iota
+	// Innovative releases are optional upgrades that can be skipped.
+	Innovative
+)
+
 // internalUsers is a set of SQL users created as part of the managed service, not to be used
 // by customers. This struct is used to hide specific users in the console.
 var internalUsers = map[string]struct{}{

--- a/pkg/update/update_cockroach_version.go
+++ b/pkg/update/update_cockroach_version.go
@@ -94,7 +94,7 @@ func UpdateClusterCockroachVersion(
 
 	l.V(int(zapcore.InfoLevel)).Info("starting upgrade")
 
-	if isForwardOneMajorVersion(update.WantVersion, update.CurrentVersion) {
+	if isMajorUpgradeAllowed(update.WantVersion, update.CurrentVersion) {
 		if err := setDowngradeOption(ctx, update.WantVersion, update.CurrentVersion, update.Db, l); err != nil {
 			return errors.Wrapf(err, "setting downgrade option for major roll forward failed")
 		}
@@ -206,7 +206,7 @@ func kindAndCheckPreserveDowngradeSetting(
 	if isPatch(wantVersion, currentVersion) {
 		l.V(int(zapcore.DebugLevel)).Info("patch upgrade")
 		return "PATCH", nil
-	} else if isForwardOneMajorVersion(wantVersion, currentVersion) {
+	} else if isMajorUpgradeAllowed(wantVersion, currentVersion) {
 		l.V(int(zapcore.DebugLevel)).Info("major upgrade")
 		s := "MAJOR_UPGRADE"
 		preserve, err := preserveDowngradeSetting(ctx, db)
@@ -226,7 +226,7 @@ func kindAndCheckPreserveDowngradeSetting(
 			}
 		}
 		return s, nil
-	} else if isBackOneMajorVersion(wantVersion, currentVersion) {
+	} else if isMajorRollbackAllowed(wantVersion, currentVersion) {
 		l.V(int(zapcore.DebugLevel)).Info("major rollback")
 		return CheckDowngradeSetting(ctx, wantVersion, currentVersion, db)
 	}

--- a/pkg/update/update_cockroach_version_common_test.go
+++ b/pkg/update/update_cockroach_version_common_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package update
 
 import (
+	"reflect"
 	"testing"
 
 	semver "github.com/Masterminds/semver/v3"
@@ -95,6 +96,18 @@ func TestIsForwardOneMajorVersion(t *testing.T) {
 			semver.MustParse("19.3.5"),
 			false,
 		},
+		{
+			"is skipping innovative release",
+			semver.MustParse("24.3"),
+			semver.MustParse("24.1"),
+			true,
+		},
+		{
+			"is skipping innovative and regular release",
+			semver.MustParse("25.1"),
+			semver.MustParse("24.1"),
+			false,
+		},
 	}
 
 	for _, test := range tests {
@@ -135,11 +148,123 @@ func TestIsBackOneMajorVersion(t *testing.T) {
 			semver.MustParse("19.3.5"),
 			false,
 		},
+		{
+			"is skipping innovative release",
+			semver.MustParse("24.1"),
+			semver.MustParse("24.3"),
+			true,
+		},
+		{
+			"is skipping innovative and regular release",
+			semver.MustParse("24.1"),
+			semver.MustParse("25.1"),
+			false,
+		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) {
 			require.True(t, isBackOneMajorVersion(test.wantVersion, test.currentVersion) == test.result, "isBackwardOneMajorVersion test failed")
+		})
+	}
+}
+
+func TestGetNextReleases(t *testing.T) {
+	tests := []struct {
+		description    string
+		currentVersion string
+		result         []string
+	}{
+		{
+			"returns the possible upgrade targets for 24.1",
+			"24.1",
+			[]string{"24.2", "24.3"},
+		},
+		{
+			"returns the possible upgrade targets for 24.3",
+			"24.3",
+			[]string{"25.1", "25.2"},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+			require.True(t, reflect.DeepEqual(getNextReleases(test.currentVersion), test.result),
+				"getNextReleases test failed")
+		})
+	}
+}
+
+func TestGetPreviousReleases(t *testing.T) {
+	tests := []struct {
+		description    string
+		currentVersion string
+		result         []string
+	}{
+		{
+			"returns the possible rollback targets for 24.3",
+			"24.3",
+			[]string{"24.2", "24.1"},
+		},
+		{
+			"returns the possible upgrade targets for 25.2",
+			"25.2",
+			[]string{"25.1", "24.3"},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+			require.True(t, reflect.DeepEqual(getPreviousReleases(test.currentVersion), test.result),
+				"getPreviousReleases test failed")
+		})
+	}
+}
+
+func TestGenerateReleases(t *testing.T) {
+	tests := []struct {
+		description string
+		uptoYear    int
+		result      []string
+	}{
+		{
+			"returns possible releases till 2025",
+			25,
+			[]string{"24.1", "24.2", "24.3", "25.1", "25.2", "25.3", "25.4"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+			require.True(t, reflect.DeepEqual(generateReleases(test.uptoYear), test.result), "generateReleases test failed")
+		})
+	}
+}
+
+func TestGetReleaseType(t *testing.T) {
+	tests := []struct {
+		description  string
+		major, minor int
+		result       ReleaseType
+	}{
+		{
+			"returns releaseType of a 24.2",
+			24, 2,
+			Innovative,
+		},
+		{
+			"returns releaseType of a 25.1",
+			24, 2,
+			Innovative,
+		},
+		{
+			"returns releaseType of a 24.3",
+			24, 3,
+			Regular,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+			require.True(t, reflect.DeepEqual(getReleaseType(test.major, test.minor), test.result),
+				"getReleaseType test failed")
 		})
 	}
 }

--- a/pkg/update/update_cockroach_version_common_test.go
+++ b/pkg/update/update_cockroach_version_common_test.go
@@ -59,7 +59,7 @@ func TestIsPatch(t *testing.T) {
 
 }
 
-func TestIsForwardOneMajorVersion(t *testing.T) {
+func TestIsMajorUpgradeAllowed(t *testing.T) {
 	tests := []struct {
 		description    string
 		wantVersion    *semver.Version
@@ -97,9 +97,15 @@ func TestIsForwardOneMajorVersion(t *testing.T) {
 			false,
 		},
 		{
-			"is skipping innovative release",
+			"is skipping innovative release same year",
 			semver.MustParse("24.3"),
 			semver.MustParse("24.1"),
+			true,
+		},
+		{
+			"is skipping innovative release next year",
+			semver.MustParse("25.2"),
+			semver.MustParse("24.3"),
 			true,
 		},
 		{
@@ -112,12 +118,12 @@ func TestIsForwardOneMajorVersion(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) {
-			require.True(t, isForwardOneMajorVersion(test.wantVersion, test.currentVersion) == test.result, "isForwardOneMajorVersion test failed")
+			require.True(t, isMajorUpgradeAllowed(test.wantVersion, test.currentVersion) == test.result, "isMajorUpgradeAllowed test failed")
 		})
 	}
 }
 
-func TestIsBackOneMajorVersion(t *testing.T) {
+func TestIsMajorRollbackAllowed(t *testing.T) {
 	tests := []struct {
 		description    string
 		wantVersion    *semver.Version
@@ -149,9 +155,15 @@ func TestIsBackOneMajorVersion(t *testing.T) {
 			false,
 		},
 		{
-			"is skipping innovative release",
+			"is skipping innovative release for same year",
 			semver.MustParse("24.1"),
 			semver.MustParse("24.3"),
+			true,
+		},
+		{
+			"is skipping innovative release previous year",
+			semver.MustParse("24.3"),
+			semver.MustParse("25.2"),
 			true,
 		},
 		{
@@ -164,7 +176,7 @@ func TestIsBackOneMajorVersion(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) {
-			require.True(t, isBackOneMajorVersion(test.wantVersion, test.currentVersion) == test.result, "isBackwardOneMajorVersion test failed")
+			require.True(t, isMajorRollbackAllowed(test.wantVersion, test.currentVersion) == test.result, "isMajorRollbackAllowed test failed")
 		})
 	}
 }
@@ -252,7 +264,7 @@ func TestGetReleaseType(t *testing.T) {
 		},
 		{
 			"returns releaseType of a 25.1",
-			24, 2,
+			25, 1,
 			Innovative,
 		},
 		{


### PR DESCRIPTION
Fixes: #1088 

1. Allow Innovative upgrades to be skipped during upgrade process.
2. Added e2e tests to for the same.
