### PR TITLE
Add human readble timestamp format in operator logs

### DIFF
--- a/cmd/cockroach-operator/BUILD.bazel
+++ b/cmd/cockroach-operator/BUILD.bazel
@@ -46,6 +46,7 @@ go_library(
         "@io_k8s_sigs_controller_runtime//pkg/log/zap:go_default_library",
         "@io_k8s_sigs_controller_runtime//pkg/metrics/server:go_default_library",
         "@io_k8s_sigs_controller_runtime//pkg/webhook:go_default_library",
+        "@org_uber_go_zap//zapcore:go_default_library",
     ],
 )
 
@@ -118,5 +119,11 @@ filegroup(
         "//cmd/cockroach-operator/linux-arm64:all-srcs",
     ],
     tags = ["automanaged"],
+    visibility = ["//visibility:public"],
+)
+
+go_binary(
+    name = "cockroach-operator",
+    embed = [":go_default_library"],
     visibility = ["//visibility:public"],
 )

--- a/cmd/cockroach-operator/main.go
+++ b/cmd/cockroach-operator/main.go
@@ -33,6 +33,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 	"sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
+	"go.uber.org/zap/zapcore"
 )
 
 const (
@@ -57,7 +58,9 @@ func main() {
 	var err error
 
 	// use zap logging cli options
-	opts := zap.Options{}
+	opts := zap.Options{
+		TimeEncoder: zapcore.RFC3339TimeEncoder,
+	}
 	opts.BindFlags(flag.CommandLine)
 
 	flag.StringVar(&metricsAddr, "metrics-addr", ":8080", "The address the metric endpoint binds to.")

--- a/config/manager/patches/image.yaml
+++ b/config/manager/patches/image.yaml
@@ -278,6 +278,8 @@ spec:
               value: cockroachdb/cockroach:v24.1.18
             - name: RELATED_IMAGE_COCKROACH_v24_1_19
               value: cockroachdb/cockroach:v24.1.19
+            - name: RELATED_IMAGE_COCKROACH_v24_1_20
+              value: cockroachdb/cockroach:v24.1.20
             - name: RELATED_IMAGE_COCKROACH_v24_2_0
               value: cockroachdb/cockroach:v24.2.0
             - name: RELATED_IMAGE_COCKROACH_v24_2_2
@@ -338,7 +340,11 @@ spec:
               value: cockroachdb/cockroach:v25.1.6
             - name: RELATED_IMAGE_COCKROACH_v25_1_7
               value: cockroachdb/cockroach:v25.1.7
+            - name: RELATED_IMAGE_COCKROACH_v25_1_8
+              value: cockroachdb/cockroach:v25.1.8
             - name: RELATED_IMAGE_COCKROACH_v25_2_0
               value: cockroachdb/cockroach:v25.2.0
             - name: RELATED_IMAGE_COCKROACH_v25_2_1
               value: cockroachdb/cockroach:v25.2.1
+            - name: RELATED_IMAGE_COCKROACH_v25_2_2
+              value: cockroachdb/cockroach:v25.2.2

--- a/config/manifests/bases/cockroach-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/cockroach-operator.clusterserviceversion.yaml
@@ -451,6 +451,8 @@ spec:
     name: RELATED_IMAGE_COCKROACH_v24_1_18
   - image: registry.connect.redhat.com/cockroachdb/cockroach@sha256:68fe64fe3e112288ccfc2a7dffd69b9b2786a5da3d3bdedd6addf41659d460c9
     name: RELATED_IMAGE_COCKROACH_v24_1_19
+  - image: registry.connect.redhat.com/cockroachdb/cockroach@sha256:1a6e2fe24ad52913e2160f85b9fe665a4e4c4d79b164b4b899f69dd9d92f999e
+    name: RELATED_IMAGE_COCKROACH_v24_1_20
   - image: registry.connect.redhat.com/cockroachdb/cockroach@sha256:cad60044ad6573bd80b65e892a9ec0510dbe4fcbbfc6b51010ecf419f56f1024
     name: RELATED_IMAGE_COCKROACH_v24_2_0
   - image: registry.connect.redhat.com/cockroachdb/cockroach@sha256:08cec123813304ab03bd66d72a09949667a874a42320bedafda391ebcdb2e56c
@@ -511,10 +513,14 @@ spec:
     name: RELATED_IMAGE_COCKROACH_v25_1_6
   - image: registry.connect.redhat.com/cockroachdb/cockroach@sha256:cc20270212f01fc231ff788e20b0476b8228c440bfc40430c0836d5eb702a042
     name: RELATED_IMAGE_COCKROACH_v25_1_7
+  - image: registry.connect.redhat.com/cockroachdb/cockroach@sha256:e18d73af3257c8cdf00245f2f718b56667524c1cc69d3db28e9b868a539ae16f
+    name: RELATED_IMAGE_COCKROACH_v25_1_8
   - image: registry.connect.redhat.com/cockroachdb/cockroach@sha256:c74cf927a2b2c5098ad74ad0880996f8b042186a9911d888a231ef5b9e2a0715
     name: RELATED_IMAGE_COCKROACH_v25_2_0
   - image: registry.connect.redhat.com/cockroachdb/cockroach@sha256:3b78a4d3864e16d270979d9d7756012abf09e6cdb7f1eb4832f6497c26281099
     name: RELATED_IMAGE_COCKROACH_v25_2_1
+  - image: registry.connect.redhat.com/cockroachdb/cockroach@sha256:f42fa22aac3cc41ce72e144a72530ffbee765a392b24593dafd06cc098f8410b
+    name: RELATED_IMAGE_COCKROACH_v25_2_2
   - image: RH_COCKROACH_OP_IMAGE_PLACEHOLDER
     name: RELATED_IMAGE_COCKROACH_OPERATOR
   version: 0.0.0

--- a/config/manifests/patches/deployment_patch.yaml
+++ b/config/manifests/patches/deployment_patch.yaml
@@ -287,6 +287,8 @@ spec:
               value: registry.connect.redhat.com/cockroachdb/cockroach@sha256:8f1f2fd1aca914a1ef007117c85ac944055bbfb873a468a7374d239ef20b065e
             - name: RELATED_IMAGE_COCKROACH_v24_1_19
               value: registry.connect.redhat.com/cockroachdb/cockroach@sha256:68fe64fe3e112288ccfc2a7dffd69b9b2786a5da3d3bdedd6addf41659d460c9
+            - name: RELATED_IMAGE_COCKROACH_v24_1_20
+              value: registry.connect.redhat.com/cockroachdb/cockroach@sha256:1a6e2fe24ad52913e2160f85b9fe665a4e4c4d79b164b4b899f69dd9d92f999e
             - name: RELATED_IMAGE_COCKROACH_v24_2_0
               value: registry.connect.redhat.com/cockroachdb/cockroach@sha256:cad60044ad6573bd80b65e892a9ec0510dbe4fcbbfc6b51010ecf419f56f1024
             - name: RELATED_IMAGE_COCKROACH_v24_2_2
@@ -347,10 +349,14 @@ spec:
               value: registry.connect.redhat.com/cockroachdb/cockroach@sha256:e8f26fd132affbaeb8ef6b1807a646c83b301e5dc334a592dfb2cf8dc3dbaf10
             - name: RELATED_IMAGE_COCKROACH_v25_1_7
               value: registry.connect.redhat.com/cockroachdb/cockroach@sha256:cc20270212f01fc231ff788e20b0476b8228c440bfc40430c0836d5eb702a042
+            - name: RELATED_IMAGE_COCKROACH_v25_1_8
+              value: registry.connect.redhat.com/cockroachdb/cockroach@sha256:e18d73af3257c8cdf00245f2f718b56667524c1cc69d3db28e9b868a539ae16f
             - name: RELATED_IMAGE_COCKROACH_v25_2_0
               value: registry.connect.redhat.com/cockroachdb/cockroach@sha256:c74cf927a2b2c5098ad74ad0880996f8b042186a9911d888a231ef5b9e2a0715
             - name: RELATED_IMAGE_COCKROACH_v25_2_1
               value: registry.connect.redhat.com/cockroachdb/cockroach@sha256:3b78a4d3864e16d270979d9d7756012abf09e6cdb7f1eb4832f6497c26281099
+            - name: RELATED_IMAGE_COCKROACH_v25_2_2
+              value: registry.connect.redhat.com/cockroachdb/cockroach@sha256:f42fa22aac3cc41ce72e144a72530ffbee765a392b24593dafd06cc098f8410b
             - name: RELATED_IMAGE_COCKROACH_OPERATOR
               value: RH_COCKROACH_OP_IMAGE_PLACEHOLDER
           image: RH_COCKROACH_OP_IMAGE_PLACEHOLDER

--- a/config/samples/crdb-tls-example.yaml
+++ b/config/samples/crdb-tls-example.yaml
@@ -19,7 +19,7 @@ kind: CrdbCluster
 metadata:
   name: crdb-tls-example
 spec:
-  cockroachDBVersion: v25.2.1
+  cockroachDBVersion: v25.2.2
   dataStore:
     pvc:
       spec:

--- a/crdb-versions.yaml
+++ b/crdb-versions.yaml
@@ -400,6 +400,9 @@ CrdbVersions:
 - image: cockroachdb/cockroach:v24.1.19
   redhatImage: registry.connect.redhat.com/cockroachdb/cockroach@sha256:68fe64fe3e112288ccfc2a7dffd69b9b2786a5da3d3bdedd6addf41659d460c9
   tag: v24.1.19
+- image: cockroachdb/cockroach:v24.1.20
+  redhatImage: registry.connect.redhat.com/cockroachdb/cockroach@sha256:1a6e2fe24ad52913e2160f85b9fe665a4e4c4d79b164b4b899f69dd9d92f999e
+  tag: v24.1.20
 - image: cockroachdb/cockroach:v24.2.0
   redhatImage: registry.connect.redhat.com/cockroachdb/cockroach@sha256:cad60044ad6573bd80b65e892a9ec0510dbe4fcbbfc6b51010ecf419f56f1024
   tag: v24.2.0
@@ -490,9 +493,15 @@ CrdbVersions:
 - image: cockroachdb/cockroach:v25.1.7
   redhatImage: registry.connect.redhat.com/cockroachdb/cockroach@sha256:cc20270212f01fc231ff788e20b0476b8228c440bfc40430c0836d5eb702a042
   tag: v25.1.7
+- image: cockroachdb/cockroach:v25.1.8
+  redhatImage: registry.connect.redhat.com/cockroachdb/cockroach@sha256:e18d73af3257c8cdf00245f2f718b56667524c1cc69d3db28e9b868a539ae16f
+  tag: v25.1.8
 - image: cockroachdb/cockroach:v25.2.0
   redhatImage: registry.connect.redhat.com/cockroachdb/cockroach@sha256:c74cf927a2b2c5098ad74ad0880996f8b042186a9911d888a231ef5b9e2a0715
   tag: v25.2.0
 - image: cockroachdb/cockroach:v25.2.1
   redhatImage: registry.connect.redhat.com/cockroachdb/cockroach@sha256:3b78a4d3864e16d270979d9d7756012abf09e6cdb7f1eb4832f6497c26281099
   tag: v25.2.1
+- image: cockroachdb/cockroach:v25.2.2
+  redhatImage: registry.connect.redhat.com/cockroachdb/cockroach@sha256:f42fa22aac3cc41ce72e144a72530ffbee765a392b24593dafd06cc098f8410b
+  tag: v25.2.2

--- a/examples/client-secure-operator.yaml
+++ b/examples/client-secure-operator.yaml
@@ -23,7 +23,7 @@ spec:
   serviceAccountName: cockroachdb-sa
   containers:
   - name: cockroachdb-client-secure
-    image: cockroachdb/cockroach:v25.2.1
+    image: cockroachdb/cockroach:v25.2.2
     imagePullPolicy: IfNotPresent
     volumeMounts:
     - name: client-certs

--- a/examples/example.yaml
+++ b/examples/example.yaml
@@ -40,9 +40,9 @@ spec:
       memory: 8Gi
   tlsEnabled: true
 # You can set either a version of the db or a specific image name
-# cockroachDBVersion: v25.2.1
+# cockroachDBVersion: v25.2.2
   image:
-    name: cockroachdb/cockroach:v25.2.1
+    name: cockroachdb/cockroach:v25.2.2
   # nodes refers to the number of crdb pods that are created
   # via the statefulset
   nodes: 3

--- a/examples/smoketest.yaml
+++ b/examples/smoketest.yaml
@@ -39,5 +39,5 @@ spec:
       memory: 300Mi
   tlsEnabled: true
   image:
-    name: cockroachdb/cockroach:v25.2.1
+    name: cockroachdb/cockroach:v25.2.2
   nodes: 3

--- a/install/operator.yaml
+++ b/install/operator.yaml
@@ -637,6 +637,8 @@ spec:
           value: cockroachdb/cockroach:v24.1.18
         - name: RELATED_IMAGE_COCKROACH_v24_1_19
           value: cockroachdb/cockroach:v24.1.19
+        - name: RELATED_IMAGE_COCKROACH_v24_1_20
+          value: cockroachdb/cockroach:v24.1.20
         - name: RELATED_IMAGE_COCKROACH_v24_2_0
           value: cockroachdb/cockroach:v24.2.0
         - name: RELATED_IMAGE_COCKROACH_v24_2_2
@@ -697,10 +699,14 @@ spec:
           value: cockroachdb/cockroach:v25.1.6
         - name: RELATED_IMAGE_COCKROACH_v25_1_7
           value: cockroachdb/cockroach:v25.1.7
+        - name: RELATED_IMAGE_COCKROACH_v25_1_8
+          value: cockroachdb/cockroach:v25.1.8
         - name: RELATED_IMAGE_COCKROACH_v25_2_0
           value: cockroachdb/cockroach:v25.2.0
         - name: RELATED_IMAGE_COCKROACH_v25_2_1
           value: cockroachdb/cockroach:v25.2.1
+        - name: RELATED_IMAGE_COCKROACH_v25_2_2
+          value: cockroachdb/cockroach:v25.2.2
         - name: OPERATOR_NAME
           value: cockroachdb
         - name: POD_NAME


### PR DESCRIPTION
Attached screenshot with readable timestamp
<img width="1501" height="686" alt="Screenshot 2025-07-18 at 10 26 35 AM" src="https://github.com/user-attachments/assets/97a0a0fe-a146-44a9-888e-fc60a93c601c" />
