### PR TITLE
pkg/resource: Add migration label support to CrdbCluster CR

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -373,4 +373,3 @@ publish-operator-openshift:
 .PHONY: release/publish-openshift-bundle
 release/publish-openshift-bundle:
 	./build/release/teamcity-publish-openshift-bundle.sh
-

--- a/apis/v1alpha1/cluster_types.go
+++ b/apis/v1alpha1/cluster_types.go
@@ -22,6 +22,13 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+const (
+	// CrdbOperatorMigrationLabel is the label used to indicate that the cluster is migrating.
+	// If this label is set to "true", the operator will stop reconciling the
+	// entire cluster.
+	CrdbOperatorMigrationLabel = "crdb.io/skip-reconcile"
+)
+
 // NOTE: json tags are required.  Any new fields you add must have json tags for the fields to be serialized.
 // Important: Run "make dev/generate" to regenerate code after modifying this file
 

--- a/config/manager/patches/image.yaml
+++ b/config/manager/patches/image.yaml
@@ -342,7 +342,35 @@ spec:
               value: cockroachdb/cockroach:v25.2.0
             - name: RELATED_IMAGE_COCKROACH_v25_2_1
               value: cockroachdb/cockroach:v25.2.1
+            - name: RELATED_IMAGE_COCKROACH_v25_2_2
+              value: cockroachdb/cockroach:v25.2.2
+            - name: RELATED_IMAGE_COCKROACH_v25_2_3
+              value: cockroachdb/cockroach:v25.2.3
+            - name: RELATED_IMAGE_COCKROACH_v25_2_4
+              value: cockroachdb/cockroach:v25.2.4
+            - name: RELATED_IMAGE_COCKROACH_v25_2_5
+              value: cockroachdb/cockroach:v25.2.5
+            - name: RELATED_IMAGE_COCKROACH_v25_2_6
+              value: cockroachdb/cockroach:v25.2.6
+            - name: RELATED_IMAGE_COCKROACH_v25_2_7
+              value: cockroachdb/cockroach:v25.2.7
+            - name: RELATED_IMAGE_COCKROACH_v25_2_8
+              value: cockroachdb/cockroach:v25.2.8
             - name: RELATED_IMAGE_COCKROACH_v25_2_10
               value: cockroachdb/cockroach:v25.2.10
+            - name: RELATED_IMAGE_COCKROACH_v25_3_0
+              value: cockroachdb/cockroach:v25.3.0
+            - name: RELATED_IMAGE_COCKROACH_v25_3_1
+              value: cockroachdb/cockroach:v25.3.1
+            - name: RELATED_IMAGE_COCKROACH_v25_3_2
+              value: cockroachdb/cockroach:v25.3.2
+            - name: RELATED_IMAGE_COCKROACH_v25_3_3
+              value: cockroachdb/cockroach:v25.3.3
+            - name: RELATED_IMAGE_COCKROACH_v25_3_4
+              value: cockroachdb/cockroach:v25.3.4
+            - name: RELATED_IMAGE_COCKROACH_v25_3_6
+              value: cockroachdb/cockroach:v25.3.6
+            - name: RELATED_IMAGE_COCKROACH_v25_4_1
+              value: cockroachdb/cockroach:v25.4.1
             - name: RELATED_IMAGE_COCKROACH_v25_4_2
               value: cockroachdb/cockroach:v25.4.2

--- a/config/manifests/bases/cockroach-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/cockroach-operator.clusterserviceversion.yaml
@@ -515,8 +515,36 @@ spec:
     name: RELATED_IMAGE_COCKROACH_v25_2_0
   - image: registry.connect.redhat.com/cockroachdb/cockroach@sha256:3b78a4d3864e16d270979d9d7756012abf09e6cdb7f1eb4832f6497c26281099
     name: RELATED_IMAGE_COCKROACH_v25_2_1
+  - image: registry.connect.redhat.com/cockroachdb/cockroach@sha256:f42fa22aac3cc41ce72e144a72530ffbee765a392b24593dafd06cc098f8410b
+    name: RELATED_IMAGE_COCKROACH_v25_2_2
+  - image: registry.connect.redhat.com/cockroachdb/cockroach@sha256:ace6130bc3492ce826fdb2363a20c7b9dea8ad307e2893b81a4ff7172d0bde6a
+    name: RELATED_IMAGE_COCKROACH_v25_2_3
+  - image: registry.connect.redhat.com/cockroachdb/cockroach@sha256:77b933878faae575e2b8df45a2a7580da204f6de6ed40c6c0b7d4ae753287e60
+    name: RELATED_IMAGE_COCKROACH_v25_2_4
+  - image: registry.connect.redhat.com/cockroachdb/cockroach@sha256:53ff9416353d211d6f02ac7b4e28f29a593a4773217b545a61b7f0d6cd5c90aa
+    name: RELATED_IMAGE_COCKROACH_v25_2_5
+  - image: registry.connect.redhat.com/cockroachdb/cockroach@sha256:9277c11fcc8cedff0d9843cefe1c5e8560d10f2b89146a24cdba55c67596bf8d
+    name: RELATED_IMAGE_COCKROACH_v25_2_6
+  - image: registry.connect.redhat.com/cockroachdb/cockroach@sha256:33370557f65035b46e0e42bcea79905aeff96951ab454012aaa5559a8edd4fd9
+    name: RELATED_IMAGE_COCKROACH_v25_2_7
+  - image: registry.connect.redhat.com/cockroachdb/cockroach@sha256:e54f78d844efd4082757cd4e3c6ea458b5418b157034d990a0a8d904eb423c02
+    name: RELATED_IMAGE_COCKROACH_v25_2_8
   - image: registry.connect.redhat.com/cockroachdb/cockroach@sha256:51a717edb6cb122b933d30bbddda8e65dd6312f521ccacacf4b014437d3128b9
     name: RELATED_IMAGE_COCKROACH_v25_2_10
+  - image: registry.connect.redhat.com/cockroachdb/cockroach@sha256:80183c72761fb64ed665c6e7699b499b08f96ae66e6a97027216dd1aa805b0aa
+    name: RELATED_IMAGE_COCKROACH_v25_3_0
+  - image: registry.connect.redhat.com/cockroachdb/cockroach@sha256:35dfe947b4f4a834013e8a975460d994db3b23fd47c87e3291ee032a44d6866f
+    name: RELATED_IMAGE_COCKROACH_v25_3_1
+  - image: registry.connect.redhat.com/cockroachdb/cockroach@sha256:d89ee6224c624abc7cdbfb0d21a758dec0198e8e08c7847c840872529adbc6bd
+    name: RELATED_IMAGE_COCKROACH_v25_3_2
+  - image: registry.connect.redhat.com/cockroachdb/cockroach@sha256:5f758b398f1d1807fbdf67833472459c3016d1759824ad4582b635c820774588
+    name: RELATED_IMAGE_COCKROACH_v25_3_3
+  - image: registry.connect.redhat.com/cockroachdb/cockroach@sha256:1cea4c986232b08180ce3ae620774901510c45d762aaa32e875a0b0dcc27f836
+    name: RELATED_IMAGE_COCKROACH_v25_3_4
+  - image: registry.connect.redhat.com/cockroachdb/cockroach@sha256:456e6562fb23cd6fab563aba396215777f062c725de6f0e1f8d9db722ae16791
+    name: RELATED_IMAGE_COCKROACH_v25_3_6
+  - image: registry.connect.redhat.com/cockroachdb/cockroach@sha256:513010c88566e851b51012047174f9bde41a53e1be8b0712f8452d316d001611
+    name: RELATED_IMAGE_COCKROACH_v25_4_1
   - image: registry.connect.redhat.com/cockroachdb/cockroach@sha256:edbb7d2cf46a6704182e5e7fc19e396f17e6c3a67f1e4cb374751f344f9b8e70
     name: RELATED_IMAGE_COCKROACH_v25_4_2
   - image: RH_COCKROACH_OP_IMAGE_PLACEHOLDER

--- a/config/manifests/patches/deployment_patch.yaml
+++ b/config/manifests/patches/deployment_patch.yaml
@@ -351,8 +351,36 @@ spec:
               value: registry.connect.redhat.com/cockroachdb/cockroach@sha256:c74cf927a2b2c5098ad74ad0880996f8b042186a9911d888a231ef5b9e2a0715
             - name: RELATED_IMAGE_COCKROACH_v25_2_1
               value: registry.connect.redhat.com/cockroachdb/cockroach@sha256:3b78a4d3864e16d270979d9d7756012abf09e6cdb7f1eb4832f6497c26281099
+            - name: RELATED_IMAGE_COCKROACH_v25_2_2
+              value: registry.connect.redhat.com/cockroachdb/cockroach@sha256:f42fa22aac3cc41ce72e144a72530ffbee765a392b24593dafd06cc098f8410b
+            - name: RELATED_IMAGE_COCKROACH_v25_2_3
+              value: registry.connect.redhat.com/cockroachdb/cockroach@sha256:ace6130bc3492ce826fdb2363a20c7b9dea8ad307e2893b81a4ff7172d0bde6a
+            - name: RELATED_IMAGE_COCKROACH_v25_2_4
+              value: registry.connect.redhat.com/cockroachdb/cockroach@sha256:77b933878faae575e2b8df45a2a7580da204f6de6ed40c6c0b7d4ae753287e60
+            - name: RELATED_IMAGE_COCKROACH_v25_2_5
+              value: registry.connect.redhat.com/cockroachdb/cockroach@sha256:53ff9416353d211d6f02ac7b4e28f29a593a4773217b545a61b7f0d6cd5c90aa
+            - name: RELATED_IMAGE_COCKROACH_v25_2_6
+              value: registry.connect.redhat.com/cockroachdb/cockroach@sha256:9277c11fcc8cedff0d9843cefe1c5e8560d10f2b89146a24cdba55c67596bf8d
+            - name: RELATED_IMAGE_COCKROACH_v25_2_7
+              value: registry.connect.redhat.com/cockroachdb/cockroach@sha256:33370557f65035b46e0e42bcea79905aeff96951ab454012aaa5559a8edd4fd9
+            - name: RELATED_IMAGE_COCKROACH_v25_2_8
+              value: registry.connect.redhat.com/cockroachdb/cockroach@sha256:e54f78d844efd4082757cd4e3c6ea458b5418b157034d990a0a8d904eb423c02
             - name: RELATED_IMAGE_COCKROACH_v25_2_10
               value: registry.connect.redhat.com/cockroachdb/cockroach@sha256:51a717edb6cb122b933d30bbddda8e65dd6312f521ccacacf4b014437d3128b9
+            - name: RELATED_IMAGE_COCKROACH_v25_3_0
+              value: registry.connect.redhat.com/cockroachdb/cockroach@sha256:80183c72761fb64ed665c6e7699b499b08f96ae66e6a97027216dd1aa805b0aa
+            - name: RELATED_IMAGE_COCKROACH_v25_3_1
+              value: registry.connect.redhat.com/cockroachdb/cockroach@sha256:35dfe947b4f4a834013e8a975460d994db3b23fd47c87e3291ee032a44d6866f
+            - name: RELATED_IMAGE_COCKROACH_v25_3_2
+              value: registry.connect.redhat.com/cockroachdb/cockroach@sha256:d89ee6224c624abc7cdbfb0d21a758dec0198e8e08c7847c840872529adbc6bd
+            - name: RELATED_IMAGE_COCKROACH_v25_3_3
+              value: registry.connect.redhat.com/cockroachdb/cockroach@sha256:5f758b398f1d1807fbdf67833472459c3016d1759824ad4582b635c820774588
+            - name: RELATED_IMAGE_COCKROACH_v25_3_4
+              value: registry.connect.redhat.com/cockroachdb/cockroach@sha256:1cea4c986232b08180ce3ae620774901510c45d762aaa32e875a0b0dcc27f836
+            - name: RELATED_IMAGE_COCKROACH_v25_3_6
+              value: registry.connect.redhat.com/cockroachdb/cockroach@sha256:456e6562fb23cd6fab563aba396215777f062c725de6f0e1f8d9db722ae16791
+            - name: RELATED_IMAGE_COCKROACH_v25_4_1
+              value: registry.connect.redhat.com/cockroachdb/cockroach@sha256:513010c88566e851b51012047174f9bde41a53e1be8b0712f8452d316d001611
             - name: RELATED_IMAGE_COCKROACH_v25_4_2
               value: registry.connect.redhat.com/cockroachdb/cockroach@sha256:edbb7d2cf46a6704182e5e7fc19e396f17e6c3a67f1e4cb374751f344f9b8e70
             - name: RELATED_IMAGE_COCKROACH_OPERATOR

--- a/crdb-versions.yaml
+++ b/crdb-versions.yaml
@@ -496,9 +496,51 @@ CrdbVersions:
 - image: cockroachdb/cockroach:v25.2.1
   redhatImage: registry.connect.redhat.com/cockroachdb/cockroach@sha256:3b78a4d3864e16d270979d9d7756012abf09e6cdb7f1eb4832f6497c26281099
   tag: v25.2.1
+- image: cockroachdb/cockroach:v25.2.2
+  redhatImage: registry.connect.redhat.com/cockroachdb/cockroach@sha256:f42fa22aac3cc41ce72e144a72530ffbee765a392b24593dafd06cc098f8410b
+  tag: v25.2.2
+- image: cockroachdb/cockroach:v25.2.3
+  redhatImage: registry.connect.redhat.com/cockroachdb/cockroach@sha256:ace6130bc3492ce826fdb2363a20c7b9dea8ad307e2893b81a4ff7172d0bde6a
+  tag: v25.2.3
+- image: cockroachdb/cockroach:v25.2.4
+  redhatImage: registry.connect.redhat.com/cockroachdb/cockroach@sha256:77b933878faae575e2b8df45a2a7580da204f6de6ed40c6c0b7d4ae753287e60
+  tag: v25.2.4
+- image: cockroachdb/cockroach:v25.2.5
+  redhatImage: registry.connect.redhat.com/cockroachdb/cockroach@sha256:53ff9416353d211d6f02ac7b4e28f29a593a4773217b545a61b7f0d6cd5c90aa
+  tag: v25.2.5
+- image: cockroachdb/cockroach:v25.2.6
+  redhatImage: registry.connect.redhat.com/cockroachdb/cockroach@sha256:9277c11fcc8cedff0d9843cefe1c5e8560d10f2b89146a24cdba55c67596bf8d
+  tag: v25.2.6
+- image: cockroachdb/cockroach:v25.2.7
+  redhatImage: registry.connect.redhat.com/cockroachdb/cockroach@sha256:33370557f65035b46e0e42bcea79905aeff96951ab454012aaa5559a8edd4fd9
+  tag: v25.2.7
+- image: cockroachdb/cockroach:v25.2.8
+  redhatImage: registry.connect.redhat.com/cockroachdb/cockroach@sha256:e54f78d844efd4082757cd4e3c6ea458b5418b157034d990a0a8d904eb423c02
+  tag: v25.2.8
 - image: cockroachdb/cockroach:v25.2.10
   redhatImage: registry.connect.redhat.com/cockroachdb/cockroach@sha256:51a717edb6cb122b933d30bbddda8e65dd6312f521ccacacf4b014437d3128b9
   tag: v25.2.10
+- image: cockroachdb/cockroach:v25.3.0
+  redhatImage: registry.connect.redhat.com/cockroachdb/cockroach@sha256:80183c72761fb64ed665c6e7699b499b08f96ae66e6a97027216dd1aa805b0aa
+  tag: v25.3.0
+- image: cockroachdb/cockroach:v25.3.1
+  redhatImage: registry.connect.redhat.com/cockroachdb/cockroach@sha256:35dfe947b4f4a834013e8a975460d994db3b23fd47c87e3291ee032a44d6866f
+  tag: v25.3.1
+- image: cockroachdb/cockroach:v25.3.2
+  redhatImage: registry.connect.redhat.com/cockroachdb/cockroach@sha256:d89ee6224c624abc7cdbfb0d21a758dec0198e8e08c7847c840872529adbc6bd
+  tag: v25.3.2
+- image: cockroachdb/cockroach:v25.3.3
+  redhatImage: registry.connect.redhat.com/cockroachdb/cockroach@sha256:5f758b398f1d1807fbdf67833472459c3016d1759824ad4582b635c820774588
+  tag: v25.3.3
+- image: cockroachdb/cockroach:v25.3.4
+  redhatImage: registry.connect.redhat.com/cockroachdb/cockroach@sha256:1cea4c986232b08180ce3ae620774901510c45d762aaa32e875a0b0dcc27f836
+  tag: v25.3.4
+- image: cockroachdb/cockroach:v25.3.6
+  redhatImage: registry.connect.redhat.com/cockroachdb/cockroach@sha256:456e6562fb23cd6fab563aba396215777f062c725de6f0e1f8d9db722ae16791
+  tag: v25.3.6
+- image: cockroachdb/cockroach:v25.4.1
+  redhatImage: registry.connect.redhat.com/cockroachdb/cockroach@sha256:513010c88566e851b51012047174f9bde41a53e1be8b0712f8452d316d001611
+  tag: v25.4.1
 - image: cockroachdb/cockroach:v25.4.2
   redhatImage: registry.connect.redhat.com/cockroachdb/cockroach@sha256:edbb7d2cf46a6704182e5e7fc19e396f17e6c3a67f1e4cb374751f344f9b8e70
   tag: v25.4.2

--- a/install/operator.yaml
+++ b/install/operator.yaml
@@ -701,8 +701,36 @@ spec:
           value: cockroachdb/cockroach:v25.2.0
         - name: RELATED_IMAGE_COCKROACH_v25_2_1
           value: cockroachdb/cockroach:v25.2.1
+        - name: RELATED_IMAGE_COCKROACH_v25_2_2
+          value: cockroachdb/cockroach:v25.2.2
+        - name: RELATED_IMAGE_COCKROACH_v25_2_3
+          value: cockroachdb/cockroach:v25.2.3
+        - name: RELATED_IMAGE_COCKROACH_v25_2_4
+          value: cockroachdb/cockroach:v25.2.4
+        - name: RELATED_IMAGE_COCKROACH_v25_2_5
+          value: cockroachdb/cockroach:v25.2.5
+        - name: RELATED_IMAGE_COCKROACH_v25_2_6
+          value: cockroachdb/cockroach:v25.2.6
+        - name: RELATED_IMAGE_COCKROACH_v25_2_7
+          value: cockroachdb/cockroach:v25.2.7
+        - name: RELATED_IMAGE_COCKROACH_v25_2_8
+          value: cockroachdb/cockroach:v25.2.8
         - name: RELATED_IMAGE_COCKROACH_v25_2_10
           value: cockroachdb/cockroach:v25.2.10
+        - name: RELATED_IMAGE_COCKROACH_v25_3_0
+          value: cockroachdb/cockroach:v25.3.0
+        - name: RELATED_IMAGE_COCKROACH_v25_3_1
+          value: cockroachdb/cockroach:v25.3.1
+        - name: RELATED_IMAGE_COCKROACH_v25_3_2
+          value: cockroachdb/cockroach:v25.3.2
+        - name: RELATED_IMAGE_COCKROACH_v25_3_3
+          value: cockroachdb/cockroach:v25.3.3
+        - name: RELATED_IMAGE_COCKROACH_v25_3_4
+          value: cockroachdb/cockroach:v25.3.4
+        - name: RELATED_IMAGE_COCKROACH_v25_3_6
+          value: cockroachdb/cockroach:v25.3.6
+        - name: RELATED_IMAGE_COCKROACH_v25_4_1
+          value: cockroachdb/cockroach:v25.4.1
         - name: RELATED_IMAGE_COCKROACH_v25_4_2
           value: cockroachdb/cockroach:v25.4.2
         - name: OPERATOR_NAME

--- a/pkg/controller/cluster_controller.go
+++ b/pkg/controller/cluster_controller.go
@@ -142,6 +142,12 @@ func (r *ClusterReconciler) Reconcile(ctx context.Context, req reconcile.Request
 		}
 	}
 
+	// If the cluster is migrating, we stop reconciliation
+	if val, ok := cluster.Unwrap().Labels[api.CrdbOperatorMigrationLabel]; ok && val == "true" {
+		log.Info("cluster is migrating, stopping reconciliation")
+		return noRequeue()
+	}
+
 	actorToExecute, err := r.Director.GetActorToExecute(ctx, &cluster, log)
 	if err != nil {
 		return requeueAfter(30*time.Second, nil)

--- a/pkg/resource/statefulset_test.go
+++ b/pkg/resource/statefulset_test.go
@@ -22,6 +22,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"testing"
 
 	api "github.com/cockroachdb/cockroach-operator/apis/v1alpha1"
 	"github.com/cockroachdb/cockroach-operator/pkg/labels"
@@ -32,8 +33,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
-
-	"testing"
 )
 
 var update = flag.Bool("update", false, "update the golden files of this test")


### PR DESCRIPTION
To support migrating CockroachDB clusters from the public operator to the CockroachDB operator through coexistence, we would need additional logic to prevent the operator from scaling up StatefulSet pods after they have been manually scaled down.

This commit introduces a new migration label(`crdb.io/stop-public-operator-reconcile`) for the CrdbCluster resource. When this label is applied, the reconciler is instructed to skip updates to the relevant StatefulSet replicas. This ensures the operator does not interfere with the controlled scale-down process required during the migration phase.