### PR TITLE
VULM-694: bump Go toolchain to 1.25.12

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -36,5 +36,22 @@ jobs:
         with:
           path: "~/.cache/bazel"
           key: bazel
+      - name: Set up Go for artifact checks
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.25.12"
       - name: Tests
         run: make test/all
+      - name: Verify operator artifact
+        run: |
+          bazel build //cmd/cockroach-operator/linux-amd64:cockroach-operator-linux-amd64
+          operator_binary="bazel-bin/cmd/cockroach-operator/linux-amd64/cockroach-operator"
+          go version -m "$operator_binary" | tee /tmp/operator-version.txt
+          grep 'go1.25.12' /tmp/operator-version.txt
+          go run golang.org/x/vuln/cmd/govulncheck@latest -mode binary "$operator_binary"
+      - name: Upload operator artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: cockroach-operator-linux-amd64-${{ github.sha }}
+          path: bazel-bin/cmd/cockroach-operator/linux-amd64/cockroach-operator
+          if-no-files-found: error

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -11,6 +11,42 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-linters-settings:
-  staticcheck:
-    go: "1.24"
+version: "2"
+
+run:
+  go: "1.25"
+
+linters:
+  default: none
+  enable:
+    - errcheck
+    - govet
+    - ineffassign
+    - staticcheck
+    - unused
+  settings:
+    staticcheck:
+      checks:
+        - all
+        - -QF*
+        - -S*
+        - -ST*
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - third_party$
+      - builtin$
+      - examples$
+
+formatters:
+  exclusions:
+    generated: lax
+    paths:
+      - third_party$
+      - builtin$
+      - examples$

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -46,10 +46,10 @@ bazel_skylib_workspace()
 
 http_archive(
     name = "io_bazel_rules_go",
-    sha256 = "f2d15bea3e241aa0e3a90fb17a82e6a8ab12214789f6aeddd53b8d04316d2b7c",
+    sha256 = "82f0af253fc61c7f06b005c67c079573776111185b7c3742563f751178aaa4c0",
     urls = [
-        "https://mirror.bazel.build/github.com/bazel-contrib/rules_go/releases/download/v0.54.0/rules_go-v0.54.0.zip",
-        "https://github.com/bazel-contrib/rules_go/releases/download/v0.54.0/rules_go-v0.54.0.zip",
+        "https://mirror.bazel.build/github.com/bazel-contrib/rules_go/releases/download/v0.58.3/rules_go-v0.58.3.zip",
+        "https://github.com/bazel-contrib/rules_go/releases/download/v0.58.3/rules_go-v0.58.3.zip",
     ],
 )
 
@@ -71,10 +71,19 @@ load("//hack/build:repos.bzl", "go_dependencies")
 
 go_rules_dependencies()
 
+go_register_toolchains(version = "1.25.12")
+
+# Create the host platform repository transitively required by rules_go.
+load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
+load("@platforms//host:extension.bzl", "host_platform_repo")
+
+maybe(
+    host_platform_repo,
+    name = "host_platform",
+)
+
 # gazelle:repository_macro hack/build/repos.bzl%_go_dependencies
 go_dependencies()
-
-go_register_toolchains(version = "1.24.2")
 
 gazelle_dependencies()
 

--- a/config/manager/patches/image.yaml
+++ b/config/manager/patches/image.yaml
@@ -352,6 +352,8 @@ spec:
               value: cockroachdb/cockroach:v24.3.33
             - name: RELATED_IMAGE_COCKROACH_v24_3_34
               value: cockroachdb/cockroach:v24.3.34
+            - name: RELATED_IMAGE_COCKROACH_v24_3_35
+              value: cockroachdb/cockroach:v24.3.35
             - name: RELATED_IMAGE_COCKROACH_v25_1_0
               value: cockroachdb/cockroach:v25.1.0
             - name: RELATED_IMAGE_COCKROACH_v25_1_1
@@ -416,6 +418,8 @@ spec:
               value: cockroachdb/cockroach:v25.2.20
             - name: RELATED_IMAGE_COCKROACH_v25_2_21
               value: cockroachdb/cockroach:v25.2.21
+            - name: RELATED_IMAGE_COCKROACH_v25_2_22
+              value: cockroachdb/cockroach:v25.2.22
             - name: RELATED_IMAGE_COCKROACH_v25_3_0
               value: cockroachdb/cockroach:v25.3.0
             - name: RELATED_IMAGE_COCKROACH_v25_3_1
@@ -456,6 +460,8 @@ spec:
               value: cockroachdb/cockroach:v25.4.12
             - name: RELATED_IMAGE_COCKROACH_v25_4_13
               value: cockroachdb/cockroach:v25.4.13
+            - name: RELATED_IMAGE_COCKROACH_v25_4_14
+              value: cockroachdb/cockroach:v25.4.14
             - name: RELATED_IMAGE_COCKROACH_v26_1_0
               value: cockroachdb/cockroach:v26.1.0
             - name: RELATED_IMAGE_COCKROACH_v26_1_1
@@ -472,6 +478,8 @@ spec:
               value: cockroachdb/cockroach:v26.1.6
             - name: RELATED_IMAGE_COCKROACH_v26_1_7
               value: cockroachdb/cockroach:v26.1.7
+            - name: RELATED_IMAGE_COCKROACH_v26_1_8
+              value: cockroachdb/cockroach:v26.1.8
             - name: RELATED_IMAGE_COCKROACH_v26_2_0
               value: cockroachdb/cockroach:v26.2.0
             - name: RELATED_IMAGE_COCKROACH_v26_2_1
@@ -482,3 +490,5 @@ spec:
               value: cockroachdb/cockroach:v26.2.3
             - name: RELATED_IMAGE_COCKROACH_v26_2_4
               value: cockroachdb/cockroach:v26.2.4
+            - name: RELATED_IMAGE_COCKROACH_v26_2_5
+              value: cockroachdb/cockroach:v26.2.5

--- a/config/manifests/bases/cockroach-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/cockroach-operator.clusterserviceversion.yaml
@@ -525,6 +525,8 @@ spec:
     name: RELATED_IMAGE_COCKROACH_v24_3_33
   - image: registry.connect.redhat.com/cockroachdb/cockroach@sha256:0ae42bd47982142033664adfcfccde29a8460da66108892e02d2ccf4e6003a47
     name: RELATED_IMAGE_COCKROACH_v24_3_34
+  - image: registry.connect.redhat.com/cockroachdb/cockroach@sha256:26d1d182a0f23d4c30953ab891c20d7ee68619c900e28a35d6ad271a5603d86f
+    name: RELATED_IMAGE_COCKROACH_v24_3_35
   - image: registry.connect.redhat.com/cockroachdb/cockroach@sha256:8e8c081c231b5b15eca483ceec16ea9190ba73aae6e421865162446eb584519a
     name: RELATED_IMAGE_COCKROACH_v25_1_0
   - image: registry.connect.redhat.com/cockroachdb/cockroach@sha256:fd6c9b8ca82ff4f2d0fe29166d1fc9bca6439cb40907be60f4d8f1b9735de2f7
@@ -589,6 +591,8 @@ spec:
     name: RELATED_IMAGE_COCKROACH_v25_2_20
   - image: registry.connect.redhat.com/cockroachdb/cockroach@sha256:09e0ed74759258f72bb4dbe5d7c12b2b95a0cded00defc07509178ef768f28f1
     name: RELATED_IMAGE_COCKROACH_v25_2_21
+  - image: registry.connect.redhat.com/cockroachdb/cockroach@sha256:1009894a4420bfdcafa7c8828a3eb3c5a8438f6fb33523c7e559e826ed211a0e
+    name: RELATED_IMAGE_COCKROACH_v25_2_22
   - image: registry.connect.redhat.com/cockroachdb/cockroach@sha256:80183c72761fb64ed665c6e7699b499b08f96ae66e6a97027216dd1aa805b0aa
     name: RELATED_IMAGE_COCKROACH_v25_3_0
   - image: registry.connect.redhat.com/cockroachdb/cockroach@sha256:35dfe947b4f4a834013e8a975460d994db3b23fd47c87e3291ee032a44d6866f
@@ -629,6 +633,8 @@ spec:
     name: RELATED_IMAGE_COCKROACH_v25_4_12
   - image: registry.connect.redhat.com/cockroachdb/cockroach@sha256:8b6fd9d469c45c419ce1c167104ccdc7c83a39a2425ce2d4a70f366a8fd2df88
     name: RELATED_IMAGE_COCKROACH_v25_4_13
+  - image: registry.connect.redhat.com/cockroachdb/cockroach@sha256:6da82bd60b3fe8b9422cf6cc8402b2875d46f53ada2e0c788658f9fee75789ca
+    name: RELATED_IMAGE_COCKROACH_v25_4_14
   - image: registry.connect.redhat.com/cockroachdb/cockroach@sha256:f3244dc3f59928a9aca8d0d9053d6101c3413fe8c3064536d94b84237ae8fb10
     name: RELATED_IMAGE_COCKROACH_v26_1_0
   - image: registry.connect.redhat.com/cockroachdb/cockroach@sha256:ec080aa4e7f5bf59074588dffbd40bd093fefc726786387987e2d88eb7f44d4a
@@ -645,6 +651,8 @@ spec:
     name: RELATED_IMAGE_COCKROACH_v26_1_6
   - image: registry.connect.redhat.com/cockroachdb/cockroach@sha256:34b62f1dd7d91196b3a5b5def90ce12b736e9a11540f2d85aab8bbaa7d2b1b12
     name: RELATED_IMAGE_COCKROACH_v26_1_7
+  - image: registry.connect.redhat.com/cockroachdb/cockroach@sha256:67a4f94516484bd9112c8af37915d9a9f9fea81d86f2356708789d0246e41bce
+    name: RELATED_IMAGE_COCKROACH_v26_1_8
   - image: registry.connect.redhat.com/cockroachdb/cockroach@sha256:ff9d44c80f8e734e6d4a061dc3b87be6e089d9b7682a67d377948d138720a1c8
     name: RELATED_IMAGE_COCKROACH_v26_2_0
   - image: registry.connect.redhat.com/cockroachdb/cockroach@sha256:25ebcaf1401f97f35796cad9dc5a9f722786d6c09cc920642e74a18b0bc40751
@@ -655,6 +663,8 @@ spec:
     name: RELATED_IMAGE_COCKROACH_v26_2_3
   - image: registry.connect.redhat.com/cockroachdb/cockroach@sha256:0ee652a9d0fb6dc6cfc72ad42b02b62ea27572220b905b338120c91000bf0f43
     name: RELATED_IMAGE_COCKROACH_v26_2_4
+  - image: registry.connect.redhat.com/cockroachdb/cockroach@sha256:44dc89272e633532b7ae72861f426ab7a55db4a52b6ff3a2cc92027d697b19e6
+    name: RELATED_IMAGE_COCKROACH_v26_2_5
   - image: RH_COCKROACH_OP_IMAGE_PLACEHOLDER
     name: RELATED_IMAGE_COCKROACH_OPERATOR
   version: 0.0.0

--- a/config/manifests/patches/deployment_patch.yaml
+++ b/config/manifests/patches/deployment_patch.yaml
@@ -361,6 +361,8 @@ spec:
               value: registry.connect.redhat.com/cockroachdb/cockroach@sha256:4b707f0ddf0945c5d7f83a63b999c1d844a4a812dc93ed138c04914e31af6b57
             - name: RELATED_IMAGE_COCKROACH_v24_3_34
               value: registry.connect.redhat.com/cockroachdb/cockroach@sha256:0ae42bd47982142033664adfcfccde29a8460da66108892e02d2ccf4e6003a47
+            - name: RELATED_IMAGE_COCKROACH_v24_3_35
+              value: registry.connect.redhat.com/cockroachdb/cockroach@sha256:26d1d182a0f23d4c30953ab891c20d7ee68619c900e28a35d6ad271a5603d86f
             - name: RELATED_IMAGE_COCKROACH_v25_1_0
               value: registry.connect.redhat.com/cockroachdb/cockroach@sha256:8e8c081c231b5b15eca483ceec16ea9190ba73aae6e421865162446eb584519a
             - name: RELATED_IMAGE_COCKROACH_v25_1_1
@@ -425,6 +427,8 @@ spec:
               value: registry.connect.redhat.com/cockroachdb/cockroach@sha256:7e7e1b25cdc4243b80d6de9baa174775952d7466eb94ba8a5674be96ef541d04
             - name: RELATED_IMAGE_COCKROACH_v25_2_21
               value: registry.connect.redhat.com/cockroachdb/cockroach@sha256:09e0ed74759258f72bb4dbe5d7c12b2b95a0cded00defc07509178ef768f28f1
+            - name: RELATED_IMAGE_COCKROACH_v25_2_22
+              value: registry.connect.redhat.com/cockroachdb/cockroach@sha256:1009894a4420bfdcafa7c8828a3eb3c5a8438f6fb33523c7e559e826ed211a0e
             - name: RELATED_IMAGE_COCKROACH_v25_3_0
               value: registry.connect.redhat.com/cockroachdb/cockroach@sha256:80183c72761fb64ed665c6e7699b499b08f96ae66e6a97027216dd1aa805b0aa
             - name: RELATED_IMAGE_COCKROACH_v25_3_1
@@ -465,6 +469,8 @@ spec:
               value: registry.connect.redhat.com/cockroachdb/cockroach@sha256:0057e5d9f446a01270fc82a3c01036493e94d3649f71f5e693a6a3ef4ad0003a
             - name: RELATED_IMAGE_COCKROACH_v25_4_13
               value: registry.connect.redhat.com/cockroachdb/cockroach@sha256:8b6fd9d469c45c419ce1c167104ccdc7c83a39a2425ce2d4a70f366a8fd2df88
+            - name: RELATED_IMAGE_COCKROACH_v25_4_14
+              value: registry.connect.redhat.com/cockroachdb/cockroach@sha256:6da82bd60b3fe8b9422cf6cc8402b2875d46f53ada2e0c788658f9fee75789ca
             - name: RELATED_IMAGE_COCKROACH_v26_1_0
               value: registry.connect.redhat.com/cockroachdb/cockroach@sha256:f3244dc3f59928a9aca8d0d9053d6101c3413fe8c3064536d94b84237ae8fb10
             - name: RELATED_IMAGE_COCKROACH_v26_1_1
@@ -481,6 +487,8 @@ spec:
               value: registry.connect.redhat.com/cockroachdb/cockroach@sha256:3e39828e16612ecf151f4fc9976bd6f7a8bf5788916660ac9d9f65a56529e9a5
             - name: RELATED_IMAGE_COCKROACH_v26_1_7
               value: registry.connect.redhat.com/cockroachdb/cockroach@sha256:34b62f1dd7d91196b3a5b5def90ce12b736e9a11540f2d85aab8bbaa7d2b1b12
+            - name: RELATED_IMAGE_COCKROACH_v26_1_8
+              value: registry.connect.redhat.com/cockroachdb/cockroach@sha256:67a4f94516484bd9112c8af37915d9a9f9fea81d86f2356708789d0246e41bce
             - name: RELATED_IMAGE_COCKROACH_v26_2_0
               value: registry.connect.redhat.com/cockroachdb/cockroach@sha256:ff9d44c80f8e734e6d4a061dc3b87be6e089d9b7682a67d377948d138720a1c8
             - name: RELATED_IMAGE_COCKROACH_v26_2_1
@@ -491,6 +499,8 @@ spec:
               value: registry.connect.redhat.com/cockroachdb/cockroach@sha256:743f30e731fcd3f15370fd04fcce90f9a14b920dc737c555df0d35fa0408088f
             - name: RELATED_IMAGE_COCKROACH_v26_2_4
               value: registry.connect.redhat.com/cockroachdb/cockroach@sha256:0ee652a9d0fb6dc6cfc72ad42b02b62ea27572220b905b338120c91000bf0f43
+            - name: RELATED_IMAGE_COCKROACH_v26_2_5
+              value: registry.connect.redhat.com/cockroachdb/cockroach@sha256:44dc89272e633532b7ae72861f426ab7a55db4a52b6ff3a2cc92027d697b19e6
             - name: RELATED_IMAGE_COCKROACH_OPERATOR
               value: RH_COCKROACH_OP_IMAGE_PLACEHOLDER
           image: RH_COCKROACH_OP_IMAGE_PLACEHOLDER

--- a/config/samples/crdb-tls-example.yaml
+++ b/config/samples/crdb-tls-example.yaml
@@ -19,7 +19,7 @@ kind: CrdbCluster
 metadata:
   name: crdb-tls-example
 spec:
-  cockroachDBVersion: v26.2.4
+  cockroachDBVersion: v26.2.5
   dataStore:
     pvc:
       spec:

--- a/crdb-versions.yaml
+++ b/crdb-versions.yaml
@@ -511,6 +511,9 @@ CrdbVersions:
 - image: cockroachdb/cockroach:v24.3.34
   redhatImage: registry.connect.redhat.com/cockroachdb/cockroach@sha256:0ae42bd47982142033664adfcfccde29a8460da66108892e02d2ccf4e6003a47
   tag: v24.3.34
+- image: cockroachdb/cockroach:v24.3.35
+  redhatImage: registry.connect.redhat.com/cockroachdb/cockroach@sha256:26d1d182a0f23d4c30953ab891c20d7ee68619c900e28a35d6ad271a5603d86f
+  tag: v24.3.35
 - image: cockroachdb/cockroach:v25.1.0
   redhatImage: registry.connect.redhat.com/cockroachdb/cockroach@sha256:8e8c081c231b5b15eca483ceec16ea9190ba73aae6e421865162446eb584519a
   tag: v25.1.0
@@ -607,6 +610,9 @@ CrdbVersions:
 - image: cockroachdb/cockroach:v25.2.21
   redhatImage: registry.connect.redhat.com/cockroachdb/cockroach@sha256:09e0ed74759258f72bb4dbe5d7c12b2b95a0cded00defc07509178ef768f28f1
   tag: v25.2.21
+- image: cockroachdb/cockroach:v25.2.22
+  redhatImage: registry.connect.redhat.com/cockroachdb/cockroach@sha256:1009894a4420bfdcafa7c8828a3eb3c5a8438f6fb33523c7e559e826ed211a0e
+  tag: v25.2.22
 - image: cockroachdb/cockroach:v25.3.0
   redhatImage: registry.connect.redhat.com/cockroachdb/cockroach@sha256:80183c72761fb64ed665c6e7699b499b08f96ae66e6a97027216dd1aa805b0aa
   tag: v25.3.0
@@ -667,6 +673,9 @@ CrdbVersions:
 - image: cockroachdb/cockroach:v25.4.13
   redhatImage: registry.connect.redhat.com/cockroachdb/cockroach@sha256:8b6fd9d469c45c419ce1c167104ccdc7c83a39a2425ce2d4a70f366a8fd2df88
   tag: v25.4.13
+- image: cockroachdb/cockroach:v25.4.14
+  redhatImage: registry.connect.redhat.com/cockroachdb/cockroach@sha256:6da82bd60b3fe8b9422cf6cc8402b2875d46f53ada2e0c788658f9fee75789ca
+  tag: v25.4.14
 - image: cockroachdb/cockroach:v26.1.0
   redhatImage: registry.connect.redhat.com/cockroachdb/cockroach@sha256:f3244dc3f59928a9aca8d0d9053d6101c3413fe8c3064536d94b84237ae8fb10
   tag: v26.1.0
@@ -691,6 +700,9 @@ CrdbVersions:
 - image: cockroachdb/cockroach:v26.1.7
   redhatImage: registry.connect.redhat.com/cockroachdb/cockroach@sha256:34b62f1dd7d91196b3a5b5def90ce12b736e9a11540f2d85aab8bbaa7d2b1b12
   tag: v26.1.7
+- image: cockroachdb/cockroach:v26.1.8
+  redhatImage: registry.connect.redhat.com/cockroachdb/cockroach@sha256:67a4f94516484bd9112c8af37915d9a9f9fea81d86f2356708789d0246e41bce
+  tag: v26.1.8
 - image: cockroachdb/cockroach:v26.2.0
   redhatImage: registry.connect.redhat.com/cockroachdb/cockroach@sha256:ff9d44c80f8e734e6d4a061dc3b87be6e089d9b7682a67d377948d138720a1c8
   tag: v26.2.0
@@ -706,3 +718,6 @@ CrdbVersions:
 - image: cockroachdb/cockroach:v26.2.4
   redhatImage: registry.connect.redhat.com/cockroachdb/cockroach@sha256:0ee652a9d0fb6dc6cfc72ad42b02b62ea27572220b905b338120c91000bf0f43
   tag: v26.2.4
+- image: cockroachdb/cockroach:v26.2.5
+  redhatImage: registry.connect.redhat.com/cockroachdb/cockroach@sha256:44dc89272e633532b7ae72861f426ab7a55db4a52b6ff3a2cc92027d697b19e6
+  tag: v26.2.5

--- a/examples/client-secure-operator.yaml
+++ b/examples/client-secure-operator.yaml
@@ -23,7 +23,7 @@ spec:
   serviceAccountName: cockroachdb-sa
   containers:
   - name: cockroachdb-client-secure
-    image: cockroachdb/cockroach:v26.2.4
+    image: cockroachdb/cockroach:v26.2.5
     imagePullPolicy: IfNotPresent
     volumeMounts:
     - name: client-certs

--- a/examples/example.yaml
+++ b/examples/example.yaml
@@ -40,9 +40,9 @@ spec:
       memory: 8Gi
   tlsEnabled: true
 # You can set either a version of the db or a specific image name
-# cockroachDBVersion: v26.2.4
+# cockroachDBVersion: v26.2.5
   image:
-    name: cockroachdb/cockroach:v26.2.4
+    name: cockroachdb/cockroach:v26.2.5
   # nodes refers to the number of crdb pods that are created
   # via the statefulset
   nodes: 3

--- a/examples/smoketest.yaml
+++ b/examples/smoketest.yaml
@@ -39,5 +39,5 @@ spec:
       memory: 300Mi
   tlsEnabled: true
   image:
-    name: cockroachdb/cockroach:v26.2.4
+    name: cockroachdb/cockroach:v26.2.5
   nodes: 3

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cockroachdb/cockroach-operator
 
-go 1.23.8
+go 1.25.12
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.0

--- a/hack/bin/deps.bzl
+++ b/hack/bin/deps.bzl
@@ -219,14 +219,14 @@ def install_k3d():
 def install_golangci_lint():
     http_archive(
         name = "golangci_lint_darwin",
-        sha256 = "b52aebb8cb51e00bfd5976099083fbe2c43ef556cef9c87e58a8ae656e740444",
-        urls = ["https://github.com/golangci/golangci-lint/releases/download/v1.64.8/golangci-lint-1.64.8-darwin-amd64.tar.gz"],
+        sha256 = "f6f06d94b6241521c53d15450c5209b028270bf966f842afb11c030c79f5bc16",
+        urls = ["https://github.com/golangci/golangci-lint/releases/download/v2.12.2/golangci-lint-2.12.2-darwin-amd64.tar.gz"],
         build_file_content =
          """
 filegroup(
      name = "file",
      srcs = [
-        "golangci-lint-1.64.8-darwin-amd64/golangci-lint",
+        "golangci-lint-2.12.2-darwin-amd64/golangci-lint",
      ],
      visibility = ["//visibility:public"],
 )
@@ -235,14 +235,14 @@ filegroup(
 
     http_archive(
             name = "golangci_lint_m1",
-            sha256 = "70543d21e5b02a94079be8aa11267a5b060865583e337fe768d39b5d3e2faf1f",
-            urls = ["https://github.com/golangci/golangci-lint/releases/download/v1.64.8/golangci-lint-1.64.8-darwin-arm64.tar.gz"],
+            sha256 = "a9c54498731b3128f79e090be6110f3e5fffccc617b08142ed244d4126c73f29",
+            urls = ["https://github.com/golangci/golangci-lint/releases/download/v2.12.2/golangci-lint-2.12.2-darwin-arm64.tar.gz"],
             build_file_content =
              """
 filegroup(
     name = "file",
     srcs = [
-       "golangci-lint-1.64.8-darwin-arm64/golangci-lint",
+       "golangci-lint-2.12.2-darwin-arm64/golangci-lint",
     ],
     visibility = ["//visibility:public"],
 )
@@ -251,14 +251,14 @@ filegroup(
 
     http_archive(
         name = "golangci_lint_linux",
-        sha256 = "b6270687afb143d019f387c791cd2a6f1cb383be9b3124d241ca11bd3ce2e54e",
-        urls = ["https://github.com/golangci/golangci-lint/releases/download/v1.64.8/golangci-lint-1.64.8-linux-amd64.tar.gz"],
+        sha256 = "8df580d2670fed8fa984aac0507099af8df275e665215f5c7a2ae3943893a553",
+        urls = ["https://github.com/golangci/golangci-lint/releases/download/v2.12.2/golangci-lint-2.12.2-linux-amd64.tar.gz"],
         build_file_content =
          """
 filegroup(
      name = "file",
      srcs = [
-        "golangci-lint-1.64.8-linux-amd64/golangci-lint",
+        "golangci-lint-2.12.2-linux-amd64/golangci-lint",
      ],
      visibility = ["//visibility:public"],
 )

--- a/install/operator.yaml
+++ b/install/operator.yaml
@@ -711,6 +711,8 @@ spec:
           value: cockroachdb/cockroach:v24.3.33
         - name: RELATED_IMAGE_COCKROACH_v24_3_34
           value: cockroachdb/cockroach:v24.3.34
+        - name: RELATED_IMAGE_COCKROACH_v24_3_35
+          value: cockroachdb/cockroach:v24.3.35
         - name: RELATED_IMAGE_COCKROACH_v25_1_0
           value: cockroachdb/cockroach:v25.1.0
         - name: RELATED_IMAGE_COCKROACH_v25_1_1
@@ -775,6 +777,8 @@ spec:
           value: cockroachdb/cockroach:v25.2.20
         - name: RELATED_IMAGE_COCKROACH_v25_2_21
           value: cockroachdb/cockroach:v25.2.21
+        - name: RELATED_IMAGE_COCKROACH_v25_2_22
+          value: cockroachdb/cockroach:v25.2.22
         - name: RELATED_IMAGE_COCKROACH_v25_3_0
           value: cockroachdb/cockroach:v25.3.0
         - name: RELATED_IMAGE_COCKROACH_v25_3_1
@@ -815,6 +819,8 @@ spec:
           value: cockroachdb/cockroach:v25.4.12
         - name: RELATED_IMAGE_COCKROACH_v25_4_13
           value: cockroachdb/cockroach:v25.4.13
+        - name: RELATED_IMAGE_COCKROACH_v25_4_14
+          value: cockroachdb/cockroach:v25.4.14
         - name: RELATED_IMAGE_COCKROACH_v26_1_0
           value: cockroachdb/cockroach:v26.1.0
         - name: RELATED_IMAGE_COCKROACH_v26_1_1
@@ -831,6 +837,8 @@ spec:
           value: cockroachdb/cockroach:v26.1.6
         - name: RELATED_IMAGE_COCKROACH_v26_1_7
           value: cockroachdb/cockroach:v26.1.7
+        - name: RELATED_IMAGE_COCKROACH_v26_1_8
+          value: cockroachdb/cockroach:v26.1.8
         - name: RELATED_IMAGE_COCKROACH_v26_2_0
           value: cockroachdb/cockroach:v26.2.0
         - name: RELATED_IMAGE_COCKROACH_v26_2_1
@@ -841,6 +849,8 @@ spec:
           value: cockroachdb/cockroach:v26.2.3
         - name: RELATED_IMAGE_COCKROACH_v26_2_4
           value: cockroachdb/cockroach:v26.2.4
+        - name: RELATED_IMAGE_COCKROACH_v26_2_5
+          value: cockroachdb/cockroach:v26.2.5
         - name: OPERATOR_NAME
           value: cockroachdb
         - name: POD_NAME


### PR DESCRIPTION
## Summary

Bumps the operator Go toolchain pins to Go 1.25.12 so release builds use a patched Go standard library. This covers the stdlib vulnerability findings under VULM-694, including the crypto/tls, crypto/x509, and encoding/asn1 advisories whose fixed versions range from Go 1.24.8 through Go 1.25.9.

Changed:
- `go.mod`: `go 1.23.8` -> `go 1.25.12`
- `WORKSPACE`: `go_register_toolchains(version = "1.24.2")` -> `"1.25.12"`
- `WORKSPACE`: `bazel-contrib/rules_go` v0.54.0 -> v0.58.3
- `WORKSPACE`: registers the Go SDK before loading Gazelle dependencies so Gazelle can resolve the downloaded toolchain
- `WORKSPACE`: adds the `host_platform` repository setup required by this `rules_go` release
- `hack/bin/deps.bzl`: updates golangci-lint from v1.64.8 to v2.12.2
- `.golangci.yaml`: migrates to golangci-lint v2 config, restores the v1-compatible exclusion presets, and limits staticcheck to the old bug-oriented check families
- Generated CRDB version files/manifests: refreshes current CockroachDB patch releases so `make release/gen-templates` is clean
- `.github/workflows/tests.yaml`: adds artifact-level verification for the built linux-amd64 operator binary

The `rules_go` bump is required for Go 1.25: CI showed v0.54.0 failing with `go: unknown GOEXPERIMENT coverageredesign`, because that experiment is no longer accepted by Go 1.25. v0.58.3 is used because it supports the Go 1.25 path without pulling in the newer external `rules_cc` stack that requires Bazel 7-era attributes not available in this repo's Bazel 6.5.0 runner.

The golangci-lint bump is required because the previous v1.64.8 binary was built with Go 1.24 and could not typecheck a module declaring Go 1.25. v2.12.2 is built with a newer Go toolchain; the config restores the old exclusion behavior to avoid unrelated lint cleanup.

## Artifact and vulnerability verification

The PR now makes CI build and inspect the actual linux-amd64 operator binary artifact:

```bash
bazel build //cmd/cockroach-operator/linux-amd64:cockroach-operator-linux-amd64
operator_binary="bazel-bin/cmd/cockroach-operator/linux-amd64/cockroach-operator"
go version -m "$operator_binary"
grep 'go1.25.12' /tmp/operator-version.txt
go run golang.org/x/vuln/cmd/govulncheck@latest -mode binary "$operator_binary"
```

The workflow also uploads the produced binary as a GitHub Actions artifact named `cockroach-operator-linux-amd64-${{ github.sha }}`. That gives us an artifact-level check, not only a source-level check: the binary must show `go1.25.12` in embedded build metadata, and `govulncheck` must not report known Go vulnerabilities for that compiled artifact.

For release closure, the production image should still be rebuilt from this commit and scanned by the normal artifact scanner/Endor path, because the Jira findings are artifact findings and will not close against already-published images.

## Operator validation plan

Local/unit coverage:

```bash
make test/all
make dev/build
make test/e2e-short
```

Cluster-backed e2e coverage available in this repo:

```bash
make test/e2e/k3d-create
make test/e2e/k3d-upgrades
make test/e2e/k3d-decommission
make test/e2e/k3d-pvcresize
```

There are also cloud/provider-backed targets for broader validation when credentials and cluster quota are available:

```bash
make test/e2e/gke
make test/e2e/eks
make test/e2e/openshift
```

For this Go toolchain-only change, the meaningful merge gate is: `make test/all`, the new artifact verification in CI, and the k3d e2e workflows already enabled on the PR. The k3d e2e jobs build and run the operator controller code against a real k3d Kubernetes cluster; they do not deploy the final operator container image as a pod, which is why the new artifact check was added separately.

## Local validation performed

```bash
git diff --check
/tmp/golangci-v2/golangci-lint-2.12.2-darwin-arm64/golangci-lint config verify --config .golangci.yaml
rg -n "go 1\\.25\\.12|go_register_toolchains\\(version = \\"1\\.25\\.12\\"\\)" go.mod WORKSPACE
gh api 'repos/bazel-contrib/rules_go/contents/go/private/actions/stdlib.bzl?ref=v0.58.3' --jq '.content' | base64 --decode | rg -n 'coverageredesign|GOEXPERIMENT' || true
gh release download v2.12.2 --repo golangci/golangci-lint --pattern 'golangci-lint-2.12.2-checksums.txt'
```

Result: passed. The v0.58.3 check returned no `coverageredesign` reference, and the golangci-lint checksums used in Bazel match the v2.12.2 release checksum file.

A local Bazel artifact build was attempted. After configuring Bazel with the corporate proxy and CA, dependency fetches progressed, but the Go SDK archive download from `dl.google.com` stalled on this workstation. CI is now the artifact-building and artifact-scanning path for this draft PR.

## Jira

Parent: VULM-694
Children addressed: VULM-695, VULM-696, VULM-697, VULM-698, VULM-699, VULM-700
