### PR TITLE
Add priorityClassName as an optional configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 # [Unreleased](https://github.com/cockroachdb/cockroach-operator/compare/v2.18.1...master)
+* Added the priorityClassName configuration
 
 # [v2.18.1](https://github.com/cockroachdb/cockroach-operator/compare/v2.18.0...v2.18.1)
 * Added support for openshift 4.19

--- a/apis/v1alpha1/cluster_types.go
+++ b/apis/v1alpha1/cluster_types.go
@@ -99,6 +99,10 @@ type CrdbClusterSpec struct {
 	// Default: ""
 	// +optional
 	CockroachDBVersion string `json:"cockroachDBVersion,omitempty"`
+	// (Optional) PriorityClassName sets the priority class of pods
+	// Default: ""
+	// +optional
+	PriorityClassName string `json:"priorityClassName,omitempty"`
 	// (Optional) PodEnvVariables is a slice of environment variables that are added to the pods
 	// Default: (empty list)
 	// +optional

--- a/config/crd/bases/crdb.cockroachlabs.com_crdbclusters.yaml
+++ b/config/crd/bases/crdb.cockroachlabs.com_crdbclusters.yaml
@@ -918,6 +918,10 @@ spec:
                 description: '(Optional) CockroachDBVersion sets the explicit version
                   of the cockroachDB image Default: ""'
                 type: string
+              priorityClassName:
+                description: '(Optional) PriorityClassName sets the priority class of 
+                  pods Default: ""'
+                type: string
               dataStore:
                 description: Database disk storage configuration
                 properties:

--- a/config/crd/bases/crdb.cockroachlabs.com_crdbclusters.yaml
+++ b/config/crd/bases/crdb.cockroachlabs.com_crdbclusters.yaml
@@ -918,10 +918,6 @@ spec:
                 description: '(Optional) CockroachDBVersion sets the explicit version
                   of the cockroachDB image Default: ""'
                 type: string
-              priorityClassName:
-                description: '(Optional) PriorityClassName sets the priority class of 
-                  pods Default: ""'
-                type: string
               dataStore:
                 description: Database disk storage configuration
                 properties:
@@ -1366,6 +1362,10 @@ spec:
                   - name
                   type: object
                 type: array
+              priorityClassName:
+                description: '(Optional) PriorityClassName sets the priority class
+                  of pods Default: ""'
+                type: string
               resources:
                 description: '(Optional) Database container resource limits. Any container
                   limits can be specified. Default: (not specified)'

--- a/install/crds.yaml
+++ b/install/crds.yaml
@@ -916,6 +916,10 @@ spec:
                 description: '(Optional) CockroachDBVersion sets the explicit version
                   of the cockroachDB image Default: ""'
                 type: string
+              priorityClassName:
+                description: '(Optional) PriorityClassName sets the priority class of 
+                  pods Default: ""'
+                type: string
               dataStore:
                 description: Database disk storage configuration
                 properties:

--- a/install/crds.yaml
+++ b/install/crds.yaml
@@ -916,10 +916,6 @@ spec:
                 description: '(Optional) CockroachDBVersion sets the explicit version
                   of the cockroachDB image Default: ""'
                 type: string
-              priorityClassName:
-                description: '(Optional) PriorityClassName sets the priority class of 
-                  pods Default: ""'
-                type: string
               dataStore:
                 description: Database disk storage configuration
                 properties:
@@ -1364,6 +1360,10 @@ spec:
                   - name
                   type: object
                 type: array
+              priorityClassName:
+                description: '(Optional) PriorityClassName sets the priority class
+                  of pods Default: ""'
+                type: string
               resources:
                 description: '(Optional) Database container resource limits. Any container
                   limits can be specified. Default: (not specified)'

--- a/pkg/resource/job.go
+++ b/pkg/resource/job.go
@@ -121,6 +121,10 @@ func (b JobBuilder) buildPodTemplate() corev1.PodTemplateSpec {
 		pod.Spec.ImagePullSecrets = []corev1.LocalObjectReference{local}
 	}
 
+	if b.Spec().PriorityClassName != "" {
+		pod.Spec.PriorityClassName = b.Spec().PriorityClassName
+	}
+
 	return pod
 }
 

--- a/pkg/resource/statefulset.go
+++ b/pkg/resource/statefulset.go
@@ -245,6 +245,10 @@ func (b StatefulSetBuilder) makePodTemplate() corev1.PodTemplateSpec {
 		pod.Spec.ImagePullSecrets = []corev1.LocalObjectReference{local}
 	}
 
+	if b.Spec().PriorityClassName != "" {
+		pod.Spec.PriorityClassName = b.Spec().PriorityClassName
+	}
+
 	return pod
 }
 


### PR DESCRIPTION
With this PR, users can specify the [priorityClassName](https://kubernetes.io/docs/concepts/scheduling-eviction/pod-priority-preemption/) for the pods:

```
apiVersion: crdb.cockroachlabs.com/v1alpha1
kind: CrdbCluster
metadata:
  name: cockroachdb
spec:
  priorityClassName: "a-priority-class-name"
```

Addressing Issue https://github.com/cockroachdb/cockroach-operator/issues/1103.

**Checklist**

* [x] I have added these changes to the changelog (or it's not applicable).
