### PR TITLE
ci: declare workflow-level `contents: read` on 8 e2e/test workflows

### DIFF
--- a/.github/workflows/e2e-kind-create.yaml
+++ b/.github/workflows/e2e-kind-create.yaml
@@ -24,6 +24,9 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   e2e-kind-create:
     runs-on: ubuntu-latest-4-core

--- a/.github/workflows/e2e-kind-decommission.yaml
+++ b/.github/workflows/e2e-kind-decommission.yaml
@@ -24,6 +24,9 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   e2e-kind-decommission:
     runs-on: ubuntu-latest-4-core

--- a/.github/workflows/e2e-kind-upgrades.yaml
+++ b/.github/workflows/e2e-kind-upgrades.yaml
@@ -24,6 +24,9 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   e2e-kind-upgrades:
     runs-on: ubuntu-latest-4-core

--- a/.github/workflows/e2e-kind-upgradessha256.yaml
+++ b/.github/workflows/e2e-kind-upgradessha256.yaml
@@ -24,6 +24,9 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   e2e-kind-upgradessha256:
     runs-on: ubuntu-latest-4-core

--- a/.github/workflows/e2e-kind-versionchecker.yaml
+++ b/.github/workflows/e2e-kind-versionchecker.yaml
@@ -24,6 +24,9 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   e2e-kind-versionchecker:
     runs-on: ubuntu-latest

--- a/.github/workflows/nightly-smoketest.yaml
+++ b/.github/workflows/nightly-smoketest.yaml
@@ -25,6 +25,9 @@ on:
   # allows running from the actions tab in GitHub
   workflow_dispatch: ~
 
+permissions:
+  contents: read
+
 jobs:
   smoketest:
     runs-on: ubuntu-latest

--- a/.github/workflows/templates.yaml
+++ b/.github/workflows/templates.yaml
@@ -24,6 +24,9 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   templates:
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -24,6 +24,9 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Pins the default `GITHUB_TOKEN` to `contents: read` on the 8 workflows in `.github/workflows/` that don't actually need any write scope:

- `e2e-kind-create.yaml`, `e2e-kind-decommission.yaml`, `e2e-kind-upgrades.yaml`, `e2e-kind-upgradessha256.yaml`, `e2e-kind-versionchecker.yaml`: kind cluster e2e suites.
- `nightly-smoketest.yaml`: scheduled smoke test.
- `templates.yaml`: template-generation check.
- `tests.yaml`: unit and integration test matrix.

None of the eight calls a GitHub API beyond the initial checkout, so workflow-level `contents: read` is sufficient.

`update-crdb-versions.yaml` is intentionally left out. It uses `peter-evans/create-pull-request` which needs `contents: write` + `pull-requests: write`. That scope is best declared by maintainers who own the version-bump flow.

## Why

CVE-2025-30066 (March 2025 `tj-actions/changed-files` supply-chain compromise) exfiltrated `GITHUB_TOKEN` from workflow logs and the leaked token retained whatever scope was issued at the workflow level. Pinning per workflow caps that runtime authority irrespective of the repo or org default, gives drift protection if the default ever widens, and is credited per-file by the OpenSSF Scorecard `Token-Permissions` check.

YAML validated locally with `yaml.safe_load` on each touched file.