### PR TITLE
Fix cockroachdb version upgrade with fips image

### DIFF
--- a/pkg/actor/partitioned_update.go
+++ b/pkg/actor/partitioned_update.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"strings"
 	"time"
 
 	"github.com/Masterminds/semver/v3"
@@ -110,7 +109,6 @@ func (up *partitionedUpdate) Act(ctx context.Context, cluster *resource.Cluster,
 		log.Info("no version changes needed")
 		return nil
 	}
-	containerWanted = getImageNameNoVersion(containerWanted)
 
 	currentVersion, err := semver.NewVersion(currentVersionCalFmtStr)
 	if err != nil {
@@ -220,19 +218,6 @@ func (up *partitionedUpdate) Act(ctx context.Context, cluster *resource.Cluster,
 func inK8s(file string) bool {
 	_, err := os.Stat(file)
 	return !os.IsNotExist(err)
-}
-
-func getImageNameNoVersion(image string) string {
-	// if somehow this arrives as sha256 we do not extract version
-	if strings.Contains(image, "@sha256") {
-		return image
-	}
-	i := strings.LastIndex(image, ":")
-	if i == -1 {
-		return image
-	}
-
-	return image[:i]
 }
 
 func statefulSetIsUpdating(ss *appsv1.StatefulSet) bool {

--- a/pkg/actor/partitioned_update_test.go
+++ b/pkg/actor/partitioned_update_test.go
@@ -19,8 +19,6 @@ package actor
 import (
 	"os"
 	"testing"
-
-	"github.com/stretchr/testify/assert"
 )
 
 func TestDeployedInCluster(t *testing.T) {
@@ -39,32 +37,5 @@ func TestDeployedInCluster(t *testing.T) {
 
 	if !inK8s {
 		t.Fatal("we should find the file")
-	}
-}
-
-func TestGetImageNameNoVersion(t *testing.T) {
-	type testCase struct {
-		Name              string
-		ImageName         string
-		ExpectedImageName string
-	}
-	tests := []testCase{
-		{
-			Name:              "should_keep_the_sha256_format_complete",
-			ImageName:         "cockroachdb/cockroach@sha256:a1ef571ff3b47b395084d2f29abbc7706be36a826a618a794697d90a03615ada",
-			ExpectedImageName: "cockroachdb/cockroach@sha256:a1ef571ff3b47b395084d2f29abbc7706be36a826a618a794697d90a03615ada",
-		},
-		{
-			Name:              "should_remove_the_version_for_non_sha256_format_of_the_image",
-			ImageName:         "cockroachdb/cockroach:v20.2.0",
-			ExpectedImageName: "cockroachdb/cockroach",
-		},
-	}
-	for _, tc := range tests {
-		t.Run(tc.Name, func(t *testing.T) {
-			actual := getImageNameNoVersion(tc.ImageName)
-			assert.NotEmpty(t, actual, "container image cannot be empty")
-			assert.Equal(t, actual, tc.ExpectedImageName, "container image not set correctly")
-		})
 	}
 }

--- a/pkg/controller/cluster_controller_test.go
+++ b/pkg/controller/cluster_controller_test.go
@@ -82,7 +82,7 @@ func TestReconcile(t *testing.T) {
 	cl := fake.NewClientBuilder().WithScheme(scheme).WithRuntimeObjects(objs...).WithStatusSubresource(cluster).Build()
 	log := zapr.NewLogger(zaptest.NewLogger(t)).WithName("cluster-controller-test")
 	req := ctrl.Request{NamespacedName: types.NamespacedName{Namespace: cluster.Namespace, Name: cluster.Name}}
-	
+
 	tests := []struct {
 		name    string
 		action  fakeActor

--- a/pkg/resource/statefulset.go
+++ b/pkg/resource/statefulset.go
@@ -47,7 +47,8 @@ const (
 	emptyDirName = "emptydir"
 
 	// DbContainerName is the name of the container definition in the pod spec
-	DbContainerName = "db"
+	DbContainerName     = "db"
+	DbInitContainerName = "db-init"
 
 	terminationGracePeriodSecs = 300
 )
@@ -256,10 +257,9 @@ func (b StatefulSetBuilder) makePodTemplate() corev1.PodTemplateSpec {
 // corev1.Container that is based on the CR.
 func (b StatefulSetBuilder) MakeInitContainers() []corev1.Container {
 	image := b.GetCockroachDBImageName()
-	initContainer := fmt.Sprintf("%s-init", DbContainerName)
 	return []corev1.Container{
 		{
-			Name:            initContainer,
+			Name:            DbInitContainerName,
 			Image:           image,
 			Command:         []string{"/bin/sh", "-c", certCpCmd},
 			ImagePullPolicy: b.GetImagePullPolicy(),
@@ -428,10 +428,9 @@ func (b StatefulSetBuilder) joinStr() string {
 }
 func addCertsVolumeMountOnInitContiners(container string, spec *corev1.PodSpec) error {
 	found := false
-	initContainer := fmt.Sprintf("%s-init", container)
 	for i := range spec.InitContainers {
 		c := &spec.InitContainers[i]
-		if c.Name == initContainer {
+		if c.Name == DbInitContainerName {
 			found = true
 
 			c.VolumeMounts = append(c.VolumeMounts, corev1.VolumeMount{

--- a/pkg/update/BUILD.bazel
+++ b/pkg/update/BUILD.bazel
@@ -51,7 +51,14 @@ go_test(
     ],
     embed = [":go_default_library"],
     deps = [
+        "//pkg/resource:go_default_library",
         "@com_github_masterminds_semver_v3//:go_default_library",
+        "@com_github_stretchr_testify//assert:go_default_library",
         "@com_github_stretchr_testify//require:go_default_library",
+        "@io_k8s_api//apps/v1:go_default_library",
+        "@io_k8s_api//core/v1:go_default_library",
+        "@io_k8s_apimachinery//pkg/apis/meta/v1:go_default_library",
+        "@io_k8s_client_go//kubernetes/fake:go_default_library",
+        "@io_k8s_sigs_controller_runtime//pkg/log:go_default_library",
     ],
 )

--- a/pkg/update/update_cockroach_version.go
+++ b/pkg/update/update_cockroach_version.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"fmt"
 	"regexp"
-	"strings"
 	"time"
 
 	"database/sql"
@@ -99,17 +98,10 @@ func UpdateClusterCockroachVersion(
 			return errors.Wrapf(err, "setting downgrade option for major roll forward failed")
 		}
 	}
-	var wantImage string = update.WantImageName
-	//if the image is already in the sha256 format  we keep it as it is
-	//otherwise we build the concatenate the image with the version to
-	//obtain the correct format
-	if !strings.Contains(update.WantImageName, "@sha256") {
-		wantImage = fmt.Sprintf("%s:%s", update.WantImageName, update.WantVersion.Original())
-	}
 
-	updateFunction := makeUpdateCockroachVersionFunction(wantImage, update.WantVersion.Original(), update.CurrentVersion.Original())
-	perPodVerificationFunction := makeIsCRBPodIsRunningNewVersionFunction(
-		wantImage,
+	updateFunction := makeUpdateCockroachVersionFunction(update.WantImageName, update.WantVersion.Original(), update.CurrentVersion.Original())
+	perPodVerificationFunction := makeIsCRDBPodIsRunningNewVersionFunction(
+		update.WantImageName,
 	)
 	updateStrategyFunction := PartitionedRollingUpdateStrategy(
 		perPodVerificationFunction,

--- a/pkg/update/update_cockroach_version_common_test.go
+++ b/pkg/update/update_cockroach_version_common_test.go
@@ -17,11 +17,19 @@ limitations under the License.
 package update
 
 import (
+	"context"
 	"reflect"
 	"testing"
 
 	semver "github.com/Masterminds/semver/v3"
+	"github.com/cockroachdb/cockroach-operator/pkg/resource"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 func TestIsPatch(t *testing.T) {
@@ -277,6 +285,336 @@ func TestGetReleaseType(t *testing.T) {
 		t.Run(test.description, func(t *testing.T) {
 			require.True(t, reflect.DeepEqual(getReleaseType(test.major, test.minor), test.result),
 				"getReleaseType test failed")
+		})
+	}
+}
+
+func TestMakeUpdateCockroachVersionFunction_FIPSImageHandling(t *testing.T) {
+	tests := []struct {
+		name           string
+		cockroachImage string
+		version        string
+		expectedImage  string
+		description    string
+	}{
+		{
+			name:           "SHA256_image_preserved",
+			cockroachImage: "registry.connect.redhat.com/cockroachdb/cockroach@sha256:3b78a4d3864e16d270979d9d7756012abf09e6cdb7f1eb4832f6497c26281099",
+			version:        "v25.2.1",
+			expectedImage:  "registry.connect.redhat.com/cockroachdb/cockroach@sha256:3b78a4d3864e16d270979d9d7756012abf09e6cdb7f1eb4832f6497c26281099",
+			description:    "FIPS SHA256 image should be preserved exactly as-is",
+		},
+		{
+			name:           "Regular_Docker_Hub_image",
+			cockroachImage: "cockroachdb/cockroach:v25.2.1",
+			version:        "v25.2.1",
+			expectedImage:  "cockroachdb/cockroach:v25.2.1",
+			description:    "Regular Docker Hub images should work normally",
+		},
+		{
+			name:           "Custom_registry_with_tag",
+			cockroachImage: "my-registry.com/cockroachdb/cockroach:v25.2.1",
+			version:        "v25.2.1",
+			expectedImage:  "my-registry.com/cockroachdb/cockroach:v25.2.1",
+			description:    "Custom registry images with tags should be preserved",
+		},
+		{
+			name:           "Fips_Image_Preserved",
+			cockroachImage: "cockroachdb/cockroach:v25.2.1-fips",
+			version:        "v25.2.1",
+			expectedImage:  "cockroachdb/cockroach:v25.2.1-fips",
+			description:    "FIPS images should be preserved",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a StatefulSet with both main and init containers
+			sts := &appsv1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "test-cluster",
+					Namespace:   "test-namespace",
+					Annotations: make(map[string]string),
+				},
+				Spec: appsv1.StatefulSetSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							InitContainers: []corev1.Container{
+								{
+									Name:  "db-init",
+									Image: "old-image:v25.1.0",
+								},
+							},
+							Containers: []corev1.Container{
+								{
+									Name:  "db",
+									Image: "old-image:v25.1.0",
+								},
+							},
+						},
+					},
+				},
+			}
+
+			// Create the update function
+			updateFunc := makeUpdateCockroachVersionFunction(tt.cockroachImage, tt.version, "v25.1.0")
+
+			// Apply the update
+			updatedSts, err := updateFunc(sts)
+			require.NoError(t, err, tt.description)
+			require.NotNil(t, updatedSts)
+
+			// Verify annotations are set correctly
+			assert.Equal(t, tt.version, updatedSts.Annotations[resource.CrdbVersionAnnotation],
+				"Version annotation should be set correctly")
+			assert.Equal(t, tt.expectedImage, updatedSts.Annotations[resource.CrdbContainerImageAnnotation],
+				"Container image annotation should preserve the exact image reference")
+
+			// Verify main container image is updated
+			assert.Equal(t, tt.expectedImage, updatedSts.Spec.Template.Spec.Containers[0].Image,
+				"Main container image should be updated to the exact image reference")
+
+			// Verify init container image is updated
+			assert.Equal(t, tt.expectedImage, updatedSts.Spec.Template.Spec.InitContainers[0].Image,
+				"Init container image should be updated to the exact image reference")
+		})
+	}
+}
+
+func TestMakeUpdateCockroachVersionFunction_NoInitContainers(t *testing.T) {
+	// Test case where StatefulSet has no init containers (TLS disabled)
+	sts := &appsv1.StatefulSet{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        "test-cluster",
+			Namespace:   "test-namespace",
+			Annotations: make(map[string]string),
+		},
+		Spec: appsv1.StatefulSetSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					// No InitContainers
+					Containers: []corev1.Container{
+						{
+							Name:  "db",
+							Image: "cockroachdb/cockroach:v25.1.0-fips",
+						},
+					},
+				},
+			},
+		},
+	}
+
+	fipsImage := "cockroachdb/cockroach:v25.2.1-fips"
+	updateFunc := makeUpdateCockroachVersionFunction(fipsImage, "v25.2.1", "v25.1.0")
+
+	updatedSts, err := updateFunc(sts)
+	require.NoError(t, err)
+	require.NotNil(t, updatedSts)
+
+	// Should not crash and should update main container
+	assert.Equal(t, fipsImage, updatedSts.Spec.Template.Spec.Containers[0].Image)
+	assert.Len(t, updatedSts.Spec.Template.Spec.InitContainers, 0, "Should have no init containers")
+}
+
+func TestMakeIsCRBPodIsRunningNewVersionFunction_WithInitContainers(t *testing.T) {
+	tests := []struct {
+		name               string
+		cockroachImage     string
+		mainContainerImage string
+		initContainerImage string
+		podReady           bool
+		expectError        bool
+		description        string
+	}{
+		{
+			name:               "All_containers_updated_and_ready",
+			cockroachImage:     "cockroachdb/cockroach:v25.2.1",
+			mainContainerImage: "cockroachdb/cockroach:v25.2.1",
+			initContainerImage: "cockroachdb/cockroach:v25.2.1",
+			podReady:           true,
+			expectError:        false,
+			description:        "When all containers are updated and pod is ready, should succeed",
+		},
+		{
+			name:               "Main_container_not_updated",
+			cockroachImage:     "cockroachdb/cockroach:v25.2.1",
+			mainContainerImage: "cockroachdb/cockroach:v25.2.0",
+			initContainerImage: "cockroachdb/cockroach:v25.2.1",
+			podReady:           true,
+			expectError:        true,
+			description:        "When main container is not updated, should return error",
+		},
+		{
+			name:               "Init_container_not_updated",
+			cockroachImage:     "cockroachdb/cockroach:v25.2.1",
+			mainContainerImage: "cockroachdb/cockroach:v25.2.0",
+			initContainerImage: "cockroachdb/cockroach:v25.2.0",
+			podReady:           true,
+			expectError:        true,
+		},
+		{
+			name:               "Pod_not_ready",
+			cockroachImage:     "cockroachdb/cockroach:v25.2.1",
+			mainContainerImage: "cockroachdb/cockroach:v25.2.1",
+			initContainerImage: "cockroachdb/cockroach:v25.2.1",
+			podReady:           false,
+			expectError:        true,
+			description:        "When pod is not ready, should return error",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a pod with both main and init containers
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-sts-0",
+					Namespace: "test-namespace",
+				},
+				Spec: corev1.PodSpec{
+					InitContainers: []corev1.Container{
+						{
+							Name:  "db-init",
+							Image: tt.initContainerImage,
+						},
+					},
+					Containers: []corev1.Container{
+						{
+							Name:  "db",
+							Image: tt.mainContainerImage,
+						},
+					},
+				},
+				Status: corev1.PodStatus{
+					Conditions: []corev1.PodCondition{},
+				},
+			}
+
+			// Set pod ready condition based on test case
+			if tt.podReady {
+				pod.Status.Conditions = append(pod.Status.Conditions, corev1.PodCondition{
+					Type:   corev1.PodReady,
+					Status: corev1.ConditionTrue,
+				})
+			}
+
+			// Create fake clientset and add the pod
+			clientset := fake.NewSimpleClientset(pod)
+
+			// Create StatefulSet
+			sts := &appsv1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-sts",
+					Namespace: "test-namespace",
+				},
+			}
+
+			// Create UpdateSts struct
+			updateSts := &UpdateSts{
+				ctx:       context.Background(),
+				clientset: clientset,
+				sts:       sts,
+			}
+
+			// Create verification function
+			verifyFunc := makeIsCRDBPodIsRunningNewVersionFunction(tt.cockroachImage)
+
+			// Test the verification
+			err := verifyFunc(updateSts, 0, logf.Log)
+
+			if tt.expectError {
+				assert.Error(t, err, tt.description)
+			} else {
+				assert.NoError(t, err, tt.description)
+			}
+		})
+	}
+}
+
+func TestMakeIsCRBPodIsRunningNewVersionFunction_NoInitContainers(t *testing.T) {
+	tests := []struct {
+		name               string
+		cockroachImage     string
+		mainContainerImage string
+		podReady           bool
+		expectError        bool
+		description        string
+	}{
+		{
+			name:               "All_containers_updated_and_ready",
+			cockroachImage:     "cockroachdb/cockroach:v25.2.1",
+			mainContainerImage: "cockroachdb/cockroach:v25.2.1",
+			podReady:           true,
+			expectError:        false,
+			description:        "When all containers are updated and pod is ready, should succeed",
+		},
+		{
+			name:               "Main_container_not_updated",
+			cockroachImage:     "cockroachdb/cockroach:v25.2.1",
+			mainContainerImage: "cockroachdb/cockroach:v25.2.0",
+			podReady:           true,
+			expectError:        true,
+			description:        "When main container is not updated, should return error",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Test pod without init containers (TLS disabled)
+			pod := &corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-sts-0",
+					Namespace: "test-namespace",
+				},
+				Spec: corev1.PodSpec{
+					// No InitContainers
+					Containers: []corev1.Container{
+						{
+							Name:  "db",
+							Image: tt.mainContainerImage,
+						},
+					},
+				},
+				Status: corev1.PodStatus{
+					Conditions: []corev1.PodCondition{},
+				},
+			}
+
+			if tt.podReady {
+				pod.Status.Conditions = append(pod.Status.Conditions, corev1.PodCondition{
+					Type:   corev1.PodReady,
+					Status: corev1.ConditionTrue,
+				})
+			}
+
+			// Create fake clientset and add the pod
+			clientset := fake.NewSimpleClientset(pod)
+
+			// Create StatefulSet
+			sts := &appsv1.StatefulSet{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-sts",
+					Namespace: "test-namespace",
+				},
+			}
+
+			// Create UpdateSts struct
+			updateSts := &UpdateSts{
+				ctx:       context.Background(),
+				clientset: clientset,
+				sts:       sts,
+			}
+
+			verifyFunc := makeIsCRDBPodIsRunningNewVersionFunction(tt.cockroachImage)
+
+			// Should succeed - no init containers to check
+			err := verifyFunc(updateSts, 0, logf.Log)
+
+			if tt.expectError {
+				assert.Error(t, err, tt.description)
+			} else {
+				assert.NoError(t, err, tt.description)
+			}
 		})
 	}
 }


### PR DESCRIPTION
Issue: When upgrading CockroachDB clusters using FIPS-compliant images, the operator was performing a double rollout:
1. First rollout: Switching to a non-FIPS version of the target image
2. Second rollout: Correcting back to the proper FIPS version

RCA:
The issue was caused by inappropriate image manipulation in two key locations:
1. `partitioned_update.go`: `getImageNameNoVersion` function stripped version tags from Docker images. For tagged FIPS images like `cockroachdb/cockroach:v25.2.1-fips`, it would strip everything after the colon, losing the FIPS designation.
2. `update_cockroach_version.go`: When `getImageNameNoVersion()` stripped the FIPS tag, this logic would reconstruct the image as cockroachdb/cockroach:v25.2.1 (standard image) instead of preserving the original cockroachdb/cockroach:v25.2.1-fips.

Also, the upgrade only updates the main container image and does not update the init container image which also contributed to two restarts.

Fix: Instead of modify the image and reconstruct it, directly used the image provided by the user. Also updated the init container as well in the upgrade logic.