### PR TITLE
Update preflight flag to --certification-component-id

### DIFF
--- a/build/release/teamcity-publish-openshift.sh
+++ b/build/release/teamcity-publish-openshift.sh
@@ -45,7 +45,7 @@ run_preflight() {
   bazel build //hack/bin:preflight
   PFLT_PYXIS_API_TOKEN="${REDHAT_API_TOKEN}" bazel-bin/hack/bin/preflight \
     check container "${RH_OPERATOR_IMG}" \
-    --certification-project-id="${RH_PROJECT_ID}" \
+    --certification-component-id="${RH_PROJECT_ID}" \
     --docker-config=/home/agent/.docker/config.json \
     --submit
 }


### PR DESCRIPTION

Fixes the team city job , to solve - 
```Error: unknown flag: --certification-project-id```